### PR TITLE
Cleanup error types.

### DIFF
--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -16,7 +16,6 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-derive_more    = "0.99.1"
 rand           = "0.7"
 
 bytes          = { version = "0.5.4", optional = true }

--- a/domain/src/base/charstr.rs
+++ b/domain/src/base/charstr.rs
@@ -746,7 +746,7 @@ mod test {
 
         assert_eq!(
             CharStrRef::parse(&mut Parser::from_static(b"\x04foo")),
-            Err(ParseError::ShortBuf)
+            Err(ParseError::ShortInput)
         )
     }
 

--- a/domain/src/base/name/chain.rs
+++ b/domain/src/base/name/chain.rs
@@ -4,7 +4,6 @@
 //! crate.
 
 use core::{fmt, iter};
-use derive_more::Display;
 use super::label::Label;
 use super::super::octets::{Compose, OctetsBuilder, ShortBuf};
 use super::relative::DnameIter;
@@ -286,12 +285,22 @@ where Octets: AsRef<[u8]>, R: ToLabelIter<'a>
 }
 
 
+//============ Error Types ===================================================
+
 //------------ LongChainError ------------------------------------------------
 
 /// Chaining domain names would exceed the size limit.
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
-#[display(fmt="long domain name")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LongChainError;
+
+
+//--- Display and Error
+
+impl fmt::Display for LongChainError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("long domain name")
+    }
+}
 
 #[cfg(feature = "std")]
 impl std::error::Error for LongChainError { }

