### PR TITLE
rdata/rfc4034: add support for calculating DNSKEY digest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
 [workspace]
 members = ["domain", "domain-core", "domain-resolv", "domain-sign", "domain-tsig", "domain-validate", "interop"]
 
+[patch.crates-io]
+ring = { git = "https://github.com/andrewtj/ring.git", rev = "eedb0514fb73e1034eefbec10140af8a51effff3"}

--- a/domain-core/Cargo.toml
+++ b/domain-core/Cargo.toml
@@ -22,4 +22,3 @@ derive_more    = "^0.14"
 rand           = "^0.6"
 unwrap         = "^1.2"
 void           = "^1.0"
-

--- a/domain-core/Cargo.toml
+++ b/domain-core/Cargo.toml
@@ -22,3 +22,4 @@ derive_more    = "^0.14"
 rand           = "^0.6"
 unwrap         = "^1.2"
 void           = "^1.0"
+

--- a/domain-core/Cargo.toml
+++ b/domain-core/Cargo.toml
@@ -20,5 +20,6 @@ bytes          = "^0.4"
 chrono         = "^0.4"
 derive_more    = "^0.14"
 rand           = "^0.6"
+unwrap         = "^1.2"
 void           = "^1.0"
 

--- a/domain-core/Changelog.md
+++ b/domain-core/Changelog.md
@@ -15,14 +15,26 @@ Breaking Changes
 
 New
 
