### PR TITLE
Move TSIG support into its own crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["domain", "domain-core", "domain-resolv", "interop"]
+members = ["domain", "domain-core", "domain-resolv", "domain-tsig", "interop"]
 

--- a/domain-core/Cargo.toml
+++ b/domain-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "domain-core"
 version = "0.4.1"
-authors = ["Martin Hoffmann <hn@nvnc.de>"]
+authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]
 description = "A DNS library for Rust – Core."
 documentation = "https://docs.rs/domain-core/"
 homepage = "https://github.com/nlnetlabs/domain/"

--- a/domain-core/Cargo.toml
+++ b/domain-core/Cargo.toml
@@ -26,6 +26,3 @@ failure_derive = "^0.1"
 rand           = "^0.6"
 void           = "^1.0"
 
-[dependencies.ring]
-version = "^0.14"
-optional = true

--- a/domain-core/Cargo.toml
+++ b/domain-core/Cargo.toml
@@ -14,10 +14,6 @@ license = "BSD-3-Clause"
 name = "domain_core"
 path = "src/lib.rs"
 
-[features]
-tsig = ["ring"]
-default = ["tsig"]
-
 [dependencies]
 bytes          = "^0.4"
 chrono         = "^0.4"

--- a/domain-core/Changelog.md
+++ b/domain-core/Changelog.md
@@ -14,7 +14,7 @@ New
 * `bits::message::Message::opt` returns a messages OPT record if present.
   ([#6], thanks to Marek Vavruša!)
 * unsafe `bits::name::Dname::from_bytes_unchecked` in order to create
-  names from well-known sequences.
+  names from well-known sequences. [(#31)]
 
 Bug fixes
 
@@ -24,9 +24,8 @@ Dependencies
 
 
 [#6]: https://github.com/NLnetLabs/domain/pull/6
-[(#16)]: https://github.com/NLnetLabs/domain/pull/16
-[(#18)]: https://github.com/NLnetLabs/domain/pull/18
 [#20]: https://github.com/NLnetLabs/domain/pull/19
+[(#31)]: https://github.com/NLnetLabs/domain/pull/31
 
 
 ## 0.4.0

--- a/domain-core/Changelog.md
+++ b/domain-core/Changelog.md
@@ -13,7 +13,8 @@ New
 
 * `bits::message::Message::opt` returns a messages OPT record if present.
   ([#6], thanks to Marek Vavruša!)
-* Support for TSIG signing of transactions and sequences. [(#16)]
+* unsafe `bits::name::Dname::from_bytes_unchecked` in order to create
+  names from well-known sequences.
 
 Bug fixes
 

--- a/domain-core/src/bits/name/dname.rs
+++ b/domain-core/src/bits/name/dname.rs
@@ -43,7 +43,7 @@ impl Dname {
     ///
     /// Since this will allow to actually construct an incorrectly encoded
     /// domain name value, the function is unsafe.
-    pub(crate) unsafe fn from_bytes_unchecked(bytes: Bytes) -> Self {
+    pub unsafe fn from_bytes_unchecked(bytes: Bytes) -> Self {
         Dname { bytes }
     }
 

--- a/domain-core/src/lib.rs
+++ b/domain-core/src/lib.rs
@@ -20,14 +20,10 @@ extern crate chrono;
 extern crate failure;
 #[macro_use] extern crate failure_derive;
 extern crate rand;
-#[cfg(feature = "tsig")]
-extern crate ring;
 extern crate void;
 
 pub mod bits;
 pub mod iana;
 pub mod master;
 pub mod rdata;
-#[cfg(feature = "tsig")]
-pub mod tsig;
 pub mod utils;

--- a/domain-tsig/Cargo.toml
+++ b/domain-tsig/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "domain-tsig"
+version = "0.4.1"
+edition = "2018"
+authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]
+description = "A DNS library for Rust – TSIG Support."
+documentation = "https://docs.rs/domain-tsig/"
+homepage = "https://github.com/nlnetlabs/domain/"
+repository = "https://github.com/nlnetlabs/domain/"
+readme = "README.md"
+keywords = ["DNS", "domain"]
+license = "BSD-3-Clause"
+
+[lib]
+name = "domain_tsig"
+path = "src/lib.rs"
+
+[dependencies]
+bytes          = "^0.4"
+derive_more    = "^0.14"
+ring           = "^0.14"
+
+[dependencies.domain-core]
+path = "../domain-core"
+version = "0.4.1"
+

--- a/domain-tsig/Changelog.md
+++ b/domain-tsig/Changelog.md
@@ -1,0 +1,8 @@
+# Change Log
+
+## Unreleased next version
+
+* Initial version.
+
+[domain-core]: https://github.com/NLnetLabs/domain/tree/master/domain-core
+

--- a/domain-tsig/src/lib.rs
+++ b/domain-tsig/src/lib.rs
@@ -55,18 +55,19 @@
 use std::{cmp, fmt, mem, str};
 use std::collections::HashMap;
 use bytes::{BigEndian, ByteOrder, Bytes, BytesMut};
+use derive_more::Display;
 use ring::{constant_time, digest, hmac, rand};
-use crate::bits::message::Message;
-use crate::bits::message_builder::{
+use domain_core::bits::message::Message;
+use domain_core::bits::message_builder::{
     AdditionalBuilder, MessageBuilder, SectionBuilder, RecordSectionBuilder
 };
-use crate::bits::name::{
+use domain_core::bits::name::{
     Dname, Label, ParsedDname, ParsedDnameError, ToDname, ToLabelIter
 };
-use crate::bits::parse::ShortBuf;
-use crate::bits::record::Record;
-use crate::iana::{Class, Rcode, TsigRcode};
-use crate::rdata::rfc2845::{Time48, Tsig};
+use domain_core::bits::parse::ShortBuf;
+use domain_core::bits::record::Record;
+use domain_core::iana::{Class, Rcode, TsigRcode};
+use domain_core::rdata::rfc2845::{Time48, Tsig};
 
 
 //------------ Key -----------------------------------------------------------
@@ -1522,12 +1523,12 @@ fn update_id(
 //------------ NewKeyError ---------------------------------------------------
 
 /// A key couldn’t be created.
-#[derive(Clone, Copy, Debug, Eq, Fail, PartialEq)]
+#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
 pub enum NewKeyError {
-    #[fail(display="minimum signature length out of bounds")]
+    #[display(fmt="minimum signature length out of bounds")]
     BadMinMacLen,
 
-    #[fail(display="created signature length out of bounds")]
+    #[display(fmt="created signature length out of bounds")]
     BadSigningLen,
 }
 
@@ -1535,15 +1536,15 @@ pub enum NewKeyError {
 //------------ GenerateKeyError ----------------------------------------------
 
 /// A key couldn’t be created.
-#[derive(Clone, Copy, Debug, Eq, Fail, PartialEq)]
+#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
 pub enum GenerateKeyError {
-    #[fail(display="minimum signature length out of bounds")]
+    #[display(fmt="minimum signature length out of bounds")]
     BadMinMacLen,
 
-    #[fail(display="created signature length out of bounds")]
+    #[display(fmt="created signature length out of bounds")]
     BadSigningLen,
 
-    #[fail(display="generating key failed")]
+    #[display(fmt="generating key failed")]
     GenerationFailed,
 }
 
@@ -1566,53 +1567,53 @@ impl From<ring::error::Unspecified> for GenerateKeyError {
 //------------ AlgorithmError ------------------------------------------------
 
 /// An invalid algorithm was provided.
-#[derive(Clone, Copy, Debug, Fail)]
-#[fail(display="invalid algorithm")]
+#[derive(Clone, Copy, Debug, Display)]
+#[display(fmt="invalid algorithm")]
 pub struct AlgorithmError;
 
 
 //------------ ValidationError -----------------------------------------------
 
 /// An error happened while validating a TSIG-signed message.
-#[derive(Clone, Debug, Fail)]
+#[derive(Clone, Debug, Display)]
 pub enum ValidationError {
-    #[fail(display="unknown algorithm")]
+    #[display(fmt="unknown algorithm")]
     BadAlg,
 
-    #[fail(display="bad content of other")]
+    #[display(fmt="bad content of other")]
     BadOther,
 
-    #[fail(display="bad signatures")]
+    #[display(fmt="bad signatures")]
     BadSig,
 
-    #[fail(display="short signature")]
+    #[display(fmt="short signature")]
     BadTrunc,
 
-    #[fail(display="unknown key")]
+    #[display(fmt="unknown key")]
     BadKey,
 
-    #[fail(display="bad time")]
+    #[display(fmt="bad time")]
     BadTime,
 
-    #[fail(display="format error")]
+    #[display(fmt="format error")]
     FormErr,
 
-    #[fail(display="unsigned answer")]
+    #[display(fmt="unsigned answer")]
     ServerUnsigned,
 
-    #[fail(display="unknown key on server")]
+    #[display(fmt="unknown key on server")]
     ServerBadKey,
 
-    #[fail(display="server failed to verify MAC")]
+    #[display(fmt="server failed to verify MAC")]
     ServerBadSig,
 
-    #[fail(display="server reported bad time")]
+    #[display(fmt="server reported bad time")]
     ServerBadTime {
         client: Time48,
         server: Time48
     },
 
-    #[fail(display="too many unsigned messages")]
+    #[display(fmt="too many unsigned messages")]
     TooManyUnsigned,
 }
 
@@ -1621,4 +1622,5 @@ impl From<ParsedDnameError> for ValidationError {
         ValidationError::FormErr
     }
 }
+
 

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "domain"
 version = "0.4.1"
-authors = ["Martin Hoffmann <hn@nvnc.de>"]
+edition = "2018"
+authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]
 description = "A DNS library for Rust – Meta Crate."
 documentation = "https://docs.rs/domain"
 homepage = "https://github.com/nlnetlabs/domain/"
@@ -10,6 +11,10 @@ readme = "README.md"
 keywords = ["DNS", "domain", "resolver", "futures"]
 license = "BSD-3-Clause"
 
+[features]
+resolv = ["domain-resolv"]
+tsig   = ["domain-tsig"]
+
 [dependencies.domain-core]
 path = "../domain-core"
 version = "0.4.1"
@@ -17,4 +22,10 @@ version = "0.4.1"
 [dependencies.domain-resolv]
 path = "../domain-resolv"
 version = "0.4.1"
+optional = true
+
+[dependencies.domain-tsig]
+path = "../domain-tsig"
+version = "0.4.1"
+optional = true
 

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -5,9 +5,14 @@
 //!
 //! Currently, these are:
 //!
-//! * [domain-core](core/index.html) under `domain::core`,
-//! * [domain-resolv](resolv/index.html) under `domain::resolv`.
+//! * [domain-core](../domain_core/index.html) under `domain::core`,
+//! * [domain-resolv](domain_resolv/index.html) under `domain::resolv`.
+//! * [domain-tsig](domain_tsig/index.html) under `domain::tsig`.
+//!
+//! Note that all but the `domain::core` re-export are optional and need
+//! to be selected via features.
 
 pub extern crate domain_core as core;
-pub extern crate domain_resolv as resolv;
+#[cfg(feature = "resolv")] pub extern crate domain_resolv as resolv;
+#[cfg(feature = "tsig")] pub extern crate domain_tsig as tsig;
 

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -8,6 +8,7 @@ license = "BSD-3-Clause"
 [dependencies]
 domain-core   = { path = "../domain-core" }
 domain-resolv = { path = "../domain-resolv" }
+domain-tsig   = { path = "../domain-tsig" }
 bytes         = "0.4"
 ring          = "0.14"
 

--- a/interop/src/lib.rs
+++ b/interop/src/lib.rs
@@ -2,10 +2,12 @@
 extern crate bytes;
 pub extern crate domain_core;
 pub extern crate domain_resolv;
+pub extern crate domain_tsig;
 
 pub mod domain {
     pub use domain_core as core;
     pub use domain_resolv as resolv;
+    pub use domain_tsig as tsig;
 }
 
 pub mod cargo;

--- a/interop/tests/tsig.rs
+++ b/interop/tests/tsig.rs
@@ -17,7 +17,7 @@ use interop::domain::core::bits::message_builder::{
 use interop::domain::core::iana::{Rcode, Rtype};
 use interop::domain::core::rdata::{A, Soa};
 use interop::domain::core::utils::base64;
-use interop::domain::core::tsig;
+use interop::domain::tsig;
 
 
 //------------ Tests --------------------------------------------------------


### PR DESCRIPTION
The main motivation is to keep `domain-core` free of features which – given that it is such a fundamental crate – may cause problems if it is imported by different crates.