--- a/domain/src/base/name/dname.rs
+++ b/domain/src/base/name/dname.rs
@@ -638,7 +638,7 @@ fn name_len<Source: AsRef<[u8]>>(
         let mut tmp = parser.peek_all();
         loop {
             if tmp.is_empty() {
-                return Err(ParseError::ShortBuf)
+                return Err(ParseError::ShortInput)
             }
             let (label, tail) = Label::split_from(tmp)?;
             tmp = tail;
@@ -814,7 +814,7 @@ impl From<DnameError> for FormError {
 impl From<DnameError> for ParseError {
     fn from(err: DnameError) -> ParseError {
         match err {
-            DnameError::ShortInput => ParseError::ShortBuf,
+            DnameError::ShortInput => ParseError::ShortInput,
             other => ParseError::Form(other.into())
         }
     }
@@ -837,7 +837,7 @@ impl fmt::Display for DnameError {
             DnameError::TrailingData
                 => f.write_str("trailing data"),
             DnameError::ShortInput
-                => ParseError::ShortBuf.fmt(f)
+                => ParseError::ShortInput.fmt(f)
         }
     }
 }
@@ -1426,11 +1426,11 @@ pub(crate) mod test {
 
         // Short buffer in middle of label.
         let mut p = Parser::from_static(b"\x03www\x07exam");
-        assert_eq!(Dname::parse(&mut p), Err(ParseError::ShortBuf));
+        assert_eq!(Dname::parse(&mut p), Err(ParseError::ShortInput));
 
         // Short buffer at end of label.
         let mut p = Parser::from_static(b"\x03www\x07example");
-        assert_eq!(Dname::parse(&mut p), Err(ParseError::ShortBuf));
+        assert_eq!(Dname::parse(&mut p), Err(ParseError::ShortInput));
 
         // Compressed name.
         let mut p = Parser::from_static(b"\x03com\x03www\x07example\xc0\0");

--- a/domain/src/base/name/dname.rs
+++ b/domain/src/base/name/dname.rs
@@ -6,7 +6,6 @@ use core::{cmp, fmt, hash, ops, str};
 use core::str::FromStr;
 #[cfg(feature = "std")] use std::vec::Vec;
 #[cfg(feature = "bytes")] use bytes::Bytes;
-use derive_more::Display;
 #[cfg(feature="master")] use crate::master::scan::{
     CharSource, Scan, Scanner, ScanError, SyntaxError
 };
@@ -639,7 +638,7 @@ fn name_len<Source: AsRef<[u8]>>(
         let mut tmp = parser.peek_all();
         loop {
             if tmp.is_empty() {
-                return Err(ShortBuf.into())
+                return Err(ParseError::ShortBuf)
             }
             let (label, tail) = Label::split_from(tmp)?;
             tmp = tail;
@@ -763,33 +762,23 @@ impl<Ref: OctetsRef> Iterator for SuffixIter<Ref> {
 }
 
 
+//============ Error Types ===================================================
+
 //------------ DnameError ----------------------------------------------------
 
 /// A domain name wasn’t encoded correctly.
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DnameError {
-    #[display(fmt="{}", _0)]
     BadLabel(LabelTypeError),
-
-    #[display(fmt="compressed domain name")]
     CompressedName,
-
-    #[display(fmt="long domain name")]
     LongName,
-
-    #[display(fmt="relative name")]
     RelativeName,
-
-    #[display(fmt="trailing data")]
     TrailingData,
-
-    #[display(fmt="unexpected end of buffer")]
-    ShortBuf,
-
+    ShortInput,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DnameError { }
+
+//--- From
 
 impl From<LabelTypeError> for DnameError {
     fn from(err: LabelTypeError) -> DnameError {
@@ -802,7 +791,7 @@ impl From<SplitLabelError> for DnameError {
         match err {
             SplitLabelError::Pointer(_) => DnameError::CompressedName,
             SplitLabelError::BadType(t) => DnameError::BadLabel(t),
-            SplitLabelError::ShortBuf => DnameError::ShortBuf,
+            SplitLabelError::ShortInput => DnameError::ShortInput,
         }
     }
 }
@@ -816,7 +805,7 @@ impl From<DnameError> for FormError {
                 DnameError::LongName => "long domain name",
                 DnameError::RelativeName => "relative domain name",
                 DnameError::TrailingData => "trailing data in buffer",
-                DnameError::ShortBuf => "unexpected end of buffer",
+                DnameError::ShortInput => "unexpected end of buffer",
             }
         )
     }
@@ -825,11 +814,36 @@ impl From<DnameError> for FormError {
 impl From<DnameError> for ParseError {
     fn from(err: DnameError) -> ParseError {
         match err {
-            DnameError::ShortBuf => ParseError::ShortBuf,
+            DnameError::ShortInput => ParseError::ShortBuf,
             other => ParseError::Form(other.into())
         }
     }
 }
+
+
+//--- Display and Error
+
+impl fmt::Display for DnameError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DnameError::BadLabel(ref err)
+                => err.fmt(f),
+            DnameError::CompressedName
+                => f.write_str("compressed domain name"),
+            DnameError::LongName
+                => f.write_str("long domain name"),
+            DnameError::RelativeName
+                => f.write_str("relative name"),
+            DnameError::TrailingData
+                => f.write_str("trailing data"),
+            DnameError::ShortInput
+                => ParseError::ShortBuf.fmt(f)
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DnameError { }
 
 
 //============ Testing =======================================================
@@ -910,7 +924,7 @@ pub(crate) mod test {
         // bytes shorter than what label length says.
         assert_eq!(
             Dname::from_slice(b"\x03www\x07exa"),
-            Err(DnameError::ShortBuf)
+            Err(DnameError::ShortInput)
         );
 
         // label 63 long ok, 64 bad.
@@ -945,7 +959,7 @@ pub(crate) mod test {
                    Err(DnameError::CompressedName.into()));
 
         // empty input
-        assert_eq!(Dname::from_slice(b""), Err(DnameError::ShortBuf));
+        assert_eq!(Dname::from_slice(b""), Err(DnameError::ShortInput));
     }
 
     // `Dname::from_chars` is covered in the `FromStr` test.
@@ -1412,11 +1426,11 @@ pub(crate) mod test {
 
         // Short buffer in middle of label.
         let mut p = Parser::from_static(b"\x03www\x07exam");
-        assert_eq!(Dname::parse(&mut p), Err(ShortBuf.into()));
+        assert_eq!(Dname::parse(&mut p), Err(ParseError::ShortBuf));
 
         // Short buffer at end of label.
         let mut p = Parser::from_static(b"\x03www\x07example");
-        assert_eq!(Dname::parse(&mut p), Err(ShortBuf.into()));
+        assert_eq!(Dname::parse(&mut p), Err(ParseError::ShortBuf));
 
         // Compressed name.
         let mut p = Parser::from_static(b"\x03com\x03www\x07example\xc0\0");

--- a/domain/src/base/name/label.rs
+++ b/domain/src/base/name/label.rs
@@ -652,7 +652,7 @@ impl From<SplitLabelError> for ParseError {
             SplitLabelError::BadType(_) => {
                 ParseError::Form(FormError::new("invalid label type"))
             }
-            SplitLabelError::ShortInput => ParseError::ShortBuf
+            SplitLabelError::ShortInput => ParseError::ShortInput
         }
     }
 }
@@ -668,7 +668,7 @@ impl fmt::Display for SplitLabelError {
             SplitLabelError::BadType(ltype)
                 => ltype.fmt(f),
             SplitLabelError::ShortInput
-                => ParseError::ShortBuf.fmt(f)
+                => ParseError::ShortInput.fmt(f)
         }
     }
 }

--- a/domain/src/base/name/label.rs
+++ b/domain/src/base/name/label.rs
@@ -4,7 +4,6 @@
 //! module.
 
 use core::{borrow, cmp, fmt, hash, ops};
-use derive_more::Display;
 use super::super::octets::{
     Compose, FormError, OctetsBuilder, ParseError, ShortBuf
 };
@@ -85,7 +84,7 @@ impl Label {
                       -> Result<(&Self, &[u8]), SplitLabelError> {
         let head = match slice.get(0) {
             Some(ch) => *ch,
-            None => return Err(SplitLabelError::ShortBuf)
+            None => return Err(SplitLabelError::ShortInput)
         };
         let end = match head {
             0 ..= 0x3F => (head as usize) + 1,
@@ -97,7 +96,7 @@ impl Label {
             0xC0 ..= 0xFF => {
                 let res = match slice.get(1) {
                     Some(ch) => u16::from(*ch),
-                    None => return Err(SplitLabelError::ShortBuf)
+                    None => return Err(SplitLabelError::ShortInput)
                 };
                 let res = res | ((u16::from(head) & 0x3F) << 8);
                 return Err(SplitLabelError::Pointer(res))
@@ -109,7 +108,7 @@ impl Label {
             }
         };
         if slice.len() < end {
-            return Err(SplitLabelError::ShortBuf)
+            return Err(SplitLabelError::ShortInput)
         }
         Ok((unsafe { Self::from_slice_unchecked(&slice[1..end]) },
             &slice[end..]))
@@ -567,21 +566,35 @@ impl<'a> Iterator for SliceLabelsIter<'a> {
 }
 
 
+//============ Error Types ===================================================
+
 //------------ LabelTypeError ------------------------------------------------
 
 /// A bad label type was encountered.
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LabelTypeError {
     /// The label was of the undefined type `0b10`.
-    #[display(fmt="undefined label type")]
     Undefined,
 
     /// The label was of extended label type given.
     /// 
     /// The type value will be in the range `0x40` to `0x7F`, that is, it
     /// includes the original label type bits `0b01`.
-    #[display(fmt="unknown extended label 0x{:02x}", _0)]
     Extended(u8),
+}
+
+
+//--- Display and Error
+
+impl fmt::Display for LabelTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            LabelTypeError::Undefined
+                => f.write_str("undefined label type"),
+            LabelTypeError::Extended(value)
+                => write!(f, "unknown extended label 0x{:02x}", value)
+        }
+    }
 }
 
 #[cfg(feature = "std")]
@@ -591,9 +604,17 @@ impl std::error::Error for LabelTypeError { }
 //------------ LongLabelError ------------------------------------------------
 
 /// A label was longer than the allowed 63 bytes.
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
-#[display(fmt="long label")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LongLabelError;
+
+
+//--- Display and Error
+
+impl fmt::Display for LongLabelError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("long label")
+    }
+}
 
 #[cfg(feature = "std")]
 impl std::error::Error for LongLabelError { }
@@ -602,23 +623,19 @@ impl std::error::Error for LongLabelError { }
 //------------ SplitLabelError -----------------------------------------------
 
 /// An error happened while splitting a label from a bytes slice.
-#[derive(Clone, Copy, Debug, Display, Eq,  PartialEq)]
+#[derive(Clone, Copy, Debug, Eq,  PartialEq)]
 pub enum SplitLabelError {
     /// The label was a pointer to the given position.
-    #[display(fmt="compressed domain name")]
     Pointer(u16),
 
     /// The label type was invalid.
-    #[display(fmt="{}", _0)]
     BadType(LabelTypeError),
 
     /// The bytes slice was too short.
-    #[display(fmt="unexpected end of input")]
-    ShortBuf,
+    ShortInput,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SplitLabelError { }
+//--- From
 
 impl From<LabelTypeError> for SplitLabelError {
     fn from(err: LabelTypeError) -> SplitLabelError {
@@ -635,10 +652,29 @@ impl From<SplitLabelError> for ParseError {
             SplitLabelError::BadType(_) => {
                 ParseError::Form(FormError::new("invalid label type"))
             }
-            SplitLabelError::ShortBuf => ParseError::ShortBuf
+            SplitLabelError::ShortInput => ParseError::ShortBuf
         }
     }
 }
+
+
+//--- Display and Error
+
+impl fmt::Display for SplitLabelError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SplitLabelError::Pointer(_)
+                => f.write_str("compressed domain name"),
+            SplitLabelError::BadType(ltype)
+                => ltype.fmt(f),
+            SplitLabelError::ShortInput
+                => ParseError::ShortBuf.fmt(f)
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SplitLabelError { }
 
 
 //============ Testing =======================================================
@@ -679,11 +715,11 @@ mod test {
 
         // short slice
         assert_eq!(Label::split_from(b"\x03ww"),
-                   Err(SplitLabelError::ShortBuf));
+                   Err(SplitLabelError::ShortInput));
 
         // empty slice
         assert_eq!(Label::split_from(b""),
-                   Err(SplitLabelError::ShortBuf));
+                   Err(SplitLabelError::ShortInput));
 
         // compressed label
         assert_eq!(Label::split_from(b"\xc0\x05foo"),

--- a/domain/src/base/name/parsed.rs
+++ b/domain/src/base/name/parsed.rs
@@ -1007,21 +1007,21 @@ mod test {
         // Short buffer in the middle of a label.
         let mut parser = p(b"\x03www\x07exam", 0);
         assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ParseError::ShortBuf));
+                   Err(ParseError::ShortInput));
         assert_eq!(ParsedDname::skip(&mut parser),
-                   Err(ParseError::ShortBuf));
+                   Err(ParseError::ShortInput));
 
         // Short buffer at end of label.
         let mut parser = p(b"\x03www\x07example", 0);
         assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ParseError::ShortBuf));
