### PR TITLE
Keep query message on end of server list.

### DIFF
--- a/domain-resolv/Changelog.md
+++ b/domain-resolv/Changelog.md
@@ -9,7 +9,13 @@ New
 
 Bug fixes
 
+* Fix a panic if the end of the server list is reached during a query.
+  Reported by [@dvc94ch]. [(#14)]
+
 Dependencies
+
+[(#14)]: https://github.com/NLnetLabs/domain/pull/14
+[@dvc94ch]: https://github.com/dvc94ch
 
 
 ## 0.4.0

--- a/domain-resolv/src/stub/resolver.rs
+++ b/domain-resolv/src/stub/resolver.rs
@@ -213,6 +213,9 @@ impl Query {
     /// Prepares the query message and then starts the server query. Returns
     /// `None` if a query cannot be started because 
     fn start_query(&mut self) -> Option<ServerQuery> {
+        if self.message.is_none() {
+            return None;
+        }
         let mut message = self.message.take().unwrap().unfreeze();
         let (message, res) = {
             let info = match self.current_server() {

--- a/domain-resolv/src/stub/resolver.rs
+++ b/domain-resolv/src/stub/resolver.rs
@@ -211,24 +211,24 @@ impl Query {
     /// Starts a new query for the current server.
     ///
     /// Prepares the query message and then starts the server query. Returns
-    /// `None` if a query cannot be started because 
+    /// `None` if a query cannot be started because there are no more servers
+    /// left.
     fn start_query(&mut self) -> Option<ServerQuery> {
-        if self.message.is_none() {
-            return None;
-        }
-        let mut message = self.message.take().unwrap().unfreeze();
+        let message = self.message.take().unwrap();
         let (message, res) = {
-            let info = match self.current_server() {
-                Some(info) => info,
-                None => return None
-            };
-            info.prepare_message(&mut message);
-            let message = message.freeze();
-            let res = ServerQuery::new(message.clone(), info);
-            (message, res)
+            match self.current_server() {
+                Some(info) => {
+                    let mut message = message.unfreeze();
+                    info.prepare_message(&mut message);
+                    let message = message.freeze();
+                    let res = ServerQuery::new(message.clone(), info);
+                    (message, Some(res))
+                }
+                None => (message, None)
+            }
         };
         self.message = Some(message);
-        Some(res)
+        res
     }
 
     /// Returns the info for the current server.


### PR DESCRIPTION
This fixes an accidental panic that happens when the end of the server list is reached in a query.

Initially reported by @dvc94ch.