### PR TITLE
Remove unwrap crate.

### DIFF
--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -19,11 +19,10 @@ path = "src/lib.rs"
 chrono         = "0.4"
 derive_more    = "0.99.1"
 rand           = "0.7"
-unwrap         = "1.2"
 void           = "1.0"
 
 bytes          = { version = "0.5.4", optional = true }
-#openssl	       = { version = "0.10", optional = true }
+#openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.16.11", optional = true }
 smallvec       = { version = "1.2", optional = true }
 

--- a/domain/src/base/charstr.rs
+++ b/domain/src/base/charstr.rs
@@ -640,7 +640,6 @@ impl std::error::Error for PushError { }
 #[cfg(test)]
 mod test {
     use std::vec::Vec;
-    use unwrap::unwrap;
     use super::*;
 
     type CharStrRef<'a> = CharStr<&'a [u8]>;
@@ -648,10 +647,10 @@ mod test {
     #[test]
     fn from_slice() {
         assert_eq!(
-            unwrap!(CharStr::from_slice(b"01234")).as_slice(),
+            CharStr::from_slice(b"01234").unwrap().as_slice(),
             b"01234"
         );
-        assert_eq!(unwrap!(CharStr::from_slice(b"")).as_slice(), b"");
+        assert_eq!(CharStr::from_slice(b"").unwrap().as_slice(), b"");
         assert!(CharStr::from_slice(&vec![0; 255]).is_ok());
         assert!(CharStr::from_slice(&vec![0; 256]).is_err());
     }
@@ -660,15 +659,15 @@ mod test {
     #[cfg(feature="bytes")]
     fn from_bytes() {
         assert_eq!(
-            unwrap!(CharStr::from_bytes(
+            CharStr::from_bytes(
                 bytes::Bytes::from_static(b"01234")
-            )) .as_slice(),
+            ).unwrap().as_slice(),
             b"01234"
         );
         assert_eq!(
-            unwrap!(CharStr::from_bytes(
+            CharStr::from_bytes(
                 bytes::Bytes::from_static(b"")
-            )).as_slice(),
+            ).unwrap().as_slice(),
             b""
         );
         assert!(CharStr::from_bytes(vec![0; 255].into()).is_ok());
@@ -705,9 +704,9 @@ mod test {
     #[test]
     fn parse() {
         let mut parser = Parser::from_static(b"12\x03foo\x02bartail");
-        unwrap!(parser.advance(2));
-        let foo = unwrap!(CharStrRef::parse(&mut parser));
-        let bar = unwrap!(CharStrRef::parse(&mut parser));
+        parser.advance(2).unwrap();
+        let foo = CharStrRef::parse(&mut parser).unwrap();
+        let bar = CharStrRef::parse(&mut parser).unwrap();
         assert_eq!(foo.as_slice(), b"foo");
         assert_eq!(bar.as_slice(), b"ba");
         assert_eq!(parser.peek_all(), b"rtail");
@@ -723,18 +722,18 @@ mod test {
         use crate::base::octets::Compose;
 
         let mut target = Vec::new();
-        let val = unwrap!(CharStr::from_slice(b"foo"));
-        unwrap!(val.compose(&mut target));
+        let val = CharStr::from_slice(b"foo").unwrap();
+        val.compose(&mut target).unwrap();
         assert_eq!(target, b"\x03foo".as_ref());
 
         let mut target = Vec::new();
-        let val = unwrap!(CharStr::from_slice(b""));
-        unwrap!(val.compose(&mut target));
+        let val = CharStr::from_slice(b"").unwrap();
+        val.compose(&mut target).unwrap();
         assert_eq!(target, &b"\x00"[..]);
     }
 
     fn are_eq(l: &[u8], r: &[u8]) -> bool {
-        unwrap!(CharStr::from_slice(l)) == unwrap!(CharStr::from_slice(r))
+        CharStr::from_slice(l).unwrap() == CharStr::from_slice(r).unwrap()
     }
 
     #[test]
@@ -753,8 +752,8 @@ mod test {
 
     fn is_ord(l: &[u8], r: &[u8], order: cmp::Ordering) {
         assert_eq!(
-            unwrap!(CharStr::from_slice(l)).cmp(
-                &unwrap!(CharStr::from_slice(r))
+            CharStr::from_slice(l).unwrap().cmp(
+                &CharStr::from_slice(r).unwrap()
             ),
             order
         )
@@ -773,26 +772,26 @@ mod test {
     #[test]
     fn push() {
         let mut o = CharStrBuilder::new_vec();
-        unwrap!(o.push(b'f'));
-        unwrap!(o.push(b'o'));
-        unwrap!(o.push(b'o'));
+        o.push(b'f').unwrap();
+        o.push(b'o').unwrap();
+        o.push(b'o').unwrap();
         assert_eq!(o.finish().as_slice(), b"foo");
 
-        let mut o = unwrap!(CharStrBuilder::from_builder(vec![0; 254]));
-        unwrap!(o.push(b'f'));
+        let mut o = CharStrBuilder::from_builder(vec![0; 254]).unwrap();
+        o.push(b'f').unwrap();
         assert_eq!(o.len(), 255);
         assert!(o.push(b'f').is_err());
     }
 
     #[test]
     fn extend_from_slice() {
-        let mut o = unwrap!(
-            CharStrBuilder::from_builder(vec![b'f', b'o', b'o'])
-        );
-        unwrap!(o.extend_from_slice(b"bar"));
+        let mut o = CharStrBuilder::from_builder(
+            vec![b'f', b'o', b'o']
+        ).unwrap();
+        o.extend_from_slice(b"bar").unwrap();
         assert_eq!(o.as_ref(), b"foobar");
         assert!(o.extend_from_slice(&[0u8; 250][..]).is_err());
-        unwrap!(o.extend_from_slice(&[0u8; 249][..]));
+        o.extend_from_slice(&[0u8; 249][..]).unwrap();
         assert_eq!(o.len(), 255);
     }
 }

--- a/domain/src/base/header.rs
+++ b/domain/src/base/header.rs
@@ -20,7 +20,6 @@
 
 use core::mem;
 use core::convert::TryInto;
-use unwrap::unwrap;
 use super::iana::{Opcode, Rcode};
 use super::octets::{
     Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf
@@ -112,7 +111,7 @@ impl Header {
     /// and is copied into a response by a server. It allows matching
     /// incoming responses to their queries.
     pub fn id(self) -> u16 {
-        u16::from_be_bytes(unwrap!(self.inner[..2].try_into()))
+        u16::from_be_bytes(self.inner[..2].try_into().unwrap())
     }
 
     /// Sets the value of the ID field.
@@ -568,9 +567,9 @@ impl HeaderCounts {
 
     /// Returns the value of the 16 bit integer starting at a given offset.
     fn get_u16(self, offset: usize) -> u16 {
-        u16::from_be_bytes(unwrap!(
-            self.inner[offset..offset + 2].try_into()
-        ))
+        u16::from_be_bytes(
+            self.inner[offset..offset + 2].try_into().unwrap()
+        )
     }
 
     /// Sets the value of the 16 bit integer starting at a given offset.

--- a/domain/src/base/message_builder.rs
+++ b/domain/src/base/message_builder.rs
@@ -6,7 +6,6 @@ use core::ops::{Deref, DerefMut};
 #[cfg(feature = "std")] use std::collections::HashMap;
 #[cfg(feature = "std")] use std::vec::Vec;
 #[cfg(feature = "bytes")] use bytes::BytesMut;
-use unwrap::unwrap;
 use super::header::{Header, HeaderCounts, HeaderSection};
 use super::iana::{OptionCode, OptRcode, Rcode, Rtype};
 use super::message::Message;
@@ -40,32 +39,32 @@ impl<Target: OctetsBuilder> MessageBuilder<Target> {
 #[cfg(feature = "std")]
 impl MessageBuilder<Vec<u8>> {
     pub fn new_vec() -> Self {
-        unwrap!(Self::from_target(Vec::new()))
+        Self::from_target(Vec::new()).unwrap()
     }
 }
 
 #[cfg(feature = "std")]
 impl MessageBuilder<StreamTarget<Vec<u8>>> {
     pub fn new_stream_vec() -> Self {
-        unwrap!(Self::from_target(
-            unwrap!(StreamTarget::new(Vec::new()))
-        ))
+        Self::from_target(
+            StreamTarget::new(Vec::new()).unwrap()
+        ).unwrap()
     }
 }
 
 #[cfg(feature="bytes")]
 impl MessageBuilder<BytesMut> {
     pub fn new_bytes() -> Self {
-        unwrap!(Self::from_target(BytesMut::new()))
+        Self::from_target(BytesMut::new()).unwrap()
     }
 }
 
 #[cfg(feature="bytes")]
 impl MessageBuilder<StreamTarget<BytesMut>> {
     pub fn new_stream_bytes() -> Self {
-        unwrap!(Self::from_target(
-            unwrap!(StreamTarget::new(BytesMut::new()))
-        ))
+        Self::from_target(
+            StreamTarget::new(BytesMut::new()).unwrap()
+        ).unwrap()
     }
 }
 
@@ -880,7 +879,7 @@ impl<Target: OctetsBuilder> OctetsBuilder for StaticCompressor<Target> {
             // Advance to the parent. If the parent is root, just write that
             // and return. Because we do that, there will always be a label
             // left here.
-            let label = unwrap!(name.next());
+            let label = name.next().unwrap();
             label.compose(self)?;
             if label.is_root() {
                 return Ok(())
@@ -974,7 +973,7 @@ impl<Target> TreeCompressor<Target> {
                 break
             }
             node = node.parents.entry(
-                unwrap!(label.as_ref().try_into())
+                label.as_ref().try_into().unwrap()
             ).or_default();
         }
         true
@@ -1032,7 +1031,7 @@ impl<Target: OctetsBuilder> OctetsBuilder for TreeCompressor<Target> {
             // Advance to the parent. If the parent is root, just write that
             // and return. Because we do that, there will always be a label
             // left here.
-            let label = unwrap!(name.next());
+            let label = name.next().unwrap();
             label.compose(self)?;
             if label.is_root() {
                 return Ok(())

--- a/domain/src/base/name/builder.rs
+++ b/domain/src/base/name/builder.rs
@@ -7,7 +7,6 @@ use core::ops;
 #[cfg(feature = "std")] use std::vec::Vec;
 #[cfg(feature = "bytes")] use bytes::BytesMut;
 use derive_more::Display;
-use unwrap::unwrap;
 use super::super::octets::{EmptyBuilder, OctetsBuilder, IntoOctets, ShortBuf};
 use super::dname::Dname;
 use super::relative::{RelativeDname, RelativeDnameError};
@@ -199,7 +198,7 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
             return Err(PushNameError)
         }
         for label in name.iter_labels() {
-            unwrap!(label.build(&mut self.builder))
+            label.build(&mut self.builder).unwrap()
         }
         Ok(())
     }
@@ -292,7 +291,7 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
             return Err(PushNameError)
         }
         for label in origin.iter_labels() {
-            unwrap!(label.build(&mut self.builder))
+            label.build(&mut self.builder).unwrap()
         }
         Ok(unsafe {
             Dname::from_octets_unchecked(self.builder.into_octets())
@@ -562,7 +561,9 @@ mod test {
         builder.append_label(b"www").unwrap();
         builder.append_label(b"example").unwrap();
         builder.append_slice(b"com").unwrap();
-        assert_eq!(unwrap!(builder.into_dname()).as_slice(),
-                   b"\x03www\x07example\x03com\x00");
+        assert_eq!(
+            builder.into_dname().unwrap().as_slice(),
+            b"\x03www\x07example\x03com\x00"
+        );
     }
 }

--- a/domain/src/base/name/dname.rs
+++ b/domain/src/base/name/dname.rs
@@ -839,7 +839,6 @@ impl From<DnameError> for ParseError {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use unwrap::unwrap;
     use super::*;
 
     macro_rules! assert_panic {
@@ -956,9 +955,9 @@ pub(crate) mod test {
     #[test]
     fn into_relative() {
         assert_eq!(
-            unwrap!(
-                Dname::from_octets(b"\x03www\0".as_ref())
-            ).into_relative().as_slice(),
+            Dname::from_octets(
+                b"\x03www\0".as_ref()
+            ).unwrap().into_relative().as_slice(),
             b"\x03www"
         );
     }
@@ -990,9 +989,7 @@ pub(crate) mod test {
     fn iter() {
         cmp_iter(Dname::root_ref().iter(), &[b""]);
         cmp_iter(
-            unwrap!(
-                Dname::from_slice(b"\x03www\x07example\x03com\0")
-            ).iter(),
+            Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap().iter(),
             &[b"www", b"example", b"com", b""]
         );
     }
@@ -1017,9 +1014,7 @@ pub(crate) mod test {
     fn iter_back() {
         cmp_iter_back(Dname::root_ref().iter(), &[b""]);
         cmp_iter_back(
-            unwrap!(
-                Dname::from_slice(b"\x03www\x07example\x03com\0")
-            ).iter(),
+            Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap().iter(),
             &[b"", b"com", b"example", b"www"]
         );
     }
@@ -1028,9 +1023,9 @@ pub(crate) mod test {
     fn iter_suffixes() {
         cmp_iter( Dname::root_ref().iter_suffixes(), &[b"\0"]);
         cmp_iter(
-            unwrap!(
-                Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-            ).iter_suffixes(),
+            Dname::from_octets(
+                b"\x03www\x07example\x03com\0".as_ref()
+            ).unwrap().iter_suffixes(),
             &[
                 b"\x03www\x07example\x03com\0", b"\x07example\x03com\0",
                 b"\x03com\0", b"\0"
@@ -1042,9 +1037,9 @@ pub(crate) mod test {
     fn label_count() {
         assert_eq!(Dname::root_ref().label_count(), 1);
         assert_eq!(
-            unwrap!(
-                Dname::from_slice(b"\x03www\x07example\x03com\0")
-            ).label_count(),
+            Dname::from_slice(
+                b"\x03www\x07example\x03com\0"
+            ).unwrap().label_count(),
             4
         );
     }
@@ -1053,9 +1048,9 @@ pub(crate) mod test {
     fn first() {
         assert_eq!(Dname::root_ref().first().as_slice(), b"");
         assert_eq!(
-            unwrap!(
-                Dname::from_slice(b"\x03www\x07example\x03com\0")
-            ).first().as_slice(),
+            Dname::from_slice(
+                b"\x03www\x07example\x03com\0"
+            ).unwrap().first().as_slice(),
             b"www"
         );
     }
@@ -1064,9 +1059,9 @@ pub(crate) mod test {
     fn last() {
         assert_eq!(Dname::root_ref().last().as_slice(), b"");
         assert_eq!(
-            unwrap!(
-                Dname::from_slice(b"\x03www\x07example\x03com\0")
-            ).last().as_slice(),
+            Dname::from_slice(
+                b"\x03www\x07example\x03com\0"
+            ).unwrap().last().as_slice(),
             b""
         );
     }
@@ -1074,9 +1069,9 @@ pub(crate) mod test {
     #[test]
     fn starts_with() {
         let root = Dname::root_ref();
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         assert!(root.starts_with(&root));
         assert!(wecr.starts_with(&wecr));
@@ -1101,21 +1096,17 @@ pub(crate) mod test {
         assert!(!root.starts_with(&test));
         assert!(!wecr.starts_with(&test));
 
-        let test = unwrap!(
-            unwrap!(
-                RelativeDname::from_octets(b"\x03www".as_ref())
-            ).chain(
-                unwrap!(RelativeDname::from_octets(b"\x07example".as_ref()))
-            )
-        );
+        let test = RelativeDname::from_octets(
+            b"\x03www".as_ref()
+        ).unwrap().chain(
+            RelativeDname::from_octets(b"\x07example".as_ref()).unwrap()
+        ).unwrap();
         assert!(!root.starts_with(&test));
         assert!( wecr.starts_with(&test));
 
-        let test = unwrap!(
-            test.chain(
-                unwrap!(RelativeDname::from_octets(b"\x03com".as_ref()))
-            )
-        );
+        let test = test.chain(
+            RelativeDname::from_octets(b"\x03com".as_ref()).unwrap()
+        ).unwrap();
         assert!(!root.starts_with(&test));
         assert!( wecr.starts_with(&test));
     }
@@ -1123,9 +1114,9 @@ pub(crate) mod test {
     #[test]
     fn ends_with() {
         let root = Dname::root_ref();
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         for name in wecr.iter_suffixes() {
             if name.is_root() {
@@ -1210,9 +1201,9 @@ pub(crate) mod test {
 
     #[test]
     fn range() {
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         assert_eq!(wecr.range(0, 4).as_slice(), b"\x03www");
         assert_eq!(wecr.range(0, 12).as_slice(), b"\x03www\x07example");
@@ -1230,9 +1221,9 @@ pub(crate) mod test {
 
     #[test]
     fn range_from() {
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         assert_eq!(
             wecr.range_from(0).as_slice(),
@@ -1248,9 +1239,9 @@ pub(crate) mod test {
 
     #[test]
     fn range_to() {
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         assert_eq!(wecr.range_to(0).as_slice(), b"");
         assert_eq!(wecr.range_to(4).as_slice(), b"\x03www");
@@ -1263,9 +1254,9 @@ pub(crate) mod test {
 
     #[test]
     fn split_at() {
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         let (left, right) = wecr.clone().split_at(0);
         assert_eq!(left.as_slice(), b"");
@@ -1291,9 +1282,9 @@ pub(crate) mod test {
 
     #[test]
     fn split_to() {
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         let mut tmp = wecr.clone();
         assert_eq!(tmp.split_to(0).as_slice(), b"");
@@ -1319,9 +1310,9 @@ pub(crate) mod test {
 
     #[test]
     fn truncate() {
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         assert_eq!(wecr.clone().truncate(0).as_slice(),
                    b"");
@@ -1340,9 +1331,9 @@ pub(crate) mod test {
 
     #[test]
     fn split_first() {
-        let mut wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let mut wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         assert_eq!(wecr.split_first().unwrap().as_slice(), b"\x03www");
         assert_eq!(wecr.as_slice(), b"\x07example\x03com\0");
@@ -1358,9 +1349,9 @@ pub(crate) mod test {
 
     #[test]
     fn parent() {
-        let mut wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let mut wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         assert!(wecr.parent());
         assert_eq!(wecr.as_slice(), b"\x07example\x03com\0");
@@ -1376,20 +1367,20 @@ pub(crate) mod test {
 
     #[test]
     fn strip_suffix() {
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
-        let ecr = unwrap!(
-            Dname::from_octets(b"\x07example\x03com\0".as_ref())
-        );
-        let cr = unwrap!(Dname::from_octets(b"\x03com\0".as_ref()));
-        let wenr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03net\0".as_ref())
-        );
-        let enr = unwrap!(
-            Dname::from_octets(b"\x07example\x03net\0".as_ref())
-        );
-        let nr = unwrap!(Dname::from_octets(b"\x03net\0".as_ref()));
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
+        let ecr = Dname::from_octets(
+            b"\x07example\x03com\0".as_ref()
+        ).unwrap();
+        let cr = Dname::from_octets(b"\x03com\0".as_ref()).unwrap();
+        let wenr = Dname::from_octets(
+            b"\x03www\x07example\x03net\0".as_ref()
+        ).unwrap();
+        let enr = Dname::from_octets(
+            b"\x07example\x03net\0".as_ref()
+        ).unwrap();
+        let nr = Dname::from_octets(b"\x03net\0".as_ref()).unwrap();
 
         assert_eq!(wecr.clone().strip_suffix(&wecr).unwrap().as_slice(),
                    b"");
@@ -1470,11 +1461,9 @@ pub(crate) mod test {
     #[test]
     fn compose_canonical() {
         let mut buf = Vec::new();
-        unwrap!(
-            unwrap!(
-                Dname::from_slice(b"\x03wWw\x07exaMPle\x03com\0")
-            ).compose_canonical(&mut buf)
-        );
+        Dname::from_slice(
+            b"\x03wWw\x07exaMPle\x03com\0"
+        ).unwrap().compose_canonical(&mut buf).unwrap();
         assert_eq!(buf.as_slice(), b"\x03www\x07example\x03com\0");
     }
 
@@ -1487,11 +1476,11 @@ pub(crate) mod test {
         use std::str::FromStr;
 
         assert_eq!(
-            unwrap!(Dname::<Vec<u8>>::from_str("www.example.com")).as_slice(),
+            Dname::<Vec<u8>>::from_str("www.example.com").unwrap().as_slice(),
             b"\x03www\x07example\x03com\0"
         );
         assert_eq!(
-            unwrap!(Dname::<Vec<u8>>::from_str("www.example.com.")).as_slice(),
+            Dname::<Vec<u8>>::from_str("www.example.com.").unwrap().as_slice(),
             b"\x03www\x07example\x03com\0"
         );
     }
@@ -1499,45 +1488,32 @@ pub(crate) mod test {
     #[test]
     fn eq() {
         assert_eq!(
-            unwrap!(Dname::from_slice(b"\x03www\x07example\x03com\0")),
-            unwrap!(Dname::from_slice(b"\x03www\x07example\x03com\0"))
-        );
-        assert_eq!(
-            unwrap!(Dname::from_slice(b"\x03www\x07example\x03com\0")),
-            unwrap!(Dname::from_slice(b"\x03wWw\x07eXAMple\x03Com\0"))
-        );
-        assert_eq!(
-            unwrap!(Dname::from_slice(b"\x03www\x07example\x03com\0")),
-            &unwrap!(
-                unwrap!(
-                    unwrap!(
-                        RelativeDname::from_octets(b"\x03www".as_ref())
-                    ).chain(
-                        unwrap!(
-                            RelativeDname::from_octets(
-                                b"\x07example\x03com".as_ref()
-                            )
-                        )
-                    )
-                ).chain(Dname::root_ref())
-            )
+            Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
+            Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap()
         );
         assert_eq!(
             Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
-            &unwrap!(
-                unwrap!(
-                    unwrap!(
-                        RelativeDname::from_octets(b"\x03wWw".as_ref())
-                    )
-                    .chain(
-                        unwrap!(
-                            RelativeDname::from_octets(
-                                b"\x07eXAMple\x03coM".as_ref()
-                            )
-                        )
-                    )
-                ).chain(Dname::root_ref())
-            )
+            Dname::from_slice(b"\x03wWw\x07eXAMple\x03Com\0").unwrap()
+        );
+        assert_eq!(
+            Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
+            &RelativeDname::from_octets(
+                b"\x03www".as_ref()
+            ).unwrap().chain(
+                RelativeDname::from_octets(
+                    b"\x07example\x03com".as_ref()
+                ).unwrap()
+            ).unwrap().chain(Dname::root_ref()).unwrap()
+        );
+        assert_eq!(
+            Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
+            &RelativeDname::from_octets(
+                b"\x03wWw".as_ref()
+            ).unwrap().chain(
+                RelativeDname::from_octets(
+                    b"\x07eXAMple\x03coM".as_ref()
+                ).unwrap()
+            ).unwrap().chain(Dname::root_ref()).unwrap()
         );
         assert_ne!(
             Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
@@ -1545,20 +1521,13 @@ pub(crate) mod test {
         );
         assert_ne!(
             Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
-            &unwrap!(
-                unwrap!(
-                    unwrap!(
-                        RelativeDname::from_octets(b"\x03www".as_ref())
-                    )
-                    .chain(
-                        unwrap!(
-                            RelativeDname::from_octets(
-                                b"\x073xample\x03com".as_ref()
-                            )
-                        )
-                    )
-                ).chain(Dname::root_ref())
-            )
+            &RelativeDname::from_octets(
+                b"\x03www".as_ref()
+            ).unwrap().chain(
+                RelativeDname::from_octets(
+                    b"\x073xample\x03com".as_ref()
+                ).unwrap()
+            ).unwrap().chain(Dname::root_ref()).unwrap()
         );
     }
 

--- a/domain/src/base/name/label.rs
+++ b/domain/src/base/name/label.rs
@@ -646,7 +646,6 @@ impl From<SplitLabelError> for ParseError {
 #[cfg(test)]
 mod test {
     use std::vec::Vec;
-    use unwrap::unwrap;
     use super::*;
 
     #[test]
@@ -702,12 +701,12 @@ mod test {
     #[test]
     fn compose() {
         let mut buf = Vec::new();
-        unwrap!(Label::root().compose(&mut buf));
+        Label::root().compose(&mut buf).unwrap();
         assert_eq!(buf, &b"\0"[..]);
 
         let mut buf = Vec::new();
         let label = Label::from_slice(b"123").unwrap();
-        unwrap!(label.compose(&mut buf));
+        label.compose(&mut buf).unwrap();
         assert_eq!(buf, &b"\x03123"[..]);
     }
 

--- a/domain/src/base/name/parsed.rs
+++ b/domain/src/base/name/parsed.rs
@@ -674,7 +674,6 @@ impl From<ParsedDnameError> for ParseError {
 #[cfg(test)]
 mod test {
     use std::vec::Vec;
-    use unwrap::unwrap;
     use crate::base::name::{Dname, RelativeDname};
     use super::*;
 
@@ -815,55 +814,53 @@ mod test {
         assert!(once_wec.starts_with(&test));
         assert!(twice_wec.starts_with(&test));
 
-        let test = unwrap!(RelativeDname::from_slice(b"\x03www"));
+        let test = RelativeDname::from_slice(b"\x03www").unwrap();
         assert!(!root.starts_with(&test));
         assert!( flat_wec.starts_with(&test));
         assert!( once_wec.starts_with(&test));
         assert!( twice_wec.starts_with(&test));
         
-        let test = unwrap!(RelativeDname::from_slice(b"\x03www\x07example"));
+        let test = RelativeDname::from_slice(b"\x03www\x07example").unwrap();
         assert!(!root.starts_with(&test));
         assert!( flat_wec.starts_with(&test));
         assert!( once_wec.starts_with(&test));
         assert!( twice_wec.starts_with(&test));
 
-        let test = unwrap!(
-            RelativeDname::from_slice(b"\x03www\x07example\x03com")
-        );
+        let test = RelativeDname::from_slice(
+            b"\x03www\x07example\x03com"
+        ).unwrap();
         assert!(!root.starts_with(&test));
         assert!( flat_wec.starts_with(&test));
         assert!( once_wec.starts_with(&test));
         assert!( twice_wec.starts_with(&test));
 
-        let test = unwrap!(Dname::from_slice(b"\x03www\x07example\x03com\0"));
+        let test = Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap();
         assert!(!root.starts_with(&test));
         assert!( flat_wec.starts_with(&test));
         assert!( once_wec.starts_with(&test));
         assert!( twice_wec.starts_with(&test));
 
-        let test = unwrap!(RelativeDname::from_slice(b"\x07example\x03com"));
+        let test = RelativeDname::from_slice(b"\x07example\x03com").unwrap();
         assert!(!root.starts_with(&test));
         assert!(!flat_wec.starts_with(&test));
         assert!(!once_wec.starts_with(&test));
         assert!(!twice_wec.starts_with(&test));
 
-        let test = unwrap!(
-            unwrap!(
-                RelativeDname::from_octets(b"\x03www".as_ref())
-            ).chain(
-                unwrap!(
-                    RelativeDname::from_octets(b"\x07example".as_ref())
-                )
-            )
-        );
+        let test = RelativeDname::from_octets(
+            b"\x03www".as_ref()
+        ).unwrap().chain(
+            RelativeDname::from_octets(
+                b"\x07example".as_ref()
+            ).unwrap()
+        ).unwrap();
         assert!(!root.starts_with(&test));
         assert!( flat_wec.starts_with(&test));
         assert!( once_wec.starts_with(&test));
         assert!( twice_wec.starts_with(&test));
 
-        let test = unwrap!(test.chain(
-            unwrap!(RelativeDname::from_octets(b"\x03com".as_ref()))
-        ));
+        let test = test.chain(
+            RelativeDname::from_octets(b"\x03com".as_ref()).unwrap()
+        ).unwrap();
         assert!(!root.starts_with(&test));
         assert!( flat_wec.starts_with(&test));
         assert!( once_wec.starts_with(&test));
@@ -876,9 +873,9 @@ mod test {
         let flat_wec = name!(flat);
         let once_wec = name!(once);
         let twice_wec = name!(twice);
-        let wecr = unwrap!(
-            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
-        );
+        let wecr = Dname::from_octets(
+            b"\x03www\x07example\x03com\0".as_ref()
+        ).unwrap();
 
         for name in wecr.iter_suffixes() {
             if name.is_root() {
@@ -1081,7 +1078,7 @@ mod test {
     fn compose() {
         fn step(name: ParsedDname<&[u8]>, result: &[u8]) {
             let mut buf = Vec::new();
-            unwrap!(name.compose(&mut buf));
+            name.compose(&mut buf).unwrap();
             assert_eq!(buf.as_slice(), result);
         }
 
@@ -1122,16 +1119,16 @@ mod test {
         step(Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap());
         step(Dname::from_slice(b"\x03wWw\x07EXAMPLE\x03com\0").unwrap());
         step(
-            unwrap!(
-                RelativeDname::from_octets(b"\x03www\x07example\x03com")
-            ).chain_root()
+            RelativeDname::from_octets(
+                b"\x03www\x07example\x03com"
+            ).unwrap().chain_root()
         );
         step(
-            unwrap!(
-                unwrap!(
-                    RelativeDname::from_octets(b"\x03www\x07example")
-                ).chain(unwrap!(Dname::from_octets(b"\x03com\0")))
-            )
+            RelativeDname::from_octets(
+                b"\x03www\x07example"
+            ).unwrap().chain(
+                Dname::from_octets(b"\x03com\0").unwrap()
+            ).unwrap()
         );
 
         ne_step(Dname::from_slice(b"\x03ww4\x07EXAMPLE\x03com\0").unwrap());

--- a/domain/src/base/name/relative.rs
+++ b/domain/src/base/name/relative.rs
@@ -734,7 +734,6 @@ impl std::error::Error for StripSuffixError { }
 
 #[cfg(test)]
 mod test {
-    use unwrap::unwrap;
     use super::*;
 
     macro_rules! assert_panic {
@@ -851,13 +850,9 @@ mod test {
     #[test]
     fn into_absolute() {
         assert_eq!(
-            unwrap!(
-                unwrap!(
-                    RelativeDname::from_octets(
-                        Vec::from(b"\x03www\x07example\x03com".as_ref())
-                    )
-                ).into_absolute()
-            ).as_slice(),
+            RelativeDname::from_octets(
+                Vec::from(b"\x03www\x07example\x03com".as_ref())
+            ).unwrap().into_absolute().unwrap().as_slice(),
             b"\x03www\x07example\x03com\0"
         );
 
@@ -869,9 +864,7 @@ mod test {
         assert_eq!(buf.len(), 250);
         let mut tmp = buf.clone();
         tmp.extend_from_slice(b"\x03123");
-        unwrap!(
-            unwrap!(RelativeDname::from_octets(tmp)).into_absolute()
-        );
+        RelativeDname::from_octets(tmp).unwrap().into_absolute().unwrap();
     }
 
     // chain is tested with the Chain type.
@@ -879,10 +872,10 @@ mod test {
     #[test]
     fn chain_root() {
         assert_eq!(
-            unwrap!(Dname::from_octets(b"\x03www\x07example\x03com\0")),
-            unwrap!(
-                RelativeDname::from_octets(b"\x03www\x07example\x03com")
-            ).chain_root()
+            Dname::from_octets(b"\x03www\x07example\x03com\0").unwrap(),
+            RelativeDname::from_octets(
+                b"\x03www\x07example\x03com"
+            ).unwrap().chain_root()
         );
     }
 
@@ -893,9 +886,9 @@ mod test {
         cmp_iter(RelativeDname::empty_ref().iter(), &[]);
         cmp_iter(RelativeDname::wildcard_ref().iter(), &[b"*"]);
         cmp_iter(
-            unwrap!(
-                RelativeDname::from_slice(b"\x03www\x07example\x03com")
-            ).iter(),
+            RelativeDname::from_slice(
+                b"\x03www\x07example\x03com"
+            ).unwrap().iter(),
             &[b"www", b"example", b"com"]
         );
     }
@@ -907,9 +900,9 @@ mod test {
         cmp_iter_back(RelativeDname::empty_ref().iter(), &[]);
         cmp_iter_back(RelativeDname::wildcard_ref().iter(), &[b"*"]);
         cmp_iter_back(
-            unwrap!(
-                RelativeDname::from_slice(b"\x03www\x07example\x03com")
-            ).iter(),
+            RelativeDname::from_slice(
+                b"\x03www\x07example\x03com"
+            ).unwrap().iter(),
             &[b"com", b"example", b"www"]
         );
     }
@@ -919,9 +912,9 @@ mod test {
         assert_eq!(RelativeDname::empty_ref().label_count(), 0);
         assert_eq!(RelativeDname::wildcard_slice().label_count(), 1);
         assert_eq!(
-            unwrap!(
-                RelativeDname::from_slice(b"\x03www\x07example\x03com")
-            ).label_count(),
+            RelativeDname::from_slice(
+                b"\x03www\x07example\x03com"
+            ).unwrap().label_count(),
             3
         );
     }
@@ -930,17 +923,15 @@ mod test {
     fn first() {
         assert_eq!(RelativeDname::empty_slice().first(), None);
         assert_eq!(
-            unwrap!(
-                unwrap!(RelativeDname::from_slice(b"\x03www")).first()
-            ).as_slice(),
+            RelativeDname::from_slice(
+                b"\x03www"
+            ).unwrap().first().unwrap().as_slice(),
             b"www"
         );
         assert_eq!(
-            unwrap!(
-                unwrap!(
-                    RelativeDname::from_slice(b"\x03www\x07example")
-                ).first()
-            ).as_slice(),
+            RelativeDname::from_slice(
+                b"\x03www\x07example"
+            ).unwrap().first().unwrap().as_slice(),
             b"www"
         );
     }
@@ -949,17 +940,15 @@ mod test {
     fn last() {
         assert_eq!(RelativeDname::empty_slice().last(), None);
         assert_eq!(
-            unwrap!(
-                unwrap!(RelativeDname::from_slice(b"\x03www")).last()
-            ).as_slice(),
+            RelativeDname::from_slice(
+                b"\x03www"
+            ).unwrap().last().unwrap().as_slice(),
             b"www"
         );
         assert_eq!(
-            unwrap!(
-                unwrap!(
-                    RelativeDname::from_slice(b"\x03www\x07example")
-                ).last()
-            ).as_slice(),
+            RelativeDname::from_slice(
+                b"\x03www\x07example"
+            ).unwrap().last().unwrap().as_slice(),
             b"example"
         );
     }
@@ -968,11 +957,11 @@ mod test {
     fn ndots() {
         assert_eq!(RelativeDname::empty_slice().ndots(), 0);
         assert_eq!(
-            unwrap!(RelativeDname::from_slice(b"\x03www")).ndots(),
+            RelativeDname::from_slice(b"\x03www").unwrap().ndots(),
             0
         );
         assert_eq!(
-            unwrap!(RelativeDname::from_slice(b"\x03www\x07example")).ndots(),
+            RelativeDname::from_slice(b"\x03www\x07example").unwrap().ndots(),
             1
         );
     }
@@ -1101,9 +1090,9 @@ mod test {
 
     #[test]
     fn range() {
-        let wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
+        let wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
         assert_eq!(wec.range(0, 4).as_slice(), b"\x03www");
         assert_eq!(wec.range(0, 12).as_slice(), b"\x03www\x07example");
         assert_eq!(wec.range(4, 12).as_slice(), b"\x07example");
@@ -1120,9 +1109,9 @@ mod test {
 
     #[test]
     fn range_from() {
-        let wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
+        let wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
 
         assert_eq!(wec.range_from(0).as_slice(),
                    b"\x03www\x07example\x03com");
@@ -1136,9 +1125,9 @@ mod test {
 
     #[test]
     fn range_to() {
-        let wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
+        let wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
 
         assert_eq!(wec.range_to(0).as_slice(), b"");
         assert_eq!(wec.range_to(4).as_slice(), b"\x03www");
@@ -1151,9 +1140,9 @@ mod test {
 
     #[test]
     fn split_off() {
-        let wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
+        let wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
 
         let mut tmp = wec.clone();
         assert_eq!(tmp.split_off(0).as_slice(), b"\x03www\x07example\x03com");
@@ -1179,9 +1168,9 @@ mod test {
 
     #[test]
     fn split_to() {
-        let wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
+        let wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
 
         let mut tmp = wec.clone();
         assert_eq!(tmp.split_to(0).as_slice(), b"");
@@ -1207,9 +1196,9 @@ mod test {
 
     #[test]
     fn truncate() {
-        let wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
+        let wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
 
         let mut tmp = wec.clone();
         tmp.truncate(0);
@@ -1235,9 +1224,9 @@ mod test {
 
     #[test]
     fn split_first() {
-        let mut wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
+        let mut wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
 
         assert_eq!(wec.split_first().unwrap().as_slice(), b"\x03www");
         assert_eq!(wec.as_slice(), b"\x07example\x03com");
@@ -1253,9 +1242,9 @@ mod test {
 
     #[test]
     fn parent() {
-        let mut wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
+        let mut wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
 
         assert!(wec.parent());
         assert_eq!(wec.as_slice(), b"\x07example\x03com");
@@ -1271,22 +1260,22 @@ mod test {
 
     #[test]
     fn strip_suffix() {
-        let wec = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
-        );
-        let ec = unwrap!(
-            RelativeDname::from_octets(b"\x07example\x03com".as_ref())
-        );
-        let c = unwrap!(
-            RelativeDname::from_octets(b"\x03com".as_ref())
-        );
-        let wen = unwrap!(
-            RelativeDname::from_octets(b"\x03www\x07example\x03net".as_ref())
-        );
-        let en = unwrap!(
-            RelativeDname::from_octets(b"\x07example\x03net".as_ref())
-        );
-        let n = unwrap!(RelativeDname::from_slice(b"\x03net".as_ref()));
+        let wec = RelativeDname::from_octets(
+            b"\x03www\x07example\x03com".as_ref()
+        ).unwrap();
+        let ec = RelativeDname::from_octets(
+            b"\x07example\x03com".as_ref()
+        ).unwrap();
+        let c = RelativeDname::from_octets(
+            b"\x03com".as_ref()
+        ).unwrap();
+        let wen = RelativeDname::from_octets(
+            b"\x03www\x07example\x03net".as_ref()
+        ).unwrap();
+        let en = RelativeDname::from_octets(
+            b"\x07example\x03net".as_ref()
+        ).unwrap();
+        let n = RelativeDname::from_slice(b"\x03net".as_ref()).unwrap();
 
         let mut tmp = wec.clone();
         assert_eq!(tmp.strip_suffix(&wec), Ok(()));

--- a/domain/src/base/name/traits.rs
+++ b/domain/src/base/name/traits.rs
@@ -5,7 +5,6 @@
 use core::cmp;
 #[cfg(feature = "std")] use std::borrow::Cow;
 #[cfg(feature = "bytes")] use bytes::Bytes;
-use unwrap::unwrap;
 use super::super::octets::{Compose, EmptyBuilder, FromBuilder, IntoOctets};
 use super::builder::PushError;
 use super::chain::{Chain, LongChainError};
@@ -124,12 +123,12 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
 
     #[cfg(feature = "std")]
     fn to_dname_vec(&self) -> Dname<std::vec::Vec<u8>> {
-        unwrap!(self.to_dname())
+        self.to_dname().unwrap()
     }
 
     #[cfg(feature="bytes")] 
     fn to_dname_bytes(&self) -> Dname<Bytes> {
-        unwrap!(self.to_dname())
+        self.to_dname().unwrap()
     }
 
     /// Returns a byte slice of the content if possible.
@@ -253,7 +252,7 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     /// or a possible initial asterisk label.
     fn rrsig_label_count(&self) -> u8 {
         let mut labels = self.iter_labels();
-        if unwrap!(labels.next()).is_wildcard() {
+        if labels.next().unwrap().is_wildcard() {
             (labels.count() - 1) as u8
         }
         else {

--- a/domain/src/base/name/uncertain.rs
+++ b/domain/src/base/name/uncertain.rs
@@ -7,7 +7,6 @@ use core::{fmt, hash, str};
 #[cfg(feature = "bytes")] use bytes::Bytes;
 #[cfg(feature = "master")] use bytes::BytesMut;
 use derive_more::From;
-#[cfg(feature = "master")] use unwrap::unwrap;
 #[cfg(feature="master")] use crate::master::scan::{
     CharSource, Scan, Scanner, ScanError
 };
@@ -385,7 +384,7 @@ impl Scan for UncertainDname<Bytes> {
                     Ok(UncertainDname::from(name.finish()))
                 }
                 else {
-                    Ok(UncertainDname::from(unwrap!(name.into_dname())))
+                    Ok(UncertainDname::from(name.into_dname().unwrap()))
                 }
             }
         )

--- a/domain/src/base/opt/mod.rs
+++ b/domain/src/base/opt/mod.rs
@@ -43,7 +43,6 @@ use core::{hash, fmt, mem, ops};
 use core::cmp::Ordering;
 use core::convert::TryInto;
 use core::marker::PhantomData;
-use unwrap::unwrap;
 use super::iana::{OptionCode, OptRcode, Rtype};
 use super::header::Header;
 use super::name::ToDname;
@@ -212,9 +211,7 @@ impl OptHeader {
     }
 
     pub fn udp_payload_size(&self) -> u16 {
-        u16::from_be_bytes(unwrap!(
-            self.inner[3..5].try_into()
-        ))
+        u16::from_be_bytes(self.inner[3..5].try_into().unwrap())
     }
 
     pub fn set_udp_payload_size(&mut self, value: u16) {
@@ -546,8 +543,8 @@ mod test {
         header.set_version(0xbd);
         header.set_dnssec_ok(true);
         let mut buf = Vec::with_capacity(11);
-        unwrap!(header.compose(&mut buf));
-        unwrap!(0u16.compose(&mut buf));
+        header.compose(&mut buf).unwrap();
+        0u16.compose(&mut buf).unwrap();
         let mut buf = Parser::from_ref(buf.as_slice());
         let record = ParsedRecord::parse(&mut buf)
             .unwrap().into_record::<Opt<_>>().unwrap().unwrap();

--- a/domain/src/base/opt/rfc8145.rs
+++ b/domain/src/base/opt/rfc8145.rs
@@ -1,7 +1,6 @@
 //! EDNS Options from RFC 8145.
 
 use core::convert::TryInto;
-use unwrap::unwrap;
 use super::super::iana::OptionCode;
 use super::super::message_builder::OptBuilder;
 use super::super::octets::{
@@ -114,7 +113,7 @@ impl<'a> Iterator for KeyTagIter<'a> {
         else {
             let (item, tail) = self.0.split_at(2);
             self.0 = tail;
-            Some(u16::from_be_bytes(unwrap!(item.try_into())))
+            Some(u16::from_be_bytes(item.try_into().unwrap()))
         }
     }
 }

--- a/domain/src/rdata/rfc1035.rs
+++ b/domain/src/rdata/rfc1035.rs
@@ -9,7 +9,6 @@ use core::cmp::Ordering;
 use core::str::FromStr;
 #[cfg(feature="bytes")] use bytes::BytesMut;
 #[cfg(feature="master")] use bytes::Bytes;
-use unwrap::unwrap;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::charstr::{CharStr, PushError};
@@ -1531,7 +1530,7 @@ impl<'a> Iterator for TxtIter<'a> {
             None
         }
         else {
-            Some(unwrap!(CharStr::parse(&mut self.0)).into_octets())
+            Some(CharStr::parse(&mut self.0).unwrap().into_octets())
         }
     }
 }

--- a/domain/src/rdata/rfc4034.rs
+++ b/domain/src/rdata/rfc4034.rs
@@ -10,7 +10,6 @@ use core::convert::TryInto;
 #[cfg(feature = "std")] use std::vec::Vec;
 #[cfg(feature="master")] use bytes::{Bytes, BytesMut};
 use derive_more::Display;
-use unwrap::unwrap;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::name::{ParsedDname, ToDname};
@@ -125,9 +124,10 @@ impl<Octets> Dnskey<Octets> {
             // key, we return 0.
             let len = self.public_key.as_ref().len();
             if len > 2 {
-                u16::from_be_bytes(unwrap!(
-                    self.public_key.as_ref()[len - 3..len - 1].try_into()
-                ))
+                u16::from_be_bytes(
+                    self.public_key.as_ref()[len - 3..len - 1]
+                        .try_into().unwrap()
+                )
             }
             else {
                 0
@@ -1278,7 +1278,7 @@ impl Scan for RtypeBitmap<Bytes> {
     ) -> Result<Self, ScanError> {
         let mut builder = RtypeBitmapBuilder::<BytesMut>::new();
         while let Ok(rtype) = Rtype::scan(scanner) {
-            unwrap!(builder.add(rtype))
+            builder.add(rtype).unwrap()
         }
         Ok(builder.finalize())
     }
@@ -1647,7 +1647,7 @@ mod test {
         assert_eq!(
             Dnskey::new(
                 256, 3, SecAlg::RsaSha256,
-                unwrap!(base64::decode(
+                base64::decode(
                     "AwEAAcTQyaIe6nt3xSPOG2L/YfwBkOVTJN6mlnZ249O5Rtt3ZSRQHxQS\
                      W61AODYw6bvgxrrGq8eeOuenFjcSYgNAMcBYoEYYmKDW6e9EryW4ZaT/\
                      MCq+8Am06oR40xAA3fClOM6QjRcT85tP41Go946AicBGP8XOP/Aj1aI/\
@@ -1655,14 +1655,14 @@ mod test {
                      bmuD3Py0IyjlBxzZUXbqLsRL9gYFkCqeTY29Ik7usuzMTa+JRSLz6KGS\
                      5RSJ7CTSMjZg8aNaUbN2dvGhakJPh92HnLvMA3TefFgbKJphFNPA3BWS\
                      KLZ02cRWXqM="
-                ))
+                ).unwrap()
             ).key_tag(),
             59944
         );
         assert_eq!(
             Dnskey::new(
                 257, 3, SecAlg::RsaSha256,
-                unwrap!(base64::decode(
+                base64::decode(
                     "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTO\
                     iW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN\
                     7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5\
@@ -1671,19 +1671,19 @@ mod test {
                     pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLY\
                     A4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws\
                     9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU="
-                ))
+                ).unwrap()
             ).key_tag(),
             20326
         );
         assert_eq!(
             Dnskey::new(
                 257, 3, SecAlg::RsaMd5,
-                unwrap!(base64::decode(
+                base64::decode(
                     "AwEAAcVaA4jSBIGRrSzpecoJELvKE9+OMuFnL8mmUBsY\
                     lB6epN1CqX7NzwjDpi6VySiEXr0C4uTYkU/L1uMv2mHE\
                     AljThFDJ1GuozJ6gA7jf3lnaGppRg2IoVQ9IVmLORmjw\
                     C+7Eoi12SqybMTicD3Ezwa9XbG1iPjmjhbMrLh7MSQpX"
-                ))
+                ).unwrap()
             ).key_tag(),
             18698
         );

--- a/domain/src/sign/records.rs
+++ b/domain/src/sign/records.rs
@@ -3,7 +3,6 @@
 use std::{fmt, io, slice};
 use std::iter::FromIterator;
 use std::vec::Vec;
-use unwrap::unwrap;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::name::ToDname;
 use crate::base::octets::{Compose, EmptyBuilder, FromBuilder};
@@ -147,9 +146,9 @@ impl<N, D> SortedRecords<N, D> {
                     key.key_tag()?,
                     apex.owner().clone(),
                 );
-                unwrap!(rrsig.compose_canonical(&mut buf));
+                rrsig.compose_canonical(&mut buf).unwrap();
                 for record in rrset.iter() {
-                    unwrap!(record.compose_canonical(&mut buf));
+                    record.compose_canonical(&mut buf).unwrap();
                 }
 
                 // Create and push the RRSIG record.
@@ -233,9 +232,9 @@ impl<N, D> SortedRecords<N, D> {
 
             let mut bitmap = RtypeBitmap::<Octets>::builder();
             // Assume there’s gonna be an RRSIG.
-            unwrap!(bitmap.add(Rtype::Rrsig));
+            bitmap.add(Rtype::Rrsig).unwrap();
             for rrset in family.rrsets() {
-                unwrap!(bitmap.add(rrset.rtype()))
+                bitmap.add(rrset.rtype()).unwrap()
             }
 
             prev = Some((name, bitmap.finalize()));

--- a/domain/src/sign/ring.rs
+++ b/domain/src/sign/ring.rs
@@ -11,7 +11,6 @@ use ring::signature::{
     Signature as RingSignature,
     ECDSA_P256_SHA256_FIXED_SIGNING
 };
-use unwrap::unwrap;
 use crate::base::iana::{DigestAlg, SecAlg};
 use crate::base::name::ToDname;
 use crate::base::octets::Compose;
@@ -69,8 +68,8 @@ impl<'a> SigningKey for Key<'a> {
         owner: N
     ) -> Result<Ds<Self::Octets>, Self::Error> {
         let mut buf = Vec::new();
-        unwrap!(owner.compose_canonical(&mut buf));
-        unwrap!(self.dnskey.compose_canonical(&mut buf));
+        owner.compose_canonical(&mut buf).unwrap();
+        self.dnskey.compose_canonical(&mut buf).unwrap();
         let digest = Vec::from(digest::digest(&digest::SHA256, &buf).as_ref());
         Ok(Ds::new(
             self.key_tag()?,

--- a/domain/src/tsig/mod.rs
+++ b/domain/src/tsig/mod.rs
@@ -61,7 +61,6 @@ use std::collections::HashMap;
 use bytes::{Bytes, BytesMut};
 use derive_more::Display;
 use ring::{constant_time, hmac, rand, hkdf::KeyType};
-use unwrap::unwrap;
 use crate::base::header::HeaderSection;
 use crate::base::iana::{Class, Rcode, TsigRcode};
 use crate::base::message::Message;
@@ -396,7 +395,7 @@ where
         &self, name: &N, algorithm: Algorithm
     ) -> Option<Self::Key> {
         // XXX This seems a bit wasteful.
-        let name = unwrap!(name.to_dname::<OctetsVec>());
+        let name = name.to_dname::<OctetsVec>().unwrap();
         self.get(&(name, algorithm)).cloned()
     }
 }


### PR DESCRIPTION
As of Rust 1.42, its functionality is part of the standard library.