+                   Err(ParseError::ShortInput));
         assert_eq!(ParsedDname::skip(&mut parser),
-                   Err(ParseError::ShortBuf));
+                   Err(ParseError::ShortInput));
 
         // Compression pointer beyond the end of buffer.
         let mut parser = p(b"\x03www\xc0\xee12", 0);
         assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ParseError::ShortBuf));
+                   Err(ParseError::ShortInput));
         assert_eq!(ParsedDname::skip(&mut parser), Ok(()));
         assert_eq!(parser.remaining(), 2);
 

--- a/domain/src/base/name/parsed.rs
+++ b/domain/src/base/name/parsed.rs
@@ -1007,21 +1007,21 @@ mod test {
         // Short buffer in the middle of a label.
         let mut parser = p(b"\x03www\x07exam", 0);
         assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ShortBuf.into()));
+                   Err(ParseError::ShortBuf));
         assert_eq!(ParsedDname::skip(&mut parser),
-                   Err(ShortBuf.into()));
+                   Err(ParseError::ShortBuf));
 
         // Short buffer at end of label.
         let mut parser = p(b"\x03www\x07example", 0);
         assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ShortBuf.into()));
+                   Err(ParseError::ShortBuf));
         assert_eq!(ParsedDname::skip(&mut parser),
-                   Err(ShortBuf.into()));
+                   Err(ParseError::ShortBuf));
 
         // Compression pointer beyond the end of buffer.
         let mut parser = p(b"\x03www\xc0\xee12", 0);
         assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ShortBuf.into()));
