### PR TITLE
Prepare for domain release 0.5.1.

### DIFF
--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain"
-version = "0.5.1-pre"
+version = "0.5.1"
 edition = "2018"
 authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]
 description = "A DNS library for Rust."

--- a/domain/Changelog.md
+++ b/domain/Changelog.md
@@ -1,9 +1,6 @@
 # Change Log
 
-
-## Unreleased next version
-
-Breaking Changes
+## 0.5.1
 
 New
 
@@ -13,8 +10,6 @@ Bug Fixes
 
 * Fix calculation of block lengths in `TxtBuilder`. ([#57], by [@vavrusa])
 * Fix construction of options in OPT records. ([#59], by [@vavrusa])
-
-Dependencies
 
 [#57]: https://github.com/NLnetLabs/domain/pull/57
 [#58]: https://github.com/NLnetLabs/domain/pull/58


### PR DESCRIPTION
There is no changes to `domain-resolv`, so no release for that.