-* `bits::message::Message::opt` returns a messages OPT record if present.
+* `message::Message::opt` returns a messages OPT record if present.
   ([#6], thanks to Marek Vavruša!)
 * unsafe `bits::name::Dname::from_bytes_unchecked` in order to create
   names from well-known sequences. [(#31)]
+* `compose::Compose::compose_canonical` for composing the canonical form
+  for DNSSEC signing. It has a default implementation just doing `compose`
+  and has been implemented for all relevant types. [(#XX)]
+* `cmp::CanonicalOrd` for the ordering of record data and records for
+  DNSSEC signing. Implemented for all relevant types. Also improved
+  implementations of `PartialEq` and `PartialOrd` for types generic over
+  domain name types to be generic over the other values domain name type.
+  [(#XX)]
+* `compose::BufMutExt` allowing to `put_slice_ascii_lowercase`. [(#XX)]
+* Allow `serial::Serial` to be created from datetimes, provide a
+  constructor for `now` and add `sub`. [(#XX)]
 
 Bug fixes
 
 * Do not compress the target of an SRV record’s data. [(#18)]
+* Fix `rdata::rfc4043::RtypeBitmapIter`. [(#XX)]
 
 Dependencies
 

--- a/domain-core/src/cmp.rs
+++ b/domain-core/src/cmp.rs
@@ -1,0 +1,101 @@
+//! Additional traits for comparisions.
+//!
+//! These traits exist because there are several ways of compare domain
+//! names included in composite structures. Normally, names are compared
+//! ignoring ASCII case. This is what `PartialEq` and `PartialOrd` do for
+//! domain names. Consequently, when comparing resource records and record
+//! data that contain domain names, ASCII case should also be ignored.
+//!
+//! However, the canonical form of most resource type’s record data (apart
+//! from a small set of well-known types) requires names to be considered
+//! as they are for comparisons. In order to make it clear when this mode
+//! of comparision is used, this module defines two new traits `CanonicalEq`
+//! and `CanonicalOrd` that allows types to define how they should be
+//! compared in the context of DNSSEC. The two traits are accompanied by
+//! `Compose::compose_canonical` which produces the canonical form of this
+//! data.
+
+use std::cmp::Ordering;
+
+
+/// A trait for the canonical sort order of values.
+///
+/// The canonical sort order is used in DNS security when multiple values are
+/// part of constructing or validating a signature. This sort order differs in
+/// some cases from the normal sort order. To avoid confusion, only this trait
+/// should be used when DNSSEC signatures are involved.
+///
+/// Canonical order is defined in [RFC 4034] and clarified in [RFC 6840]. It
+/// is defined for domain names and resource records within an RR set (i.e.,
+/// a set of records with the same owner name, class, and type).
+///
+/// For domain names, canonical order is the same as the ‘normal’ order as
+/// implemented through the `PartialOrd` and `Ord` traits: Labels are compared
+/// from right to left (i.e, starting from the root label) with each pair of
+/// labels compared as octet sequences with ASCII letters lowercased
+/// before comparison.  The `name_cmp` methods of the `ToDname` and
+/// `ToRelativeDname` traits can be used to implement this canonical order
+/// for name types.
+///
+/// Resource records within an RR set are ordered by comparing the canonical
+/// wire-format representation of their record data as octet sequences. The
+/// canonical form differs from the regular form by lower-casing domain names
+/// included in the record data for the record types NS, MD, MF, CNAME, SOA,
+/// MB, MG, MR, PTR, MINFO, MX, RP, AFSDB, RT, SIG, PX, NXT, NAPTR, KX, SRV,
+/// DNAME, A6, and RRSIG. (NSEC is listed in [RFC 4034] but has been withdrawn
+/// by [RFC 6480]). This canonical representation is provided via the
+/// `Compose::compose_canonical` method.
+///
+/// In order to help implementing this trait for record data types, there are
+/// implementations of it for some types that can appear in record data that
+/// sort differently in their composed representation than normally.
+///
+/// Apart from these explicit use cases, the `CanonicalOrd` trait is also
+/// implemented for the `Record` type to allow ordering records of a zone into
+/// RRsets. It does so by ordering by class first, then canonical owner,
+/// record type, and finally canonical record data. The reason for this
+/// somewhat odd ordering is that in this way all not only are all records
+/// for the same owner name and class kept together, but also all the records
+/// subordinate to a owner name and class pair (i.e., the records for a zone)
+/// will sort together.
+pub trait CanonicalOrd<Rhs: ?Sized = Self> {
+    #[must_use]
+    fn canonical_cmp(&self, other: &Rhs) -> Ordering;
+
+    #[inline]
+    #[must_use]
+    fn canonical_lt(&self, other: &Rhs) -> bool {
+        match self.canonical_cmp(other) {
+            Ordering::Less => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    fn canonical_le(&self, other: &Rhs) -> bool {
+        match self.canonical_cmp(other) {
+            Ordering::Less | Ordering::Equal => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    fn canonical_gt(&self, other: &Rhs) -> bool {
+        match self.canonical_cmp(other) {
+            Ordering::Greater => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    fn canonical_ge(&self, other: &Rhs) -> bool {
+        match self.canonical_cmp(other) {
+            Ordering::Greater | Ordering::Equal => true,
+            _ => false,
+        }
+    }
+}
+

--- a/domain-core/src/lib.rs
+++ b/domain-core/src/lib.rs
@@ -91,7 +91,6 @@
 //! [master]: master/index.html
 //! [rdata]: rdata/index.html
 
-
 //--- Re-exports
 
 pub use self::charstr::{CharStr, CharStrMut};

--- a/domain-core/src/lib.rs
+++ b/domain-core/src/lib.rs
@@ -95,6 +95,7 @@
 //--- Re-exports
 
 pub use self::charstr::{CharStr, CharStrMut};
+pub use self::cmp::CanonicalOrd;
 pub use self::compose::{Compose, Compress, Compressor};
 pub use self::header::{Header, HeaderCounts, HeaderSection};
 pub use self::message::{Message, RecordSection, Section};
@@ -108,11 +109,13 @@ pub use self::parse::{Parser, Parse, ParseAll, ShortBuf};
 pub use self::question::Question;
 pub use self::rdata::{ParseRecordData, RecordData, UnknownRecordData};
 pub use self::record::{Record, RecordHeader, ParsedRecord};
+pub use self::serial::Serial;
 
 
 //--- Modules
 
 pub mod charstr;
+pub mod cmp;
 pub mod compose;
 pub mod header;
 pub mod iana;
@@ -128,3 +131,4 @@ pub mod rdata;
 pub mod record;
 pub mod serial;
 pub mod utils;
+

--- a/domain-core/src/lib.rs
+++ b/domain-core/src/lib.rs
@@ -110,7 +110,6 @@ pub use self::rdata::{ParseRecordData, RecordData, UnknownRecordData};
 pub use self::record::{Record, RecordHeader, ParsedRecord};
 pub use self::serial::Serial;
 
-
 //--- Modules
 
 pub mod charstr;
@@ -130,4 +129,3 @@ pub mod rdata;
 pub mod record;
 pub mod serial;
 pub mod utils;
-

--- a/domain-core/src/master/scan.rs
+++ b/domain-core/src/master/scan.rs
@@ -1401,11 +1401,16 @@ impl From<name::PushNameError> for SyntaxError {
 //------------ ScanError -----------------------------------------------------
 
 /// An error happened while scanning master data.
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum ScanError {
+    #[display(fmt="{}: {}", _0, _1)]
     Source(io::Error, Pos),
+
+    #[display(fmt="{}: {}", _0, _1)]
     Syntax(SyntaxError, Pos),
 }
+
+impl error::Error for ScanError { }
 
 impl From<(io::Error, Pos)> for ScanError {
     fn from(err: (io::Error, Pos)) -> ScanError {
@@ -1423,7 +1428,8 @@ impl From<(SyntaxError, Pos)> for ScanError {
 //------------ Pos -----------------------------------------------------------
 
 /// The human-friendly position in a reader.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Display, Eq, PartialEq)]
+#[display(fmt="{}:{}", line, col)]
 pub struct Pos {
     line: usize,
     col: usize

--- a/domain-core/src/name/parsed.rs
+++ b/domain-core/src/name/parsed.rs
@@ -6,6 +6,7 @@
 use std::{cmp, error, fmt, hash};
 use bytes::{BufMut, Bytes};
 use derive_more::Display;
+use crate::cmp::CanonicalOrd;
 use crate::compose::{Compose, Compress, Compressor};
 use crate::parse::{
     Parse, ParseAll, Parser, ParseAllError, ParseOpenError, ShortBuf
@@ -333,6 +334,12 @@ impl Compose for ParsedDname {
             buf.put_slice(self.parser.peek(self.len).unwrap())
         }
     }
+    
+    fn compose_canonical<B: BufMut>(&self, buf: &mut B) {
+        for label in self.iter_labels() {
+            label.compose_canonical(buf)
+        }
+    }
 }
 
 impl Compress for ParsedDname {
@@ -387,7 +394,7 @@ impl<N: ToDname> PartialEq<N> for ParsedDname {
 impl Eq for ParsedDname { }
 
 
-//--- PartialOrd and Ord
+//--- PartialOrd, Ord, and CanonicalOrd
 
 impl<N: ToDname> PartialOrd<N> for ParsedDname {
     fn partial_cmp(&self, other: &N) -> Option<cmp::Ordering> {
@@ -397,6 +404,12 @@ impl<N: ToDname> PartialOrd<N> for ParsedDname {
 
 impl Ord for ParsedDname {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.name_cmp(other)
+    }
+}
+
+impl<N: ToDname> CanonicalOrd<N> for ParsedDname {
+    fn canonical_cmp(&self, other: &N) -> cmp::Ordering {
         self.name_cmp(other)
     }
 }

--- a/domain-core/src/name/relative.rs
+++ b/domain-core/src/name/relative.rs
@@ -366,6 +366,12 @@ impl Compose for RelativeDname {
     fn compose<B: BufMut>(&self, buf: &mut B) {
         buf.put_slice(self.as_ref())
     }
+    
+    fn compose_canonical<B: BufMut>(&self, buf: &mut B) {
+        for label in self.iter_labels() {
+            label.compose_canonical(buf)
+        }
+    }
 }
 
 

--- a/domain-core/src/name/uncertain.rs
+++ b/domain-core/src/name/uncertain.rs
@@ -201,6 +201,12 @@ impl Compose for UncertainDname {
             UncertainDname::Relative(ref name) => name.compose(buf),
         }
     }
+    
+    fn compose_canonical<B: BufMut>(&self, buf: &mut B) {
+        for label in self.iter_labels() {
+            label.compose_canonical(buf)
+        }
+    }
 }
 
 

--- a/domain-core/src/rdata/macros.rs
+++ b/domain-core/src/rdata/macros.rs
@@ -61,9 +61,9 @@ macro_rules! rdata_types {
 
         //--- PartialEq and Eq
 
-        impl<N> PartialEq for MasterRecordData<N>
-        where N: PartialEq {
-            fn eq(&self, other: &Self) -> bool {
+        impl<N, NN> PartialEq<MasterRecordData<NN>> for MasterRecordData<N>
+        where N: PartialEq<NN> {
+            fn eq(&self, other: &MasterRecordData<NN>) -> bool {
                 match (self, other) {
                     $( $( $(
                         (
@@ -74,6 +74,12 @@ macro_rules! rdata_types {
                             self_inner.eq(other_inner)
                         }
                     )* )* )*
+                    (
+                        &MasterRecordData::Other(ref self_inner),
+                        &MasterRecordData::Other(ref other_inner)
+                    ) => {
+                        self_inner.eq(other_inner)
+                    }
                     (_, &MasterRecordData::__Nonexhaustive(_))
                         => unreachable!(),
                     (&MasterRecordData::__Nonexhaustive(_), _)
@@ -86,6 +92,74 @@ macro_rules! rdata_types {
         impl<N> Eq for MasterRecordData<N>
         where N: PartialEq { }
 
+
+        //--- PartialOrd, Ord, and CanonicalOrd
+
+        impl<N, NN> PartialOrd<MasterRecordData<NN>> for MasterRecordData<N>
+        where
+            N: PartialOrd<NN> + $crate::compose::Compose
+                + $crate::compose::Compress,
+            NN: $crate::compose::Compose + $crate::compose::Compress
+        {
+            fn partial_cmp(
+                &self,
+                other: &MasterRecordData<NN>
+            ) -> Option<std::cmp::Ordering> {
+                match (self, other) {
+                    $( $( $(
+                        (
+                            &MasterRecordData::$mtype(ref self_inner),
+                            &MasterRecordData::$mtype(ref other_inner)
+                        )
+                        => {
+                            self_inner.partial_cmp(other_inner)
+                        }
+                    )* )* )*
+                    (
+                        &MasterRecordData::Other(ref self_inner),
+                        &MasterRecordData::Other(ref other_inner)
+                    ) => {
+                        self_inner.partial_cmp(other_inner)
+                    }
+                    (_, &MasterRecordData::__Nonexhaustive(_))
+                        => unreachable!(),
+                    (&MasterRecordData::__Nonexhaustive(_), _)
+                        => unreachable!(),
+                    _ => self.rtype().partial_cmp(&other.rtype())
+                }
+            }
+        }
+
+        impl<N, NN> CanonicalOrd<MasterRecordData<NN>> for MasterRecordData<N>
+        where N: $crate::name::ToDname, NN: $crate::name::ToDname {
+            fn canonical_cmp(
+                &self,
+                other: &MasterRecordData<NN>
+            ) -> std::cmp::Ordering {
+                match (self, other) {
+                    $( $( $(
+                        (
+                            &MasterRecordData::$mtype(ref self_inner),
+                            &MasterRecordData::$mtype(ref other_inner)
+                        )
+                        => {
+                            self_inner.canonical_cmp(other_inner)
+                        }
+                    )* )* )*
+                    (
+                        &MasterRecordData::Other(ref self_inner),
+                        &MasterRecordData::Other(ref other_inner)
+                    ) => {
+                        self_inner.canonical_cmp(other_inner)
+                    }
+                    (_, &MasterRecordData::__Nonexhaustive(_))
+                        => unreachable!(),
+                    (&MasterRecordData::__Nonexhaustive(_), _)
+                        => unreachable!(),
+                    _ => self.rtype().cmp(&other.rtype())
+                }
+            }
+        }
 
         //--- Hash
  

--- a/domain-core/src/rdata/rfc2845.rs
+++ b/domain-core/src/rdata/rfc2845.rs
@@ -5,10 +5,13 @@
 //! [RFC 2845]: https://tools.ietf.org/html/rfc2845
 
 use std::fmt;
+use std::cmp::Ordering;
 use std::time::SystemTime;
 use bytes::{BufMut, Bytes};
+use crate::cmp::CanonicalOrd;
 use crate::compose::{Compose, Compress, Compressor};
 use crate::iana::{Rtype, TsigRcode};
+use crate::name::ToDname;
 use crate::parse::{Parse, ParseAll, ParseAllError, Parser, ShortBuf};
 use crate::utils::base64;
 use super::RtypeRecordData;
@@ -16,7 +19,7 @@ use super::RtypeRecordData;
 
 //------------ Tsig ----------------------------------------------------------
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Hash)]
 pub struct Tsig<N> {
     /// The signature algorithm as a domain name.
     algorithm: N,
@@ -155,6 +158,124 @@ impl<N> Tsig<N> {
     /// [`time_signed`]: #method.time_signed
     pub fn is_valid_now(&self) -> bool {
         Time48::now().eq_fudged(self.time_signed, self.fudge.into())
+    }
+}
+
+
+//--- PartialEq and Eq
+
+impl<N: PartialEq<NN>, NN> PartialEq<Tsig<NN>> for Tsig<N> {
+    fn eq(&self, other: &Tsig<NN>) -> bool {
+        self.algorithm == other.algorithm
+        && self.time_signed == other.time_signed
+        && self.fudge == other.fudge
+        && self.mac == other.mac
+        && self.original_id == other.original_id
+        && self.error == other.error
+        && self.other == other.other
+    }
+}
+
+impl<N: Eq> Eq for Tsig<N> { }
+
+
+//--- PartialOrd, Ord, and CanonicalOrd
+
+impl<N: PartialOrd<NN>, NN> PartialOrd<Tsig<NN>> for Tsig<N> {
+    fn partial_cmp(&self, other: &Tsig<NN>) -> Option<Ordering> {
+        match self.algorithm.partial_cmp(&other.algorithm) {
+            Some(Ordering::Equal) => { }
+            other => return other
+        }
+        match self.time_signed.partial_cmp(&other.time_signed) {
+            Some(Ordering::Equal) => { }
+            other => return other
+        }
+        match self.fudge.partial_cmp(&other.fudge) {
+            Some(Ordering::Equal) => { }
+            other => return other
+        }
+        match self.mac.partial_cmp(&other.mac) {
+            Some(Ordering::Equal) => { }
+            other => return other
+        }
+        match self.original_id.partial_cmp(&other.original_id) {
+            Some(Ordering::Equal) => { }
+            other => return other
+        }
+        match self.error.partial_cmp(&other.error) {
+            Some(Ordering::Equal) => { }
+            other => return other
+        }
+        self.other.partial_cmp(&other.other)
+    }
+}
+
+impl<N: Ord> Ord for Tsig<N> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.algorithm.cmp(&other.algorithm) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.time_signed.cmp(&other.time_signed) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.fudge.cmp(&other.fudge) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.mac.cmp(&other.mac) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.original_id.cmp(&other.original_id) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.error.cmp(&other.error) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        self.other.cmp(&other.other)
+    }
+}
+
+impl<N: ToDname, NN: ToDname> CanonicalOrd<Tsig<NN>> for Tsig<N> {
+    fn canonical_cmp(&self, other: &Tsig<NN>) -> Ordering {
+        match self.algorithm.composed_cmp(&other.algorithm) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.time_signed.cmp(&other.time_signed) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.fudge.cmp(&other.fudge) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.mac.len().cmp(&other.mac.len()) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.mac.cmp(&other.mac) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.original_id.cmp(&other.original_id) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.error.cmp(&other.error) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.other.len().cmp(&other.other.len()) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        self.other.cmp(&other.other)
     }
 }
 

--- a/domain-core/src/rdata/rfc3596.rs
+++ b/domain-core/src/rdata/rfc3596.rs
@@ -5,9 +5,11 @@
 //! [RFC 3596]: https://tools.ietf.org/html/rfc3596
 
 use std::{fmt, ops};
+use std::cmp::Ordering;
 use std::net::Ipv6Addr;
 use std::str::FromStr;
 use bytes::BufMut;
+use crate::cmp::CanonicalOrd;
 use crate::compose::{Compose, Compress, Compressor};
 use crate::iana::Rtype;
 use crate::master::scan::{CharSource, Scan, Scanner, ScanError};
@@ -51,6 +53,15 @@ impl FromStr for Aaaa {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ipv6Addr::from_str(s).map(Aaaa::new)
+    }
+}
+
+
+//--- CanonicalOrd
+
+impl CanonicalOrd for Aaaa {
+    fn canonical_cmp(&self, other: &Self) -> Ordering {
+        self.cmp(other)
     }
 }
 

--- a/domain-core/src/rdata/rfc4034.rs
+++ b/domain-core/src/rdata/rfc4034.rs
@@ -21,6 +21,7 @@ use crate::parse::{Parse, ParseAll, ParseAllError, Parser, ShortBuf};
 use crate::serial::Serial;
 use super::RtypeRecordData;
 
+
 //------------ Dnskey --------------------------------------------------------
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -1153,16 +1154,18 @@ mod test {
     fn rtype_bitmap_builder() {
         let mut builder = RtypeBitmapBuilder::new();
         builder.add(Rtype::Int(1234)); // 0x04D2
-        builder.add(Rtype::A);         // 0x0001
-        builder.add(Rtype::Mx);        // 0x000F
-        builder.add(Rtype::Rrsig);     // 0x002E
-        builder.add(Rtype::Nsec);      // 0x002F
-        assert_eq!(builder.finalize().as_slice(),
-                   &b"\x00\x06\x40\x01\x00\x00\x00\x03\
+        builder.add(Rtype::A); // 0x0001
+        builder.add(Rtype::Mx); // 0x000F
+        builder.add(Rtype::Rrsig); // 0x002E
+        builder.add(Rtype::Nsec); // 0x002F
+        assert_eq!(
+            builder.finalize().as_slice(),
+            &b"\x00\x06\x40\x01\x00\x00\x00\x03\
                      \x04\x1b\x00\x00\x00\x00\x00\x00\
                      \x00\x00\x00\x00\x00\x00\x00\x00\
                      \x00\x00\x00\x00\x00\x00\x00\x00\
-                     \x00\x00\x00\x00\x20"[..]);
+                     \x00\x00\x00\x00\x20"[..]
+        );
     }
 
     #[test]

--- a/domain-core/src/rdata/rfc5155.rs
+++ b/domain-core/src/rdata/rfc5155.rs
@@ -5,9 +5,11 @@
 //! [RFC 5155]: https://tools.ietf.org/html/rfc5155
 
 use std::{error, fmt};
+use std::cmp::Ordering;
 use bytes::BufMut;
 use derive_more::Display;
 use crate::charstr::CharStr;
+use crate::cmp::CanonicalOrd;
 use crate::compose::{Compose, Compress, Compressor};
 use crate::parse::{Parse, ParseAll, ParseAllError, Parser, ShortBuf};
 use crate::iana::{Nsec3HashAlg, Rtype};
@@ -67,6 +69,35 @@ impl Nsec3 {
 
     pub fn types(&self) -> &RtypeBitmap {
         &self.types
+    }
+}
+
+
+//--- CanonicalOrd
+
+impl CanonicalOrd for Nsec3 {
+    fn canonical_cmp(&self, other: &Self) -> Ordering {
+        match self.hash_algorithm.cmp(&other.hash_algorithm) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.flags.cmp(&other.flags) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.iterations.cmp(&other.iterations) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.salt.canonical_cmp(&other.salt) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.next_owner.canonical_cmp(&other.next_owner) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        self.types.cmp(&other.types)
     }
 }
 
@@ -211,6 +242,27 @@ impl Nsec3param {
 
     pub fn salt(&self) -> &CharStr {
         &self.salt
+    }
+}
+
+
+//--- CanonicalOrd
+
+impl CanonicalOrd for Nsec3param {
+    fn canonical_cmp(&self, other: &Self) -> Ordering {
+        match self.hash_algorithm.cmp(&other.hash_algorithm) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.flags.cmp(&other.flags) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        match self.iterations.cmp(&other.iterations) {
+            Ordering::Equal => { }
+            other => return other
+        }
+        self.salt.canonical_cmp(&other.salt)
     }
 }
 

--- a/domain-core/src/rdata/rfc7344.rs
+++ b/domain-core/src/rdata/rfc7344.rs
@@ -1,5 +1,7 @@
 use std::fmt;
+use std::cmp::Ordering;
 use bytes::{BufMut, Bytes};
+use crate::cmp::CanonicalOrd;
 use crate::compose::{Compose, Compress, Compressor};
 use crate::iana::{DigestAlg, Rtype, SecAlg};
 use crate::master::scan::{CharSource, Scan, ScanError, Scanner};
@@ -18,7 +20,12 @@ pub struct Cdnskey {
 }
 
 impl Cdnskey {
-    pub fn new(flags: u16, protocol: u8, algorithm: SecAlg, public_key: Bytes) -> Self {
+    pub fn new(
+        flags: u16,
+        protocol: u8,
+        algorithm: SecAlg,
+        public_key: Bytes
+    ) -> Self {
         Cdnskey {
             flags,
             protocol,
@@ -43,6 +50,16 @@ impl Cdnskey {
         &self.public_key
     }
 }
+
+
+//--- CanonicalOrd
+
+impl CanonicalOrd for Cdnskey {
+    fn canonical_cmp(&self, other: &Self) -> Ordering {
+        self.cmp(other)
+    }
+}
+
 
 //--- ParseAll, Compose, and Compress
 
@@ -81,6 +98,7 @@ impl Compress for Cdnskey {
     }
 }
 
+
 //--- Scan and Display
 
 impl Scan for Cdnskey {
@@ -101,11 +119,13 @@ impl fmt::Display for Cdnskey {
     }
 }
 
+
 //--- RecordData
 
 impl RtypeRecordData for Cdnskey {
     const RTYPE: Rtype = Rtype::Cdnskey;
 }
+
 
 //------------ Cds -----------------------------------------------------------
 
@@ -118,7 +138,12 @@ pub struct Cds {
 }
 
 impl Cds {
-    pub fn new(key_tag: u16, algorithm: SecAlg, digest_type: DigestAlg, digest: Bytes) -> Self {
+    pub fn new(
+        key_tag: u16,
+        algorithm: SecAlg,
+        digest_type: DigestAlg,
+        digest: Bytes
+    ) -> Self {
         Cds {
             key_tag,
             algorithm,
@@ -143,6 +168,16 @@ impl Cds {
         &self.digest
     }
 }
+
+
+//--- CanonicalOrd
+
+impl CanonicalOrd for Cds {
+    fn canonical_cmp(&self, other: &Self) -> Ordering {
+        self.cmp(other)
+    }
+}
+
 
 //--- ParseAll, Compose, and Compress
 
@@ -181,6 +216,7 @@ impl Compress for Cds {
     }
 }
 
+
 //--- Scan and Display
 
 impl Scan for Cds {
@@ -207,6 +243,7 @@ impl fmt::Display for Cds {
         Ok(())
     }
 }
+
 
 //--- RtypeRecordData
 

--- a/domain-sign/Cargo.toml
+++ b/domain-sign/Cargo.toml
@@ -16,8 +16,16 @@ name = "domain_sign"
 path = "src/lib.rs"
 
 [dependencies]
+bytes 		= "0.4"
+derive_more	= "^0.15"
+openssl		= { version = "^0.10", optional = true }
+ring		= { version = "^0.14", optional = true }
+untrusted 	= { version = "^0.6", optional = true }
+unwrap         	= "^1.2"
 
 [dependencies.domain-core]
 path = "../domain-core"
 version = "0.4.1"
 
+[features]
+ringsigner = ["ring", "untrusted"]

--- a/domain-sign/Cargo.toml
+++ b/domain-sign/Cargo.toml
@@ -19,14 +19,13 @@ path = "src/lib.rs"
 bytes 		= "0.4"
 derive_more	= "^0.15"
 openssl		= { version = "^0.10", optional = true }
-ring		= { version = "^0.14", optional = true }
-untrusted 	= { version = "^0.6", optional = true }
-unwrap         	= "^1.2"
+ring		= { version = "0.15.0-alpha", optional = true }
+unwrap      = "^1.2"
 
 [dependencies.domain-core]
 path = "../domain-core"
 version = "0.4.1"
 
 [features]
-ringsigner = ["ring", "untrusted"]
+ringsigner = ["ring"]
 default = ["ringsigner"]

--- a/domain-sign/Cargo.toml
+++ b/domain-sign/Cargo.toml
@@ -29,3 +29,4 @@ version = "0.4.1"
 
 [features]
 ringsigner = ["ring", "untrusted"]
+default = ["ringsigner"]

--- a/domain-sign/src/bin/signzone.rs
+++ b/domain-sign/src/bin/signzone.rs
@@ -1,0 +1,153 @@
+//! Signs a zone file.
+
+use std::io;
+use std::fs::File;
+use domain_core::{Dname, Record, Serial};
+use domain_core::rdata::MasterRecordData;
+use domain_core::master::reader::{Reader, ReaderItem};
+use domain_sign::ring;
+use domain_sign::sign::{FamilyName, SortedRecords};
+use ::ring::rand::SystemRandom;
+use unwrap::unwrap;
+
+
+fn main() {
+    let mut args = std::env::args();
+    let _ = unwrap!(args.next());
+    let infile = match args.next() {
+        Some(infile) => infile,
+        None => {
+            eprintln!("Usage: signzone <infile> [<outfile>]");
+            std::process::exit(1)
+        }
+    };
+    let outfile = args.next();
+
+    if let Err(err) = sign_zone(infile, outfile) {
+        eprintln!("{}", err);
+        std::process::exit(1)
+    }
+        
+}
+
+
+type Records = SortedRecords<Dname, MasterRecordData<Dname>>;
+
+
+fn sign_zone(infile: String, outfile: Option<String>) -> Result<(), io::Error> {
+    let rng = SystemRandom::new();
+    let key = match ring::Key::throwaway_13(256, &rng) {
+        Ok(key) => key,
+        Err(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to create key"
+            ))
+        }
+    };
+    let mut records = load_zone(infile)?;
+    let (apex, ttl) = find_apex(&records)?;
+    let nsecs = records.nsecs(&apex, ttl);
+    records.extend(nsecs.into_iter().map(Record::from_record));
+    match apex.dnskey(ttl, &key) {
+        Ok(record) => {
+            let _ = records.insert(Record::from_record(record));
+        }
+        Err(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Creating DNSKEY record failed."
+            ))
+        }
+    }
+    let inception = Serial::now().sub(10);
+    let expiration = inception.add(2592000); // XXX 30 days
+    let rrsigs = match records.sign(&apex, expiration, inception, &key) {
+        Ok(rrsigs) => rrsigs,
+        Err(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Signing failed."
+            ))
+        }
+    };
+    records.extend(rrsigs.into_iter().map(Record::from_record));
+    let _ds = match apex.ds(ttl, key) {
+        Ok(ds) => ds,
+        Err(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Creating DS record failed."
+            ))
+        }
+    };
+
+    match outfile {
+        Some(path) => {
+            let mut file = File::create(path)?;
+            records.write(&mut file)?;
+        }
+        None => {
+            {
+                let stdout = io::stdout();
+                let mut stdout = stdout.lock();
+                records.write(&mut stdout)?;
+            }
+            println!("");
+        }
+    }
+    //println!("{}", ds);
+    Ok(())
+}
+
+
+fn load_zone(infile: String) -> Result<Records, io::Error> {
+    let reader = Reader::open(infile)?;
+    let mut res = SortedRecords::new();
+    for item in reader {
+        match item {
+            Ok(ReaderItem::Record(record)) => {
+                let _ = res.insert(record);
+            }
+            Ok(ReaderItem::Include {..}) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "$include not supported"
+                ))
+            }
+            Ok(ReaderItem::Control {name, ..}) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("${} not supported", name)
+                ))
+            }
+            Err(err) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("{}", err)
+                ))
+            }
+        }
+    }
+    Ok(res)
+}
+
+fn find_apex(
+    records: &Records
+) -> Result<(FamilyName<Dname>, u32), io::Error> {
+    let soa = match records.find_soa() {
+        Some(soa) => soa,
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "cannot find SOA record"
+            ))
+        }
+    };
+    let ttl = match *soa.first().data() {
+        MasterRecordData::Soa(ref soa) => soa.minimum(),
+        _ => unreachable!()
+    };
+    Ok((soa.family_name().to_name(), ttl))
+}
+

--- a/domain-sign/src/key.rs
+++ b/domain-sign/src/key.rs
@@ -1,0 +1,47 @@
+use bytes::Bytes;
+use domain_core::ToDname;
+use domain_core::iana::SecAlg;
+use domain_core::rdata::{Ds, Dnskey};
+
+
+pub trait SigningKey {
+    type Error;
+
+    fn dnskey(&self) -> Result<Dnskey, Self::Error>;
+    fn ds<N: ToDname>(&self, owner: N) -> Result<Ds, Self::Error>;
+
+    fn algorithm(&self) -> Result<SecAlg, Self::Error> {
+        self.dnskey().map(|dnskey| dnskey.algorithm())
+    }
+
+    fn key_tag(&self) -> Result<u16, Self::Error> {
+        self.dnskey().map(|dnskey| dnskey.key_tag())
+    }
+
+    fn sign(&self, data: &[u8]) -> Result<Bytes, Self::Error>;
+}
+
+
+impl<'a, K: SigningKey> SigningKey for &'a K {
+    type Error = K::Error;
+
+    fn dnskey(&self) -> Result<Dnskey, Self::Error> {
+        (*self).dnskey()
+    }
+    fn ds<N: ToDname>(&self, owner: N) -> Result<Ds, Self::Error> {
+        (*self).ds(owner)
+    }
+
+    fn algorithm(&self) -> Result<SecAlg, Self::Error> {
+        (*self).algorithm()
+    }
+
+    fn key_tag(&self) -> Result<u16, Self::Error> {
+        (*self).key_tag()
+    }
+
+    fn sign(&self, data: &[u8]) -> Result<Bytes, Self::Error> {
+        (*self).sign(data)
+    }
+}
+

--- a/domain-sign/src/lib.rs
+++ b/domain-sign/src/lib.rs
@@ -1,0 +1,5 @@
+
+pub mod key;
+pub mod openssl;
+pub mod ring;
+pub mod sign;

--- a/domain-sign/src/openssl.rs
+++ b/domain-sign/src/openssl.rs
@@ -1,0 +1,50 @@
+//! Key and Signer using OpenSSL.
+#![cfg(feature = "openssl")]
+
+use bytes::Bytes;
+use domain_core::{Compose, ToDname};
+use domain_core::iana::DigestAlg;
+use domain_core::rdata::{Ds, Dnskey};
+use openssl::error::ErrorStack;
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, Private};
+use openssl::sha::sha256;
+use openssl::sign::Signer as OpenSslSigner;
+use crate::key::SigningKey;
+
+
+pub struct Key {
+    dnskey: Dnskey,
+    key: PKey<Private>,
+    digest: Option<MessageDigest>,
+}
+
+impl SigningKey for Key {
+    type Error = ErrorStack;
+
+    fn dnskey(&self) -> Result<Dnskey, Self::Error> {
+        Ok(self.dnskey.clone())
+    }
+
+    fn ds<N: ToDname>(&self, owner: N) -> Result<Ds, Self::Error> {
+        let mut buf = Vec::new();
+        owner.compose_canonical(&mut buf);
+        self.dnskey.compose_canonical(&mut buf);
+        let digest = Bytes::from(sha256(&buf).as_ref());
+        Ok(Ds::new(
+            self.key_tag()?,
+            self.dnskey.algorithm(),
+            DigestAlg::Sha256,
+            digest,
+        ))
+    }
+
+    fn sign(&self, data: &[u8]) -> Result<Bytes, Self::Error> {
+        let mut signer = OpenSslSigner::new_intern(
+            self.digest, &self.key
+        )?;
+        signer.update(data)?;
+        signer.sign_to_vec().map(Into::into)
+    }
+}
+

--- a/domain-sign/src/ring.rs
+++ b/domain-sign/src/ring.rs
@@ -12,7 +12,6 @@ use ring::signature::{
     EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaEncoding, RsaKeyPair,
     ECDSA_P256_SHA256_FIXED_SIGNING
 };
-use untrusted::Input;
 use crate::key::SigningKey;
 
 
@@ -39,7 +38,7 @@ impl<'a> Key<'a> {
         )?;
         let keypair = EcdsaKeyPair::from_pkcs8(
             &ECDSA_P256_SHA256_FIXED_SIGNING,
-            Input::from(pkcs8.as_ref())
+            pkcs8.as_ref()
         )?;
         let public_key = keypair.public_key().as_ref()[1..].into();
         Ok(Key {
@@ -75,7 +74,7 @@ impl<'a> SigningKey for Key<'a> {
     fn sign(&self, msg: &[u8]) -> Result<Bytes, Self::Error> {
         match self.key {
             RingKey::Ecdsa(ref key) => {
-                Ok(Bytes::from(key.sign(self.rng, Input::from(msg))?.as_ref()))
+                Ok(Bytes::from(key.sign(self.rng, msg)?.as_ref()))
             }
             RingKey::Ed25519(ref key) => {
                 Ok(Bytes::from(key.sign(msg).as_ref()))

--- a/domain-sign/src/ring.rs
+++ b/domain-sign/src/ring.rs
@@ -1,0 +1,91 @@
+//! Key and Signer using ring.
+#![cfg(feature = "ringsigner")]
+
+use bytes::Bytes;
+use domain_core::{Compose, ToDname};
+use domain_core::iana::{DigestAlg, SecAlg};
+use domain_core::rdata::{Ds, Dnskey};
+use ring::digest;
+use ring::error::Unspecified;
+use ring::rand::SecureRandom;
+use ring::signature::{
+    EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaEncoding, RsaKeyPair,
+    ECDSA_P256_SHA256_FIXED_SIGNING
+};
+use untrusted::Input;
+use crate::key::SigningKey;
+
+
+pub struct Key<'a> {
+    dnskey: Dnskey,
+    key: RingKey,
+    rng: &'a dyn SecureRandom,
+}
+
+#[allow(dead_code)]
+enum RingKey {
+    Ecdsa(EcdsaKeyPair),
+    Ed25519(Ed25519KeyPair),
+    Rsa(RsaKeyPair, &'static dyn RsaEncoding),
+}
+
+impl<'a> Key<'a> {
+    pub fn throwaway_13(
+        flags: u16,
+        rng: &'a dyn SecureRandom
+    ) -> Result<Self, Unspecified> {
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(
+            &ECDSA_P256_SHA256_FIXED_SIGNING, rng
+        )?;
+        let keypair = EcdsaKeyPair::from_pkcs8(
+            &ECDSA_P256_SHA256_FIXED_SIGNING,
+            Input::from(pkcs8.as_ref())
+        )?;
+        let public_key = keypair.public_key().as_ref()[1..].into();
+        Ok(Key {
+            dnskey: Dnskey::new(
+                flags, 3, SecAlg::EcdsaP256Sha256, public_key
+            ),
+            key: RingKey::Ecdsa(keypair),
+            rng
+        })
+    }
+}
+
+impl<'a> SigningKey for Key<'a> {
+    type Error = Unspecified;
+
+    fn dnskey(&self) -> Result<Dnskey, Self::Error> {
+        Ok(self.dnskey.clone())
+    }
+
+    fn ds<N: ToDname>(&self, owner: N) -> Result<Ds, Self::Error> {
+        let mut buf = Vec::new();
+        owner.compose_canonical(&mut buf);
+        self.dnskey.compose_canonical(&mut buf);
+        let digest = digest::digest(&digest::SHA256, &buf);
+        Ok(Ds::new(
+            self.key_tag()?,
+            self.dnskey.algorithm(),
+            DigestAlg::Sha256,
+            Bytes::from(digest.as_ref())
+        ))
+    }
+
+    fn sign(&self, msg: &[u8]) -> Result<Bytes, Self::Error> {
+        match self.key {
+            RingKey::Ecdsa(ref key) => {
+                Ok(Bytes::from(key.sign(self.rng, Input::from(msg))?.as_ref()))
+            }
+            RingKey::Ed25519(ref key) => {
+                Ok(Bytes::from(key.sign(msg).as_ref()))
+            }
+            RingKey::Rsa(ref key, encoding) => {
+                let mut sig = vec![0; key.public_modulus_len()];
+                key.sign(encoding, self.rng, msg, &mut sig)?;
+                Ok(sig.into())
+            }
+        }
+    }
+}
+

--- a/domain-sign/src/sign.rs
+++ b/domain-sign/src/sign.rs
@@ -1,0 +1,558 @@
+//! Actual signing.
+
+use std::{fmt, io, slice};
+use std::iter::FromIterator;
+use bytes::Bytes;
+use domain_core::{
+    CanonicalOrd, Compose, Dname, Record, RecordData, Serial, ToDname
+};
+use domain_core::iana::{Class, Rtype};
+use domain_core::rdata::{Dnskey, Ds, Nsec, Rrsig};
+use domain_core::rdata::rfc4034::RtypeBitmap;
+use crate::key::SigningKey;
+
+
+//------------ SortedRecords -------------------------------------------------
+
+/// A collection of resource records sorted for signing.
+#[derive(Clone)]
+pub struct SortedRecords<N, D> {
+    records: Vec<Record<N, D>>,
+}
+
+impl<N, D> SortedRecords<N, D> {
+    pub fn new() -> Self {
+        SortedRecords { records: Vec::new() }
+    }
+
+    pub fn insert(
+        &mut self,
+        record: Record<N, D>
+    ) -> Result<(), Record<N, D>>
+    where N: ToDname, D: RecordData + CanonicalOrd {
+        let idx = self.records.binary_search_by(|stored| {
+            stored.canonical_cmp(&record)
+        });
+        match idx {
+            Ok(_) => Err(record),
+            Err(idx) => {
+                self.records.insert(idx, record);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn families(&self) -> RecordsIter<N, D> {
+        RecordsIter::new(&self.records)
+    }
+
+    pub fn rrsets(&self) -> RrsetIter<N, D> {
+        RrsetIter::new(&self.records)
+    }
+
+    pub fn find_soa(&self) -> Option<Rrset<N, D>>
+    where N: ToDname, D: RecordData {
+        for rrset in self.rrsets() {
+            if rrset.rtype() == Rtype::Soa {
+                return Some(rrset)
+            }
+        }
+        None
+    }
+
+
+    pub fn sign<K: SigningKey>(
+        &self,
+        apex: &FamilyName<Dname>,
+        expiration: Serial,
+        inception: Serial,
+        key: K
+    ) -> Result<Vec<Record<Dname, Rrsig>>, K::Error>
+    where N: ToDname, D: RecordData {
+        let mut res = Vec::new();
+        let mut buf = Vec::new();
+
+        // The owner name of a zone cut if we currently are at or below one.
+        let mut cut: Option<FamilyName<Dname>> = None;
+
+        let mut families = self.families();
+
+        // Since the records are ordered, the first family is the apex --
+        // we can skip everything before that.
+        families.skip_before(apex);
+        
+        for family in families {
+            // If the owner is out of zone, we have moved out of our zone and
+            // are done.
+            if !family.is_in_zone(apex) {
+                break
+            }
+
+            // If the family is below a zone cut, we must ignore it.
+            if let Some(ref cut) = cut {
+                if family.owner().ends_with(cut.owner()) {
+                    continue
+                }
+            }
+
+            // Create an owned, uncompressed family name. We’ll need it later.
+            let name = family.family_name().to_name();
+
+            // If this family is the parent side of a zone cut, we keep the
+            // family name for later. This also means below that if
+            // `cut.is_some()` we are at the parent side of a zone.
+            cut = if family.is_zone_cut(apex) {
+                Some(name.clone())
+            }
+            else {
+                None
+            };
+
+            for rrset in family.rrsets() {
+                if cut.is_some() {
+                    // If we are at a zone cut, we only sign DS and NSEC
+                    // records. NS records we must not sign and everything
+                    // else shouldn’t be here, really.
+                    if rrset.rtype() != Rtype::Ds
+                                             && rrset.rtype() != Rtype::Nsec {
+                        continue
+                    }
+                }
+                else {
+                    // Otherwise we only ignore RRSIGs.
+                    if rrset.rtype() == Rtype::Rrsig {
+                        continue
+                    }
+                }
+
+                // Let’s make a signature!
+                let mut rrsig = Record::new(
+                    name.owner().clone(),
+                    name.class(),
+                    rrset.ttl(),
+                    Rrsig::new(
+                        rrset.rtype(),
+                        key.algorithm()?,
+                        name.owner().rrsig_label_count(),
+                        rrset.ttl(),
+                        expiration,
+                        inception,
+                        key.key_tag()?,
+                        apex.owner().clone(),
+                        Bytes::new(),
+                    )
+                );
+                buf.clear();
+                rrsig.data().compose_canonical(&mut buf);
+
+                for record in rrset.iter() {
+                    record.compose_canonical(&mut buf);
+                }
+
+                rrsig.data_mut().set_signature(key.sign(&buf)?);
+                res.push(rrsig);
+            }
+        }
+        Ok(res)
+    }
+
+    pub fn nsecs(
+        &self,
+        apex: &FamilyName<Dname>,
+        ttl: u32
+    ) -> Vec<Record<Dname, Nsec<Dname>>>
+    where N: ToDname, D: RecordData {
+        let mut res = Vec::new();
+
+        // The owner name of a zone cut if we currently are at or below one.
+        let mut cut: Option<FamilyName<Dname>> = None;
+
+        let mut families = self.families();
+
+        // Since the records are ordered, the first family is the apex --
+        // we can skip everything before that.
+        families.skip_before(apex);
+
+        // Because of the next name thing, we need to keep the last NSEC
+        // around.
+        let mut prev: Option<Record<Dname, Nsec<Dname>>> = None;
+
+        for family in families {
+            // If the owner is out of zone, we have moved out of our zone and
+            // are done.
+            if !family.is_in_zone(apex) {
+                break
+            }
+
+            // If the family is below a zone cut, we must ignore it.
+            if let Some(ref cut) = cut {
+                if family.owner().ends_with(cut.owner()) {
+                    continue
+                }
+            }
+
+            // Create an owned, uncompressed family name. We’ll need it later.
+            let name = family.family_name().to_name();
+
+            // If this family is the parent side of a zone cut, we keep the
+            // family name for later. This also means below that if
+            // `cut.is_some()` we are at the parent side of a zone.
+            cut = if family.is_zone_cut(apex) {
+                Some(name.clone())
+            }
+            else {
+                None
+            };
+
+            if let Some(mut nsec) = prev.take() {
+                nsec.data_mut().set_next_name(name.owner().clone());
+                res.push(nsec);
+            }
+
+            let mut bitmap = RtypeBitmap::builder();
+            bitmap.add(Rtype::Rrsig); // Assume there’s gonna be an RRSIG.
+            for rrset in family.rrsets() {
+                bitmap.add(rrset.rtype())
+            }
+
+            prev = Some(name.into_record(ttl, Nsec::new(
+                Dname::root(),
+                bitmap.finalize()
+            )))
+        }
+        if let Some(mut nsec) = prev {
+            nsec.data_mut().set_next_name(apex.owner().clone());
+            res.push(nsec)
+        }
+        res
+    }
+
+    pub fn write<W>(&self, target: &mut W) -> Result<(), io::Error>
+    where N: fmt::Display, D: RecordData + fmt::Display, W: io::Write {
+        for record in &self.records {
+            writeln!(target, "{}", record)?;
+        }
+        Ok(())
+    }
+}
+
+impl<N, D> Default for SortedRecords<N, D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+
+impl<N, D> From<Vec<Record<N, D>>> for SortedRecords<N, D>
+where N: ToDname, D: RecordData + CanonicalOrd {
+    fn from(mut src: Vec<Record<N, D>>) -> Self {
+        src.sort_by(CanonicalOrd::canonical_cmp);
+            SortedRecords { records: src }
+    }
+}
+
+impl<N, D> FromIterator<Record<N, D>> for SortedRecords<N, D>
+where N: ToDname, D: RecordData + CanonicalOrd {
+    fn from_iter<T: IntoIterator<Item = Record<N, D>>>(iter: T) -> Self {
+        let mut res = Self::new();
+        for item in iter {
+            let _ = res.insert(item);
+        }
+        res
+    }
+}
+
+impl<N, D> Extend<Record<N, D>> for SortedRecords<N, D>
+where N: ToDname, D: RecordData + CanonicalOrd {
+    fn extend<T: IntoIterator<Item = Record<N, D>>>(&mut self, iter: T) {
+        for item in iter {
+            let _ = self.insert(item);
+        }
+    }
+}
+
+
+//------------ Family --------------------------------------------------------
+
+/// A set of records with the same owner name and class.
+pub struct Family<'a, N, D> {
+    slice: &'a [Record<N, D>],
+}
+
+impl<'a, N, D> Family<'a, N, D> {
+    fn new(slice: &'a [Record<N, D>]) -> Self {
+        Family { slice }
+    }
+
+    pub fn owner(&self) -> &N {
+        self.slice[0].owner()
+    }
+
+    pub fn class(&self) -> Class {
+        self.slice[0].class()
+    }
+
+    pub fn family_name(&self) -> FamilyName<&N> {
+        FamilyName::new(self.owner(), self.class())
+    }
+
+    pub fn rrsets(&self) -> FamilyIter<'a, N, D> {
+        FamilyIter::new(self.slice)
+    }
+
+    pub fn records(&self) -> slice::Iter<'a, Record<N, D>> {
+        self.slice.iter()
+    }
+
+    pub fn is_zone_cut<NN>(&self, apex: &FamilyName<NN>) -> bool
+    where N: ToDname, NN: ToDname, D: RecordData {
+        self.family_name().ne(apex)
+        && self.records().any(|record| record.rtype() == Rtype::Ns)
+    }
+
+    pub fn is_in_zone<NN: ToDname>(&self, apex: &FamilyName<NN>) -> bool
+    where N: ToDname {
+        self.owner().ends_with(&apex.owner) && self.class() == apex.class
+    }
+}
+
+
+//------------ FamilyName ----------------------------------------------------
+
+/// The identifier for a family, i.e., a owner name and class.
+#[derive(Clone)]
+pub struct FamilyName<N> {
+    owner: N,
+    class: Class
+}
+
+impl<N> FamilyName<N> {
+    fn new(owner: N, class: Class) -> Self {
+        FamilyName { owner, class }
+    }
+
+    pub fn owner(&self) -> &N {
+        &self.owner
+    }
+
+    pub fn class(&self) -> Class {
+        self.class
+    }
+
+    pub fn to_name(&self) -> FamilyName<Dname>
+    where N: ToDname {
+        FamilyName::new(self.owner.to_name(), self.class)
+    }
+
+    pub fn into_record<D>(self, ttl: u32, data: D) -> Record<N, D> {
+        Record::new(self.owner, self.class, ttl, data)
+    }
+
+    pub fn dnskey<K: SigningKey>(
+        &self,
+        ttl: u32,
+        key: K
+    ) -> Result<Record<N, Dnskey>, K::Error>
+    where N: Clone {
+        key.dnskey().map(|dnskey| self.clone().into_record(ttl, dnskey))
+    }
+
+    pub fn ds<K: SigningKey>(
+        &self,
+        ttl: u32,
+        key: K
+    ) -> Result<Record<N, Ds>, K::Error>
+    where N: ToDname + Clone {
+        key.ds(&self.owner).map(|ds| self.clone().into_record(ttl, ds))
+    }
+}
+
+impl<N: ToDname, NN: ToDname> PartialEq<FamilyName<NN>> for FamilyName<N> {
+    fn eq(&self, other: &FamilyName<NN>) -> bool {
+        self.owner.name_eq(&other.owner) && self.class == other.class
+    }
+}
+
+impl<N: ToDname, NN: ToDname, D> PartialEq<Record<NN, D>> for FamilyName<N> {
+    fn eq(&self, other: &Record<NN, D>) -> bool {
+        self.owner.name_eq(other.owner()) && self.class == other.class()
+    }
+}
+
+
+//------------ Rrset ---------------------------------------------------------
+
+/// A set of records with the same owner name, class, and record type.
+pub struct Rrset<'a, N, D> {
+    slice: &'a [Record<N, D>],
+}
+
+impl<'a, N, D> Rrset<'a, N, D> {
+    fn new(slice: &'a [Record<N, D>]) -> Self {
+        Rrset { slice }
+    }
+
+    pub fn owner(&self) -> &N {
+        self.slice[0].owner()
+    }
+
+    pub fn class(&self) -> Class {
+        self.slice[0].class()
+    }
+
+    pub fn family_name(&self) -> FamilyName<&N> {
+        FamilyName::new(self.owner(), self.class())
+    }
+
+    pub fn rtype(&self) -> Rtype
+    where D: RecordData {
+        self.slice[0].rtype()
+    }
+
+    pub fn ttl(&self) -> u32 {
+        self.slice[0].ttl()
+    }
+
+    pub fn first(&self) -> &Record<N, D> {
+        &self.slice[0]
+    }
+
+    pub fn iter(&self) -> slice::Iter<'a, Record<N, D>> {
+        self.slice.iter()
+    }
+}
+
+
+//------------ RecordsIter ---------------------------------------------------
+
+/// An iterator that produces families from sorted records.
+pub struct RecordsIter<'a, N, D> {
+    slice: &'a [Record<N, D>],
+}
+
+impl<'a, N, D> RecordsIter<'a, N, D> {
+    fn new(slice: &'a [Record<N, D>]) -> Self {
+        RecordsIter { slice }
+    }
+
+    pub fn skip_before<NN: ToDname>(&mut self, apex: &FamilyName<NN>)
+    where N: ToDname {
+        while let Some(first) = self.slice.first() {
+            if apex == first {
+                break;
+            }
+            self.slice = &self.slice[1..]
+        }
+    }
+}
+
+
+impl<'a, N, D> Iterator for RecordsIter<'a, N, D>
+where
+    N: ToDname + 'a,
+    D: RecordData + 'a,
+{
+    type Item = Family<'a, N, D>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let first = match self.slice.first() {
+            Some(first) => first,
+            None => return None,
+        };
+        let mut end = 1;
+        while let Some(record) = self.slice.get(end) {
+            if !record.owner().name_eq(first.owner())
+                || record.class() != first.class()
+            {
+                break
+            }
+            end += 1;
+        }
+        let (res, slice) = self.slice.split_at(end);
+        self.slice = slice;
+        Some(Family::new(res))
+    }
+}
+
+
+//------------ RrsetIter -----------------------------------------------------
+
+/// An iterator that produces RRsets from sorted records.
+pub struct RrsetIter<'a, N, D> {
+    slice: &'a [Record<N, D>],
+}
+
+impl<'a, N, D> RrsetIter<'a, N, D> {
+    fn new(slice: &'a [Record<N, D>]) -> Self {
+        RrsetIter { slice }
+    }
+}
+
+impl<'a, N, D> Iterator for RrsetIter<'a, N, D>
+where
+    N: ToDname + 'a,
+    D: RecordData + 'a,
+{
+    type Item = Rrset<'a, N, D>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let first = match self.slice.first() {
+            Some(first) => first,
+            None => return None,
+        };
+        let mut end = 1;
+        while let Some(record) = self.slice.get(end) {
+            if !record.owner().name_eq(first.owner())
+                || record.rtype() != first.rtype()
+                || record.class() != first.class()
+            {
+                break
+            }
+            end += 1;
+        }
+        let (res, slice) = self.slice.split_at(end);
+        self.slice = slice;
+        Some(Rrset::new(res))
+    }
+}
+
+
+//------------ FamilyIter ----------------------------------------------------
+
+/// An iterator that produces RRsets from a record family.
+pub struct FamilyIter<'a, N, D> {
+    slice: &'a [Record<N, D>],
+}
+
+impl<'a, N, D> FamilyIter<'a, N, D> {
+    fn new(slice: &'a [Record<N, D>]) -> Self {
+        FamilyIter { slice }
+    }
+}
+
+impl<'a, N, D> Iterator for FamilyIter<'a, N, D>
+where
+    N: ToDname + 'a,
+    D: RecordData + 'a,
+{
+    type Item = Rrset<'a, N, D>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let first = match self.slice.first() {
+            Some(first) => first,
+            None => return None,
+        };
+        let mut end = 1;
+        while let Some(record) = self.slice.get(end) {
+            if record.rtype() != first.rtype() {
+                break
+            }
+            end += 1;
+        }
+        let (res, slice) = self.slice.split_at(end);
+        self.slice = slice;
+        Some(Rrset::new(res))
+    }
+}
+
+

--- a/domain-sign/src/signer.rs
+++ b/domain-sign/src/signer.rs
@@ -1,0 +1,36 @@
+//! Signer.
+
+use bytes::Bytes;
+use domain_core::iana::SecAlg;
+use domain_core::rdata::Dnskey;
+
+
+pub trait Key {
+    type Error;
+    type Signer: Signer<Error=Self::Error>;
+
+    fn dnskey(&self) -> Result<Dnskey, Self::Error>;
+    fn signer(&self) -> Result<Self::Signer, Self::Error>;
+
+    fn algorithm(&self) -> Result<SecAlg, Self::Error> {
+        self.dnskey().map(|dnskey| dnskey.algorithm())
+    }
+
+    fn key_tag(&self) -> Result<u16, Self::Error> {
+        self.dnskey().map(|dnskey| dnskey.key_tag())
+    }
+
+    fn sign(&self, data: &[u8]) -> Result<Bytes, Self::Error> {
+        let mut signer = self.signer()?;
+        signer.update(data)?;
+        signer.finalize()
+    }
+}
+
+pub trait Signer {
+    type Error;
+
+    fn update(&mut self, data: &[u8]) -> Result<(), Self::Error>;
+    fn finalize(self) -> Result<Bytes, Self::Error>;
+}
+

--- a/domain-sign/test-data/example.com.zone
+++ b/domain-sign/test-data/example.com.zone
@@ -1,0 +1,28 @@
+$ORIGIN example.com.
+$TTL 86400
+
+@		IN      SOA     ns.example.com. hostmaster.example.com. (
+                                2019070801
+                                86400 3600 604800 300 )
+		IN	NS	ns.example.com.
+		IN	NS	ns1.example.net.
+		IN	NS	ns2.example.net.
+
+		IN	A	192.0.2.2
+		IN	AAAA	2001:db8::2
+
+ns		IN	A	192.0.2.3
+ns		IN	AAAA	2001:db8::3
+
+*		IN	A	192.0.2.4
+*		IN	A	192.0.2.5
+
+www		IN	A	192.0.2.6
+wWw		IN	A	192.0.2.7
+
+sub		IN	NS	ns.sub.example.com.
+sub		IN	NS	ns1.example.net.
+sub		IN	NS	ns2.example.net.
+
+ns.sub		IN	A	192.0.2.4
+ns.sub		IN	AAAA	2001:db8::4

--- a/domain-tsig/Cargo.toml
+++ b/domain-tsig/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 bytes          = "^0.4"
 derive_more    = "^0.14"
-ring           = "^0.14"
+ring           = "0.15.0-alpha"
 
 [dependencies.domain-core]
 path = "../domain-core"

--- a/domain-validate/Cargo.toml
+++ b/domain-validate/Cargo.toml
@@ -18,8 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 bytes 		= "0.4"
 derive_more	= "^0.15"
-ring		= { version = "^0.14" }
-untrusted 	= { version = "^0.6" }
+ring        = "=0.15.0-alpha3"
 
 [dependencies.domain-core]
 path = "../domain-core"

--- a/domain-validate/Cargo.toml
+++ b/domain-validate/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 bytes 		= "0.4"
 derive_more	= "^0.15"
 ring		= { version = "^0.14" }
+untrusted 	= { version = "^0.6" }
 
 [dependencies.domain-core]
 path = "../domain-core"

--- a/domain-validate/Cargo.toml
+++ b/domain-validate/Cargo.toml
@@ -16,8 +16,10 @@ name = "domain_validate"
 path = "src/lib.rs"
 
 [dependencies]
+bytes 		= "0.4"
+derive_more	= "^0.15"
+ring		= { version = "^0.14" }
 
 [dependencies.domain-core]
 path = "../domain-core"
 version = "0.4.1"
-

--- a/domain-validate/src/lib.rs
+++ b/domain-validate/src/lib.rs
@@ -89,7 +89,7 @@ impl DnskeyExt for Dnskey {
     }
 
     fn rsa_exponent_modulus(&self) -> Result<(&[u8], &[u8]), AlgorithmError> {
-        assert!(self.algorithm() == SecAlg::RsaSha1 || self.algorithm() == SecAlg::RsaSha256);
+        assert!(self.algorithm() == SecAlg::RsaSha1 || self.algorithm() == SecAlg::RsaSha1Nsec3Sha1 || self.algorithm() == SecAlg::RsaSha256);
 
         let public_key = self.public_key();
         if public_key.len() <= 3 {
@@ -228,8 +228,9 @@ impl RrsigExt for Rrsig {
         let signature = Input::from(self.signature());
 
         match self.algorithm() {
-            SecAlg::RsaSha1 | SecAlg::RsaSha256 | SecAlg::RsaSha512 => {
+            SecAlg::RsaSha1 | SecAlg::RsaSha1Nsec3Sha1 | SecAlg::RsaSha256 | SecAlg::RsaSha512 => {
                 let algorithm = match self.algorithm() {
+                    SecAlg::RsaSha1Nsec3Sha1 => &signature::RSA_PKCS1_2048_8192_SHA1,
                     SecAlg::RsaSha1 => &signature::RSA_PKCS1_2048_8192_SHA1,
                     SecAlg::RsaSha256 => &signature::RSA_PKCS1_2048_8192_SHA256,
                     SecAlg::RsaSha512 => &signature::RSA_PKCS1_2048_8192_SHA512,

--- a/domain-validate/src/lib.rs
+++ b/domain-validate/src/lib.rs
@@ -1,8 +1,9 @@
+use bytes::{BufMut, Bytes};
 use derive_more::Display;
-use domain_core::{Compose, ToDname};
-use domain_core::iana::DigestAlg;
-use domain_core::rdata::Dnskey;
-use ring::digest;
+use domain_core::iana::{DigestAlg, SecAlg};
+use domain_core::rdata::{Dnskey, Rrsig, RtypeRecordData};
+use domain_core::{CanonicalOrd, Compose, Compress, Record, ToDname};
+use ring::{digest, signature};
 use std::error;
 
 //------------ AlgorithmError ------------------------------------------------
@@ -10,11 +11,13 @@ use std::error;
 /// An algorithm error during verification.
 #[derive(Clone, Debug, Display)]
 pub enum AlgorithmError {
-    #[display(fmt="unsupported algorithm")]
+    #[display(fmt = "unsupported algorithm")]
     Unsupported,
+    #[display(fmt = "bad signature")]
+    BadSig,
 }
 
-impl error::Error for AlgorithmError { }
+impl error::Error for AlgorithmError {}
 
 /// Extensions for DNSKEY record type.
 pub trait DnskeyExt: Compose {
@@ -33,7 +36,15 @@ pub trait DnskeyExt: Compose {
     ///
     ///     DNSKEY RDATA = Flags | Protocol | Algorithm | Public Key.
     /// ```
-    fn digest<N: ToDname>(&self, dname: &N, algorithm: DigestAlg) -> Result<digest::Digest, AlgorithmError>;
+    fn digest<N: ToDname>(
+        &self,
+        dname: &N,
+        algorithm: DigestAlg,
+    ) -> Result<digest::Digest, AlgorithmError>;
+
+    // Extract public key exponent and modulus.
+    // See [RFC3110, Section 2](https://tools.ietf.org/html/rfc3110#section-2)
+    fn rsa_exponent_modulus(&self) -> Result<(&[u8], &[u8]), AlgorithmError>;
 }
 
 impl DnskeyExt for Dnskey {
@@ -52,7 +63,11 @@ impl DnskeyExt for Dnskey {
     ///
     ///     DNSKEY RDATA = Flags | Protocol | Algorithm | Public Key.
     /// ```
-    fn digest<N: ToDname>(&self, dname: &N, algorithm: DigestAlg) -> Result<digest::Digest, AlgorithmError> {
+    fn digest<N: ToDname>(
+        &self,
+        dname: &N,
+        algorithm: DigestAlg,
+    ) -> Result<digest::Digest, AlgorithmError> {
         let mut buf: Vec<u8> = Vec::new();
         dname.compose(&mut buf);
         self.compose(&mut buf);
@@ -60,13 +75,199 @@ impl DnskeyExt for Dnskey {
         let mut ctx = match algorithm {
             DigestAlg::Sha1 => digest::Context::new(&digest::SHA1),
             DigestAlg::Sha256 => digest::Context::new(&digest::SHA256),
-            DigestAlg::Gost => { return Err(AlgorithmError::Unsupported); }
+            DigestAlg::Gost => {
+                return Err(AlgorithmError::Unsupported);
+            }
             DigestAlg::Sha384 => digest::Context::new(&digest::SHA384),
-            _ => { return Err(AlgorithmError::Unsupported); }
+            _ => {
+                return Err(AlgorithmError::Unsupported);
+            }
         };
 
         ctx.update(&buf);
         Ok(ctx.finish())
+    }
+
+    fn rsa_exponent_modulus(&self) -> Result<(&[u8], &[u8]), AlgorithmError> {
+        assert!(self.algorithm() == SecAlg::RsaSha1 || self.algorithm() == SecAlg::RsaSha256);
+
+        let public_key = self.public_key();
+        if public_key.len() <= 3 {
+            // TODO: return a better error
+            return Err(AlgorithmError::Unsupported);
+        }
+
+        let (pos, exp_len) = match public_key[0] {
+            0 => (
+                3,
+                (usize::from(public_key[1]) << 8) | usize::from(public_key[2]),
+            ),
+            len => (1, usize::from(len)),
+        };
+
+        // Check if there's enough space for exponent and modulus.
+        if public_key.len() < pos + exp_len {
+            return Err(AlgorithmError::Unsupported);
+        };
+
+        Ok(public_key[pos..].split_at(exp_len))
+    }
+}
+
+/// Extensions for DNSKEY record type.
+pub trait RrsigExt: Compose {
+    /// Compose the signed data according to [RC4035, Section 5.3.2](https://tools.ietf.org/html/rfc4035#section-5.3.2).
+    ///
+    /// ```text
+    ///    Once the RRSIG RR has met the validity requirements described in
+    ///    Section 5.3.1, the validator has to reconstruct the original signed
+    ///    data.  The original signed data includes RRSIG RDATA (excluding the
+    ///    Signature field) and the canonical form of the RRset.  Aside from
+    ///    being ordered, the canonical form of the RRset might also differ from
+    ///    the received RRset due to DNS name compression, decremented TTLs, or
+    ///    wildcard expansion.
+    /// ```
+    fn signed_data<N: ToDname, D: RtypeRecordData, B: BufMut>(
+        &self,
+        buf: &mut B,
+        records: &mut [Record<N, D>],
+    ) where
+        D: CanonicalOrd + Compose + Compress + Sized;
+
+    /// Attempt to use the cryptographic signature to authenticate the signed data, and thus authenticate the RRSET.
+    /// The signed data is expected to be calculated as per [RFC4035, Section 5.3.2](https://tools.ietf.org/html/rfc4035#section-5.3.2).
+    ///
+    /// [RFC4035, Section 5.3.2](https://tools.ietf.org/html/rfc4035#section-5.3.2):
+    /// ```text
+    /// 5.3.3.  Checking the Signature
+    ///
+    ///    Once the resolver has validated the RRSIG RR as described in Section
+    ///    5.3.1 and reconstructed the original signed data as described in
+    ///    Section 5.3.2, the validator can attempt to use the cryptographic
+    ///    signature to authenticate the signed data, and thus (finally!)
+    ///    authenticate the RRset.
+    ///
+    ///    The Algorithm field in the RRSIG RR identifies the cryptographic
+    ///    algorithm used to generate the signature.  The signature itself is
+    ///    contained in the Signature field of the RRSIG RDATA, and the public
+    ///    key used to verify the signature is contained in the Public Key field
+    ///    of the matching DNSKEY RR(s) (found in Section 5.3.1).  [RFC4034]
+    ///    provides a list of algorithm types and provides pointers to the
+    ///    documents that define each algorithm's use.
+    /// ```
+    fn verify_signed_data(
+        &self,
+        dnskey: &Dnskey,
+        signed_data: &Bytes,
+    ) -> Result<(), AlgorithmError>;
+}
+
+impl RrsigExt for Rrsig {
+    fn signed_data<N: ToDname, D: RtypeRecordData, B: BufMut>(
+        &self,
+        buf: &mut B,
+        records: &mut [Record<N, D>],
+    ) where
+        D: CanonicalOrd + Compose + Compress + Sized,
+    {
+        // signed_data = RRSIG_RDATA | RR(1) | RR(2)...  where
+        //    "|" denotes concatenation
+        // RRSIG_RDATA is the wire format of the RRSIG RDATA fields
+        //    with the Signature field excluded and the Signer's Name
+        //    in canonical form.
+        self.type_covered().compose(buf);
+        self.algorithm().compose(buf);
+        self.labels().compose(buf);
+        self.original_ttl().compose(buf);
+        self.expiration().compose(buf);
+        self.inception().compose(buf);
+        self.key_tag().compose(buf);
+        self.signer_name().compose_canonical(buf);
+
+        // The set of all RR(i) is sorted into canonical order.
+        // See https://tools.ietf.org/html/rfc4034#section-6.3
+        records.sort_by(|a, b| a.data().canonical_cmp(b.data()));
+
+        // RR(i) = name | type | class | OrigTTL | RDATA length | RDATA
+        for rr in records {
+            // Handle expanded wildcards as per [RFC4035, Section 5.3.2](https://tools.ietf.org/html/rfc4035#section-5.3.2).
+            let rrsig_labels = usize::from(self.labels());
+            let fqdn = rr.owner();
+            // Subtract the root label from count as the algorithm doesn't accomodate that.
+            let mut fqdn_labels = fqdn.iter_labels().count() - 1;
+            if rrsig_labels < fqdn_labels {
+                // name = "*." | the rightmost rrsig_label labels of the fqdn
+                b"\x01*".compose(buf);
+                let mut fqdn = fqdn.to_name();
+                while fqdn_labels < rrsig_labels {
+                    fqdn.parent();
+                    fqdn_labels -= 1;
+                }
+                fqdn.compose_canonical(buf);
+            } else {
+                fqdn.compose_canonical(buf);
+            }
+
+            rr.rtype().compose(buf);
+            rr.class().compose(buf);
+            self.original_ttl().compose(buf);
+            let rdlen = rr.data().compose_len() as u16;
+            rdlen.compose(buf);
+            rr.data().compose_canonical(buf);
+        }
+    }
+
+    fn verify_signed_data(
+        &self,
+        dnskey: &Dnskey,
+        signed_data: &Bytes,
+    ) -> Result<(), AlgorithmError> {
+        use untrusted::Input;
+
+        let message = untrusted::Input::from(signed_data);
+        let signature = Input::from(self.signature());
+
+        match self.algorithm() {
+            SecAlg::RsaSha1 | SecAlg::RsaSha256 | SecAlg::RsaSha512 => {
+                let algorithm = match self.algorithm() {
+                    SecAlg::RsaSha1 => &signature::RSA_PKCS1_2048_8192_SHA1,
+                    SecAlg::RsaSha256 => &signature::RSA_PKCS1_2048_8192_SHA256,
+                    SecAlg::RsaSha512 => &signature::RSA_PKCS1_2048_8192_SHA512,
+                    _ => unreachable!(),
+                };
+                // The key isn't available in either PEM or DER, so use the direct RSA verifier.
+                let (e, m) = dnskey.rsa_exponent_modulus()?;
+                signature::primitive::verify_rsa(
+                    algorithm,
+                    (Input::from(m), Input::from(e)),
+                    message,
+                    signature,
+                )
+                .map_err(|_| AlgorithmError::BadSig)
+            }
+            SecAlg::EcdsaP256Sha256 | SecAlg::EcdsaP384Sha384 => {
+                let algorithm = match self.algorithm() {
+                    SecAlg::EcdsaP256Sha256 => &signature::ECDSA_P256_SHA256_FIXED,
+                    SecAlg::EcdsaP384Sha384 => &signature::ECDSA_P384_SHA384_FIXED,
+                    _ => unreachable!(),
+                };
+
+                // Add 0x4 identifier to the ECDSA pubkey as expected by ring.
+                let public_key = dnskey.public_key();
+                let mut key = Vec::with_capacity(public_key.len() + 1);
+                key.push(0x4);
+                key.extend_from_slice(&public_key);
+
+                signature::verify(algorithm, Input::from(&key), message, signature)
+                    .map_err(|_| AlgorithmError::BadSig)
+            }
+            SecAlg::Ed25519 => {
+                let key = dnskey.public_key();
+                signature::verify(&signature::ED25519, Input::from(&key), message, signature)
+                    .map_err(|_| AlgorithmError::BadSig)
+            }
+            _ => return Err(AlgorithmError::Unsupported),
+        }
     }
 }
 
@@ -75,26 +276,107 @@ impl DnskeyExt for Dnskey {
 #[cfg(test)]
 mod test {
     use super::*;
-    use domain_core::{Dname, iana::SecAlg, utils::base64, rdata::Ds};
+    use domain_core::iana::{Class, Rtype, SecAlg};
+    use domain_core::{rdata::Ds, utils::base64, Dname};
 
-    // Returns current root KSK for testing.
-    fn root_pubkey() -> Dnskey {
-        let pubkey = base64::decode("AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU=").unwrap().into();
-        Dnskey::new(257, 3, SecAlg::RsaSha256, pubkey)
+    // Returns current root KSK/ZSK for testing.
+    fn root_pubkey() -> (Dnskey, Dnskey) {
+        let ksk = base64::decode("AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU=").unwrap().into();
+        let zsk = base64::decode("AwEAAeVDC34GZILwsQJy97K2Fst4P3XYZrXLyrkausYzSqEjSUulgh+iLgHg0y7FIF890+sIjXsk7KLJUmCOWfYWPorNKEOKLk5Zx/4M6D3IHZE3O3m/Eahrc28qQzmTLxiMZAW65MvR2UO3LxVtYOPBEBiDgAQD47x2JLsJYtavCzNL5WiUk59OgvHmDqmcC7VXYBhK8V8Tic089XJgExGeplKWUt9yyc31ra1swJX51XsOaQz17+vyLVH8AZP26KvKFiZeoRbaq6vl+hc8HQnI2ug5rA2zoz3MsSQBvP1f/HvqsWxLqwXXKyDD1QM639U+XzVB8CYigyscRP22QCnwKIU=").unwrap().into();
+        (
+            Dnskey::new(257, 3, SecAlg::RsaSha256, ksk),
+            Dnskey::new(256, 3, SecAlg::RsaSha256, zsk),
+        )
     }
 
     #[test]
     fn dnskey_digest() {
-        let dnskey = root_pubkey();
+        let (dnskey, _) = root_pubkey();
         let owner = Dname::root();
-        let expected = Ds::new(20326, SecAlg::RsaSha256, DigestAlg::Sha256, base64::decode("4G1EuAuPHTmpXAsNfGXQhFjogECbvGg0VxBCN8f47I0=").unwrap().into());
-        assert_eq!(dnskey.digest(&owner, DigestAlg::Sha256).unwrap().as_ref(), expected.digest().as_ref());
+        let expected = Ds::new(
+            20326,
+            SecAlg::RsaSha256,
+            DigestAlg::Sha256,
+            base64::decode("4G1EuAuPHTmpXAsNfGXQhFjogECbvGg0VxBCN8f47I0=")
+                .unwrap()
+                .into(),
+        );
+        assert_eq!(
+            dnskey.digest(&owner, DigestAlg::Sha256).unwrap().as_ref(),
+            expected.digest().as_ref()
+        );
     }
 
     #[test]
     fn dnskey_digest_unsupported() {
-        let dnskey = root_pubkey();
+        let (dnskey, _) = root_pubkey();
         let owner = Dname::root();
         assert_eq!(dnskey.digest(&owner, DigestAlg::Gost).is_err(), true);
+    }
+
+    fn rrsig_verify_dnskey(ksk: Dnskey, zsk: Dnskey, rrsig: Rrsig) {
+        let mut records: Vec<_> = [&ksk, &zsk]
+            .iter()
+            .cloned()
+            .map(|x| Record::new(rrsig.signer_name().clone(), Class::In, 0, x.clone()))
+            .collect();
+        let signed_data = {
+            let mut buf = Vec::new();
+            rrsig.signed_data(&mut buf, records.as_mut_slice());
+            Bytes::from(buf)
+        };
+
+        // Test that the KSK is sorted after ZSK key
+        assert_eq!(ksk.key_tag(), rrsig.key_tag());
+        assert_eq!(ksk.key_tag(), records[1].data().key_tag());
+
+        // Test verifier
+        assert!(rrsig.verify_signed_data(&ksk, &signed_data).is_ok());
+        assert!(rrsig.verify_signed_data(&zsk, &signed_data).is_err());
+    }
+
+    #[test]
+    fn rrsig_verify_rsa_sha256() {
+        let (ksk, zsk) = root_pubkey();
+        let rrsig = Rrsig::new(Rtype::Dnskey, SecAlg::RsaSha256, 0, 172800, 1560211200.into(), 1558396800.into(), 20326, Dname::root(), base64::decode("otBkINZAQu7AvPKjr/xWIEE7+SoZtKgF8bzVynX6bfJMJuPay8jPvNmwXkZOdSoYlvFp0bk9JWJKCh8y5uoNfMFkN6OSrDkr3t0E+c8c0Mnmwkk5CETH3Gqxthi0yyRX5T4VlHU06/Ks4zI+XAgl3FBpOc554ivdzez8YCjAIGx7XgzzooEb7heMSlLc7S7/HNjw51TPRs4RxrAVcezieKCzPPpeWBhjE6R3oiSwrl0SBD4/yplrDlr7UHs/Atcm3MSgemdyr2sOoOUkVQCVpcj3SQQezoD2tCM7861CXEQdg5fjeHDtz285xHt5HJpA5cOcctRo4ihybfow/+V7AQ==").unwrap().into());
+        rrsig_verify_dnskey(ksk, zsk, rrsig);
+    }
+
+    #[test]
+    fn rrsig_verify_ecdsap256_sha256() {
+        let (ksk, zsk) = (
+            Dnskey::new(257, 3, SecAlg::EcdsaP256Sha256, base64::decode("mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==").unwrap().into()),
+            Dnskey::new(256, 3, SecAlg::EcdsaP256Sha256, base64::decode("oJMRESz5E4gYzS/q6XDrvU1qMPYIjCWzJaOau8XNEZeqCYKD5ar0IRd8KqXXFJkqmVfRvMGPmM1x8fGAa2XhSA==").unwrap().into()),
+        );
+
+        let owner = Dname::from_slice(b"\x0acloudflare\x03com\x00").unwrap();
+        let rrsig = Rrsig::new(Rtype::Dnskey, SecAlg::EcdsaP256Sha256, 2, 3600, 1560314494.into(), 1555130494.into(), 2371, owner.clone(), base64::decode("8jnAGhG7O52wmL065je10XQztRX1vK8P8KBSyo71Z6h5wAT9+GFxKBaEzcJBLvRmofYFDAhju21p1uTfLaYHrg==").unwrap().into());
+        rrsig_verify_dnskey(ksk, zsk, rrsig);
+    }
+
+    #[test]
+    fn rrsig_verify_ed25519() {
+        let (ksk, zsk) = (
+            Dnskey::new(
+                257,
+                3,
+                SecAlg::Ed25519,
+                base64::decode("m1NELLVVQKl4fHVn/KKdeNO0PrYKGT3IGbYseT8XcKo=")
+                    .unwrap()
+                    .into(),
+            ),
+            Dnskey::new(
+                256,
+                3,
+                SecAlg::Ed25519,
+                base64::decode("2tstZAjgmlDTePn0NVXrAHBJmg84LoaFVxzLl1anjGI=")
+                    .unwrap()
+                    .into(),
+            ),
+        );
+
+        let owner = Dname::from_slice(b"\x07ED25519\x02nl\x00").unwrap();
+        let rrsig = Rrsig::new(Rtype::Dnskey, SecAlg::Ed25519, 2, 3600, 1559174400.into(), 1557360000.into(), 45515, owner.clone(), base64::decode("hvPSS3E9Mx7lMARqtv6IGiw0NE0uz0mZewndJCHTkhwSYqlasUq7KfO5QdtgPXja7YkTaqzrYUbYk01J8ICsAA==").unwrap().into());
+        rrsig_verify_dnskey(ksk, zsk, rrsig);
     }
 }

--- a/domain-validate/src/lib.rs
+++ b/domain-validate/src/lib.rs
@@ -1,0 +1,100 @@
+use derive_more::Display;
+use domain_core::{Compose, ToDname};
+use domain_core::iana::DigestAlg;
+use domain_core::rdata::Dnskey;
+use ring::digest;
+use std::error;
+
+//------------ AlgorithmError ------------------------------------------------
+
+/// An algorithm error during verification.
+#[derive(Clone, Debug, Display)]
+pub enum AlgorithmError {
+    #[display(fmt="unsupported algorithm")]
+    Unsupported,
+}
+
+impl error::Error for AlgorithmError { }
+
+/// Extensions for DNSKEY record type.
+pub trait DnskeyExt: Compose {
+    /// Calculates a digest from DNSKEY.
+    /// See [RFC 4034, Section 5.1.4](https://tools.ietf.org/html/rfc4034#section-5.1.4)
+    ///
+    /// ```text
+    /// 5.1.4.  The Digest Field
+    ///   The digest is calculated by concatenating the canonical form of the
+    ///   fully qualified owner name of the DNSKEY RR with the DNSKEY RDATA,
+    ///   and then applying the digest algorithm.
+    ///
+    ///     digest = digest_algorithm( DNSKEY owner name | DNSKEY RDATA);
+    ///
+    ///      "|" denotes concatenation
+    ///
+    ///     DNSKEY RDATA = Flags | Protocol | Algorithm | Public Key.
+    /// ```
+    fn digest<N: ToDname>(&self, dname: &N, algorithm: DigestAlg) -> Result<digest::Digest, AlgorithmError>;
+}
+
+impl DnskeyExt for Dnskey {
+    /// Calculates a digest from DNSKEY.
+    /// See [RFC 4034, Section 5.1.4](https://tools.ietf.org/html/rfc4034#section-5.1.4)
+    ///
+    /// ```text
+    /// 5.1.4.  The Digest Field
+    ///   The digest is calculated by concatenating the canonical form of the
+    ///   fully qualified owner name of the DNSKEY RR with the DNSKEY RDATA,
+    ///   and then applying the digest algorithm.
+    ///
+    ///     digest = digest_algorithm( DNSKEY owner name | DNSKEY RDATA);
+    ///
+    ///      "|" denotes concatenation
+    ///
+    ///     DNSKEY RDATA = Flags | Protocol | Algorithm | Public Key.
+    /// ```
+    fn digest<N: ToDname>(&self, dname: &N, algorithm: DigestAlg) -> Result<digest::Digest, AlgorithmError> {
+        let mut buf: Vec<u8> = Vec::new();
+        dname.compose(&mut buf);
+        self.compose(&mut buf);
+
+        let mut ctx = match algorithm {
+            DigestAlg::Sha1 => digest::Context::new(&digest::SHA1),
+            DigestAlg::Sha256 => digest::Context::new(&digest::SHA256),
+            DigestAlg::Gost => { return Err(AlgorithmError::Unsupported); }
+            DigestAlg::Sha384 => digest::Context::new(&digest::SHA384),
+            _ => { return Err(AlgorithmError::Unsupported); }
+        };
+
+        ctx.update(&buf);
+        Ok(ctx.finish())
+    }
+}
+
+//============ Test ==========================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use domain_core::{Dname, iana::SecAlg, utils::base64, rdata::Ds};
+
+    // Returns current root KSK for testing.
+    fn root_pubkey() -> Dnskey {
+        let pubkey = base64::decode("AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU=").unwrap().into();
+        Dnskey::new(257, 3, SecAlg::RsaSha256, pubkey)
+    }
+
+    #[test]
+    fn dnskey_digest() {
+        let dnskey = root_pubkey();
+        let owner = Dname::root();
+        let expected = Ds::new(20326, SecAlg::RsaSha256, DigestAlg::Sha256, base64::decode("4G1EuAuPHTmpXAsNfGXQhFjogECbvGg0VxBCN8f47I0=").unwrap().into());
+        assert_eq!(dnskey.digest(&owner, DigestAlg::Sha256).unwrap().as_ref(), expected.digest().as_ref());
+    }
+
+    #[test]
+    fn dnskey_digest_unsupported() {
+        let dnskey = root_pubkey();
+        let owner = Dname::root();
+        assert_eq!(dnskey.digest(&owner, DigestAlg::Gost).is_err(), true);
+    }
+}

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -11,5 +11,5 @@ domain-core   = { path = "../domain-core" }
 domain-resolv = { path = "../domain-resolv" }
 domain-tsig   = { path = "../domain-tsig" }
 bytes         = "0.4"
-ring          = "0.14"
+ring          = "0.15.0-alpha"
 


### PR DESCRIPTION
This commit implements necessary interfaces for RFC4034, 5.2:

```
5.2.  Processing of DS RRs When Validating Responses

   The DS RR links the authentication chain across zone boundaries, so
   the DS RR requires extra care in processing.  The DNSKEY RR referred
   to in the DS RR MUST be a DNSSEC zone key.  The DNSKEY RR Flags MUST
   have Flags bit 7 set.  If the DNSKEY flags do not indicate a DNSSEC
   zone key, the DS RR (and the DNSKEY RR it references) MUST NOT be
   used in the validation process.
```