+                   Err(ParseError::ShortBuf));
         assert_eq!(ParsedDname::skip(&mut parser), Ok(()));
         assert_eq!(parser.remaining(), 2);
 

--- a/domain/src/base/name/relative.rs
+++ b/domain/src/base/name/relative.rs
@@ -725,7 +725,7 @@ impl fmt::Display for RelativeDnameError {
             RelativeDnameError::CompressedName
                 => f.write_str("compressed domain name"),
             RelativeDnameError::ShortInput
-                => ParseError::ShortBuf.fmt(f),
+                => ParseError::ShortInput.fmt(f),
             RelativeDnameError::LongName
                 => f.write_str("long domain name"),
             RelativeDnameError::AbsoluteName

--- a/domain/src/base/name/uncertain.rs
+++ b/domain/src/base/name/uncertain.rs
@@ -6,7 +6,6 @@ use core::{fmt, hash, str};
 #[cfg(feature = "std")] use std::vec::Vec;
 #[cfg(feature = "bytes")] use bytes::Bytes;
 #[cfg(feature = "master")] use bytes::BytesMut;
-use derive_more::From;
 #[cfg(feature="master")] use crate::master::scan::{
     CharSource, Scan, Scanner, ScanError
 };
@@ -29,7 +28,7 @@ use super::traits::{ToEitherDname, ToLabelIter};
 ///
 /// This type is helpful when reading a domain name from some source where it
 /// may end up being absolute or not.
