### PR TITLE
Don’t compress an SRV record’s target.

### DIFF
--- a/domain-core/Changelog.md
+++ b/domain-core/Changelog.md
@@ -13,11 +13,14 @@ New
 
 Bug fixes
 
+* Do not compress the target of an SRV record’s data. [(#18)]
+
 Dependencies
 
 
 [#6]: https://github.com/NLnetLabs/domain/pull/6
 [(#16)]: https://github.com/NLnetLabs/domain/pull/16
+[(#18)]: https://github.com/NLnetLabs/domain/pull/18
 
 ## 0.4.0
 

--- a/domain-core/src/rdata/rfc2782.rs
+++ b/domain-core/src/rdata/rfc2782.rs
@@ -80,12 +80,12 @@ impl<N: Compose> Compose for Srv<N> {
     }
 }
 
-impl<N: Compress> Compress for Srv<N> {
+impl<N: Compose> Compress for Srv<N> {
     fn compress(&self, buf: &mut Compressor) -> Result<(), ShortBuf> {
         buf.compose(&self.priority)?;
         buf.compose(&self.weight)?;
         buf.compose(&self.port)?;
-        self.target.compress(buf)
+        buf.compose(&self.target)
     }
 }
 


### PR DESCRIPTION
Fixes #13.