-#[derive(Clone, From)]
+#[derive(Clone)]
 pub enum UncertainDname<Octets> {
     Absolute(Dname<Octets>),
     Relative(RelativeDname<Octets>),
@@ -226,6 +225,22 @@ impl<Octets> UncertainDname<Octets> {
         Chain::new_uncertain(self, suffix)
     }
 }
+
+
+//--- From
+
+impl<Octets> From<Dname<Octets>> for UncertainDname<Octets> {
+    fn from(src: Dname<Octets>) -> Self {
+        UncertainDname::Absolute(src)
+    }
+}
+
+impl<Octets> From<RelativeDname<Octets>> for UncertainDname<Octets> {
+    fn from(src: RelativeDname<Octets>) -> Self {
+        UncertainDname::Relative(src)
+    }
+}
+
 
 //--- FromStr
 

--- a/domain/src/base/record.rs
+++ b/domain/src/base/record.rs
@@ -410,7 +410,7 @@ impl<Name> RecordHeader<Name> {
         let header = Self::parse(parser)?;
         match parser.advance(header.rdlen() as usize) {
             Ok(()) => Ok(header),
-            Err(_) => Err(ParseError::ShortBuf),
+            Err(_) => Err(ParseError::ShortInput),
         }
     }
 }

--- a/domain/src/base/record.rs
+++ b/domain/src/base/record.rs
@@ -410,7 +410,7 @@ impl<Name> RecordHeader<Name> {
         let header = Self::parse(parser)?;
         match parser.advance(header.rdlen() as usize) {
             Ok(()) => Ok(header),
-            Err(_) => Err(ShortBuf.into()),
+            Err(_) => Err(ParseError::ShortBuf),
         }
     }
 }

--- a/domain/src/base/str.rs
+++ b/domain/src/base/str.rs
@@ -197,7 +197,7 @@ impl fmt::Display for SymbolError {
             SymbolError::BadEscape
                 => f.write_str("illegal escape sequence"),
             SymbolError::ShortInput
-                => ParseError::ShortBuf.fmt(f)
+                => ParseError::ShortInput.fmt(f)
         }
     }
 }

--- a/domain/src/base/str.rs
+++ b/domain/src/base/str.rs
@@ -2,8 +2,9 @@
 
 use core::fmt;
 #[cfg(feature = "bytes")] use bytes::{BufMut, BytesMut};
-use derive_more::Display;
 #[cfg(feature = "master")] use crate::master::scan::SyntaxError;
+use super::octets::ParseError;
+
 
 //------------ Symbol --------------------------------------------------------
 
@@ -176,16 +177,29 @@ impl fmt::Display for Symbol {
 }
 
 
+//============ Error Types ===================================================
+
 //------------ SymbolError ---------------------------------------------------
 
 /// An error happened when reading a symbol.
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SymbolError {
-    #[display(fmt="illegal escape sequence")]
     BadEscape,
-
-    #[display(fmt="unexpected end of input")]
     ShortInput
+}
+
+
+//--- Display and Error
+
+impl fmt::Display for SymbolError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SymbolError::BadEscape
+                => f.write_str("illegal escape sequence"),
+            SymbolError::ShortInput
+                => ParseError::ShortBuf.fmt(f)
+        }
+    }
 }
 
 #[cfg(feature = "std")]
@@ -195,9 +209,17 @@ impl std::error::Error for SymbolError { }
 //------------ BadSymbol -----------------------------------------------------
 
 /// A symbol of unexepected value was encountered. 
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
-#[display(fmt="bad symbol '{}'", _0)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BadSymbol(pub Symbol);
+
+
+//--- Display and Error
+
+impl fmt::Display for BadSymbol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "bad symbol '{}'", self.0)
+    }
+}
 
 #[cfg(feature = "std")]
 impl std::error::Error for BadSymbol { }

--- a/domain/src/base/utils/base64.rs
+++ b/domain/src/base/utils/base64.rs
@@ -3,7 +3,6 @@
 use core::fmt;
 #[cfg(feature = "std")] use std::string::String;
 #[cfg(feature= "bytes" )] use bytes::{BufMut, Bytes, BytesMut};
-use derive_more::Display;
 
 
 //------------ Convenience Functions -----------------------------------------
@@ -163,26 +162,40 @@ impl Default for Decoder {
     }
 }
 
+
+//============ Error Types ===================================================
+
 //------------ DecodeError ---------------------------------------------------
 
 /// An error happened while decoding a Base64 string.
-#[derive(Debug, Display, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum DecodeError {
-    #[display(fmt="incomplete input")]
     IncompleteInput,
-
-    #[display(fmt="trailing input")]
     TrailingInput,
-
-    #[display(fmt="illegal character '{}'", _0)]
     IllegalChar(char),
+}
+
+
+//--- Display and Error
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DecodeError::IncompleteInput
+                => f.write_str("incomplete input"),
+            DecodeError::TrailingInput
+                => f.write_str("trailing input"),
+            DecodeError::IllegalChar(ch)
+                => write!(f, "illegal character '{}'", ch)
+        }
+    }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for DecodeError { }
 
 
-//------------ Constants -----------------------------------------------------
+//============ Constants =====================================================
 
 /// The alphabet used by the decoder.
 ///

--- a/domain/src/master/source.rs
+++ b/domain/src/master/source.rs
@@ -3,13 +3,12 @@
 //! This is here so we can read from things that aren’t ASCII or UTF-8.
 #![cfg(feature = "std")]
 
-use std::{char, error, io};
+use std::{char, error, fmt, io};
 use std::boxed::Box;
 use std::io::Read;
 use std::fs::File;
 use std::path::Path;
 use std::vec::Vec;
-use derive_more::Display;
 use super::scan::CharSource;
 
 
@@ -95,16 +94,6 @@ impl CharSource for AsciiFile {
         err
     }
 }
-
-
-//------------ AsciiError ----------------------------------------------------
-
-/// An error happened while reading an ASCII-only file.
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
-#[display(fmt="invalid ASCII character '{}'", _0)]
-pub struct AsciiError(u8);
-
-impl error::Error for AsciiError { }
 
 
 //------------ Utf8File ------------------------------------------------------
@@ -193,16 +182,6 @@ impl CharSource for Utf8File {
     }
 }
 
-
-//------------ Utf8Error -----------------------------------------------------
-
-/// An error happened while reading an ASCII-only file.
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
-#[display(fmt="invalid UTF-8 sequence")]
-pub struct Utf8Error;
-
-impl error::Error for Utf8Error { }
-
 impl From<Utf8Error> for io::Error {
     fn from(err: Utf8Error) -> Self {
         io::Error::new(io::ErrorKind::Other, err)
@@ -272,3 +251,43 @@ impl OctetFile {
         err
     }
 }
+
+
+//=========== Error Types ===================================================
+
+
+//------------ AsciiError ----------------------------------------------------
+
+/// An error happened while reading an ASCII-only file.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AsciiError(u8);
+
+
+//--- Display and Error
+
+impl fmt::Display for AsciiError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid ASCII character '{}'", self.0)
+    }
+}
+
+impl error::Error for AsciiError { }
+
+
+//------------ Utf8Error -----------------------------------------------------
+
+/// An error happened while reading a file encoded with UTF-8.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Utf8Error;
+
+
+//--- Display and Error
+
+impl fmt::Display for Utf8Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid UTF-8 sequence")
+    }
+}
+
+impl error::Error for Utf8Error { }
+

--- a/domain/src/rdata/rfc4034.rs
+++ b/domain/src/rdata/rfc4034.rs
@@ -225,7 +225,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Dnskey<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = match parser.remaining().checked_sub(4) {
             Some(len) => len,
-            None => return Err(ParseError::ShortBuf)
+            None => return Err(ParseError::ShortInput)
         };
         Ok(Self::new(
             u16::parse(parser)?,
@@ -237,7 +237,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Dnskey<Ref::Range> {
 
     fn skip(parser: &mut Parser<Ref>) -> Result<(), ParseError> {
         if parser.remaining() < 4 {
-            return Err(ParseError::ShortBuf)
+            return Err(ParseError::ShortInput)
         }
         parser.advance_to_end();
         Ok(())
@@ -1023,7 +1023,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Ds<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = match parser.remaining().checked_sub(4) {
             Some(len) => len,
-            None => return Err(ParseError::ShortBuf)
+            None => return Err(ParseError::ShortInput)
         };
         Ok(Self::new(
             u16::parse(parser)?,
@@ -1035,7 +1035,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Ds<Ref::Range> {
 
     fn skip(parser: &mut Parser<Ref>) -> Result<(), ParseError> {
         if parser.remaining() < 4 {
-            return Err(ParseError::ShortBuf);
+            return Err(ParseError::ShortInput);
         }
         parser.advance_to_end();
         Ok(())
@@ -1522,7 +1522,7 @@ pub enum RtypeBitmapError {
 impl From<RtypeBitmapError> for ParseError {
     fn from(err: RtypeBitmapError) -> ParseError {
         match err {
-            RtypeBitmapError::ShortInput => ParseError::ShortBuf,
+            RtypeBitmapError::ShortInput => ParseError::ShortInput,
             RtypeBitmapError::BadRtypeBitmap => {
                 FormError::new("invalid NSEC bitmap").into()
             }
@@ -1537,7 +1537,7 @@ impl fmt::Display for RtypeBitmapError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             RtypeBitmapError::ShortInput
-                => ParseError::ShortBuf.fmt(f),
+                => ParseError::ShortInput.fmt(f),
             RtypeBitmapError::BadRtypeBitmap
                 => f.write_str("invalid record type bitmap")
         }

--- a/domain/src/rdata/rfc4034.rs
+++ b/domain/src/rdata/rfc4034.rs
@@ -9,7 +9,6 @@ use core::cmp::Ordering;
 use core::convert::TryInto;
 #[cfg(feature = "std")] use std::vec::Vec;
 #[cfg(feature="master")] use bytes::{Bytes, BytesMut};
-use derive_more::Display;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::name::{ParsedDname, ToDname};
@@ -1120,7 +1119,7 @@ impl<Octets> RtypeBitmap<Octets> {
             while !data.is_empty() {
                 // At least bitmap number and length must be present.
                 if data.len() < 2 {
-                    return Err(RtypeBitmapError::ShortBuf)
+                    return Err(RtypeBitmapError::ShortInput)
                 }
 
                 let len = (data[1] as usize) + 2;
@@ -1133,7 +1132,7 @@ impl<Octets> RtypeBitmap<Octets> {
                     return Err(RtypeBitmapError::BadRtypeBitmap)
                 }
                 if data.len() < len {
-                    return Err(RtypeBitmapError::ShortBuf)
+                    return Err(RtypeBitmapError::ShortInput)
                 }
                 data = &data[len..];
             }
@@ -1511,34 +1510,42 @@ impl<'a> Iterator for RtypeBitmapIter<'a> {
 
 //------------ RtypeBitmapError ----------------------------------------------
 
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RtypeBitmapError {
-    #[display(fmt="short field")]
-    ShortBuf,
-
-    #[display(fmt="invalid record type bitmap")]
+    ShortInput,
     BadRtypeBitmap,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RtypeBitmapError { }
 
-impl From<ShortBuf> for RtypeBitmapError {
-    fn from(_: ShortBuf) -> Self {
-        RtypeBitmapError::ShortBuf
-    }
-}
+//--- From
 
 impl From<RtypeBitmapError> for ParseError {
     fn from(err: RtypeBitmapError) -> ParseError {
         match err {
-            RtypeBitmapError::ShortBuf => ParseError::ShortBuf,
+            RtypeBitmapError::ShortInput => ParseError::ShortBuf,
             RtypeBitmapError::BadRtypeBitmap => {
                 FormError::new("invalid NSEC bitmap").into()
             }
         }
     }
 }
+
+
+//--- Display and Error
+
+impl fmt::Display for RtypeBitmapError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            RtypeBitmapError::ShortInput
+                => ParseError::ShortBuf.fmt(f),
+            RtypeBitmapError::BadRtypeBitmap
+                => f.write_str("invalid record type bitmap")
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RtypeBitmapError { }
 
 
 //------------ Friendly Helper Functions -------------------------------------

--- a/domain/src/rdata/rfc7344.rs
+++ b/domain/src/rdata/rfc7344.rs
@@ -124,7 +124,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Cdnskey<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = match parser.remaining().checked_sub(4) {
             Some(len) => len,
-            None => return Err(ParseError::ShortBuf)
+            None => return Err(ParseError::ShortInput)
         };
         Ok(Self::new(
             u16::parse(parser)?,
@@ -136,7 +136,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Cdnskey<Ref::Range> {
 
     fn skip(parser: &mut Parser<Ref>) -> Result<(), ParseError> {
         if parser.remaining() < 4 {
-            return Err(ParseError::ShortBuf)
+            return Err(ParseError::ShortInput)
         }
         parser.advance_to_end();
         Ok(())
@@ -325,7 +325,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Cds<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = match parser.remaining().checked_sub(4) {
             Some(len) => len,
-            None => return Err(ParseError::ShortBuf)
+            None => return Err(ParseError::ShortInput)
         };
         Ok(Self::new(
             u16::parse(parser)?,
@@ -337,7 +337,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Cds<Ref::Range> {
 
     fn skip(parser: &mut Parser<Ref>) -> Result<(), ParseError> {
         if parser.remaining() < 4 {
-            return Err(ParseError::ShortBuf);
+            return Err(ParseError::ShortInput);
         }
         parser.advance_to_end();
         Ok(())


### PR DESCRIPTION
This PR does two things:

* removes the dependency on `derive_more` by manually implementing the `From` and `Display` traits for error types,
* renames the `ShortBuf` variant of all parse error types to `ShortInput` for more consistent naming. Now `ShortBuf` is for when an octet builder runs out of space only.