### PR TITLE
domain/octets: implement Convert trait to allow converting octet types

### DIFF
--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -33,7 +33,7 @@ use core::{cmp, fmt, hash, ops, str};
 };
 use super::cmp::CanonicalOrd;
 use super::octets::{
-    Compose, Convert, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsRef,
+    Compose, ConvertOctets, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsRef,
     Parse, ParseError, Parser, ShortBuf
 };
 use super::str::{BadSymbol, Symbol, SymbolError};
@@ -163,10 +163,10 @@ impl CharStr<[u8]> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<Octets, Other> Convert<CharStr<Other>> for CharStr<Octets>
-where Octets: AsRef<[u8]> + Convert<Other> {
+impl<Octets, Other> ConvertOctets<CharStr<Other>> for CharStr<Octets>
+where Octets: AsRef<[u8]> + ConvertOctets<Other> {
     fn convert(&self) -> Result<CharStr<Other>, ShortBuf> {
         unsafe { Ok(CharStr::from_octets_unchecked(self.0.convert()?)) }
     }

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -33,7 +33,7 @@ use core::{cmp, fmt, hash, ops, str};
 };
 use super::cmp::CanonicalOrd;
 use super::octets::{
-    Compose, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsRef,
+    Compose, Convert, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsRef,
     Parse, ParseError, Parser, ShortBuf
 };
 use super::str::{BadSymbol, Symbol, SymbolError};
@@ -159,6 +159,16 @@ impl CharStr<[u8]> {
                 &*(slice as *const [u8] as *const CharStr<[u8]>)
             })
         }
+    }
+}
+
+
+//--- Convert
+
+impl<Octets, Other> Convert<CharStr<Other>> for CharStr<Octets>
+where Octets: AsRef<[u8]> + Convert<Other> {
+    fn convert(&self) -> Result<CharStr<Other>, ShortBuf> {
+        unsafe { Ok(CharStr::from_octets_unchecked(self.0.convert()?)) }
     }
 }
 

--- a/src/base/iana/rtype.rs
+++ b/src/base/iana/rtype.rs
@@ -300,6 +300,16 @@ int_enum!{
     /// See draft-wessels-dns-zone-digest.
     (Zonemd => 63, b"ZONEMD")
 
+    /// General Purpose Service Endpoints.
+    ///
+    /// See draft-ietf-dnsop-svcb-https.
+    (Svcb => 64, b"SVCB")
+
+    /// HTTPS Specific Service Endpoints.
+    ///
+    /// See draft-ietf-dnsop-svcb-https.
+    (Https => 65, b"HTTPS")
+
     /// SPF.
     ///
     /// RFC 7208.

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -12,7 +12,7 @@ use core::str::FromStr;
 use super::parsed::ParsedDname;
 use super::super::cmp::CanonicalOrd;
 use super::super::octets::{
-    Compose, Convert, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsExt,
+    Compose, ConvertOctets, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsExt,
     OctetsRef, Parse, Parser, ParseError, ShortBuf
 };
 use super::builder::{DnameBuilder, FromStrError, PushError};
@@ -572,10 +572,10 @@ impl<Octets: AsRef<[u8]>> Dname<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<Octets, Other> Convert<Dname<Other>> for Dname<Octets>
-where Octets: AsRef<[u8]> + Convert<Other> {
+impl<Octets, Other> ConvertOctets<Dname<Other>> for Dname<Octets>
+where Octets: AsRef<[u8]> + ConvertOctets<Other> {
     fn convert(&self) -> Result<Dname<Other>, ShortBuf> {
         unsafe { Ok(Dname::from_octets_unchecked(self.0.convert()?)) }
     }

--- a/src/base/name/parsed.rs
+++ b/src/base/name/parsed.rs
@@ -6,7 +6,7 @@
 use core::{cmp, fmt, hash};
 use super::super::cmp::CanonicalOrd;
 use super::super::octets::{
-    Compose, Convert, EmptyBuilder, FromBuilder, FormError, OctetsBuilder,
+    Compose, ConvertOctets, EmptyBuilder, FromBuilder, FormError, OctetsBuilder,
     OctetsRef, Parse, Parser, ParseError, ShortBuf
 };
 use super::dname::Dname;
@@ -292,9 +292,9 @@ impl<'a, Ref: AsRef<[u8]>> IntoIterator for &'a ParsedDname<Ref> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<Octets, Other> Convert<Dname<Other>> for ParsedDname<Octets>
+impl<Octets, Other> ConvertOctets<Dname<Other>> for ParsedDname<Octets>
 where Octets: AsRef<[u8]>, Other: FromBuilder, <Other as FromBuilder>::Builder: EmptyBuilder {
     fn convert(&self) -> Result<Dname<Other>, ShortBuf> {
         self.to_dname().map_err(|_| ShortBuf)

--- a/src/base/name/parsed.rs
+++ b/src/base/name/parsed.rs
@@ -6,8 +6,8 @@
 use core::{cmp, fmt, hash};
 use super::super::cmp::CanonicalOrd;
 use super::super::octets::{
-    Compose, FormError, OctetsBuilder, OctetsRef, Parse, Parser, ParseError,
-    ShortBuf
+    Compose, Convert, EmptyBuilder, FromBuilder, FormError, OctetsBuilder,
+    OctetsRef, Parse, Parser, ParseError, ShortBuf
 };
 use super::dname::Dname;
 use super::label::{Label, LabelTypeError};
@@ -288,6 +288,16 @@ impl<'a, Ref: AsRef<[u8]>> IntoIterator for &'a ParsedDname<Ref> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+
+//--- Convert
+
+impl<Octets, Other> Convert<Dname<Other>> for ParsedDname<Octets>
+where Octets: AsRef<[u8]>, Other: FromBuilder, <Other as FromBuilder>::Builder: EmptyBuilder {
+    fn convert(&self) -> Result<Dname<Other>, ShortBuf> {
+        self.to_dname().map_err(|_| ShortBuf)
     }
 }
 
@@ -1094,6 +1104,22 @@ mod test {
         step(name!(flat), WECR);
         step(name!(once), WECR);
         step(name!(twice), WECR);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn convert() {
+        use std::vec::Vec;
+
+        fn step(name: ParsedDname<&[u8]>) {
+            let c1: Dname<Vec<u8>> = name.convert().unwrap();
+            assert_eq!(name, c1);
+        }
+
+        step(name!(root));
+        step(name!(flat));
+        step(name!(once));
+        step(name!(twice));
     }
 
     // XXX TODO compose_canonical

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -47,7 +47,7 @@ use super::iana::{OptionCode, OptRcode, Rtype};
 use super::header::Header;
 use super::name::ToDname;
 use super::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 use super::rdata::RtypeRecordData;
 use super::record::Record;
@@ -137,6 +137,16 @@ impl<Octets: AsRef<[u8]>> Ord for Opt<Octets> {
 impl<Octets: AsRef<[u8]>> hash::Hash for Opt<Octets> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.octets.as_ref().hash(state)
+    }
+}
+
+
+//--- Convert
+
+impl<O, Other> Convert<Opt<Other>> for Opt<O>
+where O: Convert<Other> {
+    fn convert(&self) -> Result<Opt<Other>, ShortBuf> {
+        Ok(Opt { octets: self.octets.convert()? })
     }
 }
 
@@ -423,6 +433,22 @@ impl<Octets> ops::Deref for OptRecord<Octets> {
 impl<Octets> AsRef<Opt<Octets>> for OptRecord<Octets> {
     fn as_ref(&self) -> &Opt<Octets> {
         &self.data
+    }
+}
+
+
+//--- Convert
+
+impl<O, Other> Convert<OptRecord<Other>> for OptRecord<O>
+where O: Convert<Other> {
+    fn convert(&self) -> Result<OptRecord<Other>, ShortBuf> {
+        Ok(OptRecord {
+            udp_payload_size: self.udp_payload_size,
+            ext_rcode: self.ext_rcode,
+            version: self.version,
+            flags: self.flags,
+            data: self.data.convert()?
+        })
     }
 }
 

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -47,7 +47,7 @@ use super::iana::{OptionCode, OptRcode, Rtype};
 use super::header::Header;
 use super::name::ToDname;
 use super::octets::{
-    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, ConvertOctets, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 use super::rdata::RtypeRecordData;
 use super::record::Record;
@@ -141,10 +141,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Opt<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Opt<Other>> for Opt<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<Opt<Other>> for Opt<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<Opt<Other>, ShortBuf> {
         Ok(Opt { octets: self.octets.convert()? })
     }
@@ -437,10 +437,10 @@ impl<Octets> AsRef<Opt<Octets>> for OptRecord<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<OptRecord<Other>> for OptRecord<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<OptRecord<Other>> for OptRecord<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<OptRecord<Other>, ShortBuf> {
         Ok(OptRecord {
             udp_payload_size: self.udp_payload_size,

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -31,7 +31,7 @@ use core::cmp::Ordering;
 use super::cmp::CanonicalOrd;
 use super::iana::Rtype;
 use super::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 
 
@@ -261,7 +261,17 @@ impl<Octets: AsRef<[u8]>> Ord for UnknownRecordData<Octets> {
 }
 
 
-//--- Compose, and Compress
+//--- Convert
+
+impl<O, Other> Convert<UnknownRecordData<Other>> for UnknownRecordData<O>
+where O: Convert<Other> {
+    fn convert(&self) -> Result<UnknownRecordData<Other>, ShortBuf> {
+        Ok(UnknownRecordData::from_octets(self.rtype, self.data.convert()?))
+    }
+}
+
+
+//--- Compose
 
 impl<Octets: AsRef<[u8]>> Compose for UnknownRecordData<Octets> {
     fn compose<T: OctetsBuilder>(

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -31,7 +31,7 @@ use core::cmp::Ordering;
 use super::cmp::CanonicalOrd;
 use super::iana::Rtype;
 use super::octets::{
-    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, ConvertOctets, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 
 
@@ -261,10 +261,10 @@ impl<Octets: AsRef<[u8]>> Ord for UnknownRecordData<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<UnknownRecordData<Other>> for UnknownRecordData<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<UnknownRecordData<Other>> for UnknownRecordData<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<UnknownRecordData<Other>, ShortBuf> {
         Ok(UnknownRecordData::from_octets(self.rtype, self.data.convert()?))
     }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -21,7 +21,7 @@ use super::cmp::CanonicalOrd;
 use super::iana::{Class, Rtype};
 use super::name::{ParsedDname, ToDname};
 use super::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, Parser, ParseError, ShortBuf
+    Compose, Convert, OctetsBuilder, OctetsRef, Parse, Parser, ParseError, ShortBuf
 };
 use super::rdata::{RecordData, ParseRecordData};
 
@@ -263,6 +263,21 @@ where Name: hash::Hash, Data: hash::Hash {
     }
 }
         
+
+//--- Convert
+
+impl<N, D, NN, DD> Convert<Record<NN, DD>> for Record<N, D>
+where N: Convert<NN>, D: Convert<DD> {
+    fn convert(&self) -> Result<Record<NN, DD>, ShortBuf> {
+        Ok(Record::new(
+            self.owner.convert()?,
+            self.class,
+            self.ttl,
+            self.data.convert()?
+        ))
+    }
+}
+
 
 //--- Parse and Compose
 

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -21,7 +21,7 @@ use super::cmp::CanonicalOrd;
 use super::iana::{Class, Rtype};
 use super::name::{ParsedDname, ToDname};
 use super::octets::{
-    Compose, Convert, OctetsBuilder, OctetsRef, Parse, Parser, ParseError, ShortBuf
+    Compose, ConvertOctets, OctetsBuilder, OctetsRef, Parse, Parser, ParseError, ShortBuf
 };
 use super::rdata::{RecordData, ParseRecordData};
 
@@ -264,10 +264,10 @@ where Name: hash::Hash, Data: hash::Hash {
 }
         
 
-//--- Convert
+//--- ConvertOctets
 
-impl<N, D, NN, DD> Convert<Record<NN, DD>> for Record<N, D>
-where N: Convert<NN>, D: Convert<DD> {
+impl<N, D, NN, DD> ConvertOctets<Record<NN, DD>> for Record<N, D>
+where N: ConvertOctets<NN>, D: ConvertOctets<DD> {
     fn convert(&self) -> Result<Record<NN, DD>, ShortBuf> {
         Ok(Record::new(
             self.owner.convert()?,

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -199,6 +199,25 @@ macro_rules! rdata_types {
         }
 
 
+        //--- Convert
+
+        impl<O, OO, N, NN> $crate::base::octets::Convert<MasterRecordData<OO, NN>> for MasterRecordData<O, N>
+        where O: AsRef<[u8]> + $crate::base::octets::Convert<OO>, N: $crate::base::octets::Convert<NN> {
+            fn convert(&self) -> Result<MasterRecordData<OO, NN>, $crate::base::octets::ShortBuf> {
+                match *self {
+                    $( $( $(
+                        MasterRecordData::$mtype(ref inner) => {
+                            Ok(MasterRecordData::$mtype(inner.convert()?))
+                        }
+                    )* )* )*
+                    MasterRecordData::Other(ref inner) => {
+                        Ok(MasterRecordData::Other(inner.convert()?))
+                    }
+                }
+            }
+        }
+
+
         //--- Compose
         //
         //    No Parse or ParseAll because Other variant needs to know the
@@ -512,6 +531,33 @@ macro_rules! rdata_types {
         }
 
 
+        //--- Convert
+
+        impl<O, OO, N, NN> $crate::base::octets::Convert<AllRecordData<OO, NN>> for AllRecordData<O, N>
+        where O: AsRef<[u8]> + $crate::base::octets::Convert<OO>, N: $crate::base::octets::Convert<NN> {
+            fn convert(&self) -> Result<AllRecordData<OO, NN>, $crate::base::octets::ShortBuf> {
+                match *self {
+                    $( $( $(
+                        AllRecordData::$mtype(ref inner) => {
+                            Ok(AllRecordData::$mtype(inner.convert()?))
+                        }
+                    )* )* )*
+                    $( $( $(
+                        AllRecordData::$ptype(ref inner) => {
+                            Ok(AllRecordData::$ptype(inner.convert()?))
+                        }
+                    )* )* )*
+                    AllRecordData::Opt(ref inner) => {
+                        Ok(AllRecordData::Opt(inner.convert()?))
+                    }
+                    AllRecordData::Other(ref inner) => {
+                        Ok(AllRecordData::Other(inner.convert()?))
+                    }
+                }
+            }
+        }
+
+
         //--- Compose
         //
         //    No Parse or ParseAll because Other variant needs to know the
@@ -725,6 +771,16 @@ macro_rules! dname_type {
 
             pub fn $field(&self) -> &N {
                 &self.$field
+            }
+        }
+
+
+        //--- Convert
+
+        impl<N, Other> $crate::base::octets::Convert<$target<Other>> for $target<N>
+        where N: $crate::base::octets::Convert<Other> {
+            fn convert(&self) -> Result<$target<Other>, ShortBuf> {
+                Ok($target::new(self.$field.convert()?))
             }
         }
 

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -199,10 +199,10 @@ macro_rules! rdata_types {
         }
 
 
-        //--- Convert
+        //--- ConvertOctets
 
-        impl<O, OO, N, NN> $crate::base::octets::Convert<MasterRecordData<OO, NN>> for MasterRecordData<O, N>
-        where O: AsRef<[u8]> + $crate::base::octets::Convert<OO>, N: $crate::base::octets::Convert<NN> {
+        impl<O, OO, N, NN> $crate::base::octets::ConvertOctets<MasterRecordData<OO, NN>> for MasterRecordData<O, N>
+        where O: AsRef<[u8]> + $crate::base::octets::ConvertOctets<OO>, N: $crate::base::octets::ConvertOctets<NN> {
             fn convert(&self) -> Result<MasterRecordData<OO, NN>, $crate::base::octets::ShortBuf> {
                 match *self {
                     $( $( $(
@@ -531,10 +531,10 @@ macro_rules! rdata_types {
         }
 
 
-        //--- Convert
+        //--- ConvertOctets
 
-        impl<O, OO, N, NN> $crate::base::octets::Convert<AllRecordData<OO, NN>> for AllRecordData<O, N>
-        where O: AsRef<[u8]> + $crate::base::octets::Convert<OO>, N: $crate::base::octets::Convert<NN> {
+        impl<O, OO, N, NN> $crate::base::octets::ConvertOctets<AllRecordData<OO, NN>> for AllRecordData<O, N>
+        where O: AsRef<[u8]> + $crate::base::octets::ConvertOctets<OO>, N: $crate::base::octets::ConvertOctets<NN> {
             fn convert(&self) -> Result<AllRecordData<OO, NN>, $crate::base::octets::ShortBuf> {
                 match *self {
                     $( $( $(
@@ -775,10 +775,10 @@ macro_rules! dname_type {
         }
 
 
-        //--- Convert
+        //--- ConvertOctets
 
-        impl<N, Other> $crate::base::octets::Convert<$target<Other>> for $target<N>
-        where N: $crate::base::octets::Convert<Other> {
+        impl<N, Other> $crate::base::octets::ConvertOctets<$target<Other>> for $target<N>
+        where N: $crate::base::octets::ConvertOctets<Other> {
             fn convert(&self) -> Result<$target<Other>, ShortBuf> {
                 Ok($target::new(self.$field.convert()?))
             }

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -16,7 +16,7 @@ use crate::base::str::Symbol;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::net::Ipv4Addr;
 use crate::base::octets::{
-    Compose, Convert, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsRef, Parse,
+    Compose, ConvertOctets, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsRef, Parse,
     ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
@@ -88,9 +88,9 @@ impl CanonicalOrd for A {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl Convert<A> for A {
+impl ConvertOctets<A> for A {
     fn convert(&self) -> Result<A, ShortBuf> {
         Ok(self.clone())
     }
@@ -277,10 +277,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Hinfo<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<Octets, Other> Convert<Hinfo<Other>> for Hinfo<Octets>
-where Octets: AsRef<[u8]> + Convert<Other> {
+impl<Octets, Other> ConvertOctets<Hinfo<Other>> for Hinfo<Octets>
+where Octets: AsRef<[u8]> + ConvertOctets<Other> {
     fn convert(&self) -> Result<Hinfo<Other>, ShortBuf> {
         Ok(Hinfo::new(self.cpu.convert()?, self.os.convert()?))
     }
@@ -453,10 +453,10 @@ impl<N> Minfo<N> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<N, Other> Convert<Minfo<Other>> for Minfo<N>
-where N: Convert<Other> {
+impl<N, Other> ConvertOctets<Minfo<Other>> for Minfo<N>
+where N: ConvertOctets<Other> {
     fn convert(&self) -> Result<Minfo<Other>, ShortBuf> {
         Ok(Minfo::new(self.rmailbx.convert()?, self.emailbx.convert()?))
     }
@@ -624,10 +624,10 @@ impl<N> Mx<N> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<N, Other> Convert<Mx<Other>> for Mx<N>
-where N: Convert<Other> {
+impl<N, Other> ConvertOctets<Mx<Other>> for Mx<N>
+where N: ConvertOctets<Other> {
     fn convert(&self) -> Result<Mx<Other>, ShortBuf> {
         Ok(Mx::new(self.preference, self.exchange.convert()?))
     }
@@ -842,10 +842,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Null<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Null<Other>> for Null<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<Null<Other>> for Null<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<Null<Other>, ShortBuf> {
         Ok(Null::new(self.data.convert()?))
     }
@@ -1116,10 +1116,10 @@ impl<N: ToDname, NN: ToDname> CanonicalOrd<Soa<NN>> for Soa<N> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<N, Other> Convert<Soa<Other>> for Soa<N>
-where N: Convert<Other> {
+impl<N, Other> ConvertOctets<Soa<Other>> for Soa<N>
+where N: ConvertOctets<Other> {
     fn convert(&self) -> Result<Soa<Other>, ShortBuf> {
         Ok(Soa::new(
             self.mname.convert()?,
@@ -1354,10 +1354,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Txt<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Txt<Other>> for Txt<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<Txt<Other>> for Txt<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<Txt<Other>, ShortBuf> {
         Ok(Txt(self.0.convert()?))
     }

--- a/src/rdata/rfc2782.rs
+++ b/src/rdata/rfc2782.rs
@@ -10,7 +10,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, Parser, ParseError,
+    Compose, Convert, OctetsBuilder, OctetsRef, Parse, Parser, ParseError,
     ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
@@ -131,7 +131,17 @@ impl<N: ToDname, NN: ToDname> CanonicalOrd<Srv<NN>> for Srv<N> {
 }
 
 
-//--- Parse, ParseAll, Compose and Compress
+//--- Convert
+
+impl<N, Other> Convert<Srv<Other>> for Srv<N>
+where N: Convert<Other> {
+    fn convert(&self) -> Result<Srv<Other>, ShortBuf> {
+        Ok(Srv::new(self.priority, self.weight, self.port, self.target.convert()?))
+    }
+}
+
+
+//--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Srv<ParsedDname<Ref>> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {

--- a/src/rdata/rfc2782.rs
+++ b/src/rdata/rfc2782.rs
@@ -10,7 +10,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, Convert, OctetsBuilder, OctetsRef, Parse, Parser, ParseError,
+    Compose, ConvertOctets, OctetsBuilder, OctetsRef, Parse, Parser, ParseError,
     ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
@@ -131,10 +131,10 @@ impl<N: ToDname, NN: ToDname> CanonicalOrd<Srv<NN>> for Srv<N> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<N, Other> Convert<Srv<Other>> for Srv<N>
-where N: Convert<Other> {
+impl<N, Other> ConvertOctets<Srv<Other>> for Srv<N>
+where N: ConvertOctets<Other> {
     fn convert(&self) -> Result<Srv<Other>, ShortBuf> {
         Ok(Srv::new(self.priority, self.weight, self.port, self.target.convert()?))
     }

--- a/src/rdata/rfc2845.rs
+++ b/src/rdata/rfc2845.rs
@@ -11,7 +11,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Rtype, TsigRcode};
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser,
+    Compose, ConvertOctets, OctetsBuilder, OctetsRef, Parse, ParseError, Parser,
     ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
@@ -301,10 +301,10 @@ impl<O: AsRef<[u8]>, N: hash::Hash> hash::Hash for Tsig<O, N> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, OO, N, NN> Convert<Tsig<OO, NN>> for Tsig<O, N>
-where O: Convert<OO>, N: Convert<NN> {
+impl<O, OO, N, NN> ConvertOctets<Tsig<OO, NN>> for Tsig<O, N>
+where O: ConvertOctets<OO>, N: ConvertOctets<NN> {
     fn convert(&self) -> Result<Tsig<OO, NN>, ShortBuf> {
         Ok(Tsig::new(
             self.algorithm.convert()?,

--- a/src/rdata/rfc3596.rs
+++ b/src/rdata/rfc3596.rs
@@ -10,7 +10,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::net::Ipv6Addr;
 use crate::base::octets::{
-    Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf
+    Compose, Convert, OctetsBuilder, Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -68,7 +68,16 @@ impl CanonicalOrd for Aaaa {
 }
 
 
-//--- Parse, ParseAll, and Compose
+//--- Convert
+
+impl Convert<Aaaa> for Aaaa {
+    fn convert(&self) -> Result<Aaaa, ShortBuf> {
+        Ok(self.clone())
+    }
+}
+
+
+//--- Parse and Compose
 
 impl<Ref: AsRef<[u8]>> Parse<Ref> for Aaaa {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {

--- a/src/rdata/rfc3596.rs
+++ b/src/rdata/rfc3596.rs
@@ -10,7 +10,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::net::Ipv6Addr;
 use crate::base::octets::{
-    Compose, Convert, OctetsBuilder, Parse, ParseError, Parser, ShortBuf
+    Compose, ConvertOctets, OctetsBuilder, Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -68,9 +68,9 @@ impl CanonicalOrd for Aaaa {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl Convert<Aaaa> for Aaaa {
+impl ConvertOctets<Aaaa> for Aaaa {
     fn convert(&self) -> Result<Aaaa, ShortBuf> {
         Ok(self.clone())
     }

--- a/src/rdata/rfc4034.rs
+++ b/src/rdata/rfc4034.rs
@@ -13,7 +13,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, Convert, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsRef,
+    Compose, ConvertOctets, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsRef,
     Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::{RtypeRecordData};
@@ -220,10 +220,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Dnskey<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Dnskey<Other>> for Dnskey<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<Dnskey<Other>> for Dnskey<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<Dnskey<Other>, ShortBuf> {
         Ok(Dnskey::new(
             self.flags,
@@ -372,10 +372,10 @@ impl<Name> ProtoRrsig<Name> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<N, Other> Convert<ProtoRrsig<Other>> for ProtoRrsig<N>
-where N: Convert<Other> {
+impl<N, Other> ConvertOctets<ProtoRrsig<Other>> for ProtoRrsig<N>
+where N: ConvertOctets<Other> {
     fn convert(&self) -> Result<ProtoRrsig<Other>, ShortBuf> {
         Ok(ProtoRrsig::new(
             self.type_covered,
@@ -637,10 +637,10 @@ impl<O: AsRef<[u8]>, N: hash::Hash> hash::Hash for Rrsig<O, N> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, OO, N, NN> Convert<Rrsig<OO, NN>> for Rrsig<O, N>
-where O: Convert<OO>, N: Convert<NN> {
+impl<O, OO, N, NN> ConvertOctets<Rrsig<OO, NN>> for Rrsig<O, N>
+where O: ConvertOctets<OO>, N: ConvertOctets<NN> {
     fn convert(&self) -> Result<Rrsig<OO, NN>, ShortBuf> {
         Ok(Rrsig::new(
             self.type_covered,
@@ -883,10 +883,10 @@ impl<Octets: AsRef<[u8]>, Name: hash::Hash> hash::Hash for Nsec<Octets, Name> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, OO, N, NN> Convert<Nsec<OO, NN>> for Nsec<O, N>
-where O: Convert<OO>, N: Convert<NN> {
+impl<O, OO, N, NN> ConvertOctets<Nsec<OO, NN>> for Nsec<O, N>
+where O: ConvertOctets<OO>, N: ConvertOctets<NN> {
     fn convert(&self) -> Result<Nsec<OO, NN>, ShortBuf> {
         Ok(Nsec::new(self.next_name.convert()?, self.types.convert()?))
     }
@@ -1083,10 +1083,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Ds<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Ds<Other>> for Ds<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<Ds<Other>> for Ds<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<Ds<Other>, ShortBuf> {
         Ok(Ds::new(self.key_tag, self.algorithm, self.digest_type, self.digest.convert()?))
     }
@@ -1320,10 +1320,10 @@ impl<'a, Octets: AsRef<[u8]>> IntoIterator for &'a RtypeBitmap<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<RtypeBitmap<Other>> for RtypeBitmap<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<RtypeBitmap<Other>> for RtypeBitmap<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<RtypeBitmap<Other>, ShortBuf> {
         Ok(RtypeBitmap(self.0.convert()?))
     }

--- a/src/rdata/rfc5155.rs
+++ b/src/rdata/rfc5155.rs
@@ -11,7 +11,7 @@ use crate::base::charstr::CharStr;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Nsec3HashAlg, Rtype};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -169,7 +169,24 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Nsec3<Octets> {
 }
 
 
-//--- ParseAll and Compose
+//--- Convert
+
+impl<O, Other> Convert<Nsec3<Other>> for Nsec3<O>
+where O: AsRef<[u8]> + Convert<Other> {
+    fn convert(&self) -> Result<Nsec3<Other>, ShortBuf> {
+        Ok(Nsec3::new(
+            self.hash_algorithm,
+            self.flags,
+            self.iterations,
+            self.salt.convert()?,
+            self.next_owner.convert()?,
+            self.types.convert()?,
+        ))
+    }
+}
+
+
+//--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Nsec3<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
@@ -407,7 +424,22 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Nsec3param<Octets> {
 }
 
 
-//--- Parse, ParseAll, and Compose
+//--- Convert
+
+impl<O, Other> Convert<Nsec3param<Other>> for Nsec3param<O>
+where O: AsRef<[u8]> + Convert<Other> {
+    fn convert(&self) -> Result<Nsec3param<Other>, ShortBuf> {
+        Ok(Nsec3param::new(
+            self.hash_algorithm,
+            self.flags,
+            self.iterations,
+            self.salt.convert()?,
+        ))
+    }
+}
+
+
+//--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Nsec3param<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {

--- a/src/rdata/rfc5155.rs
+++ b/src/rdata/rfc5155.rs
@@ -11,7 +11,7 @@ use crate::base::charstr::CharStr;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Nsec3HashAlg, Rtype};
 use crate::base::octets::{
-    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, ConvertOctets, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -169,10 +169,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Nsec3<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Nsec3<Other>> for Nsec3<O>
-where O: AsRef<[u8]> + Convert<Other> {
+impl<O, Other> ConvertOctets<Nsec3<Other>> for Nsec3<O>
+where O: AsRef<[u8]> + ConvertOctets<Other> {
     fn convert(&self) -> Result<Nsec3<Other>, ShortBuf> {
         Ok(Nsec3::new(
             self.hash_algorithm,
@@ -424,10 +424,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Nsec3param<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Nsec3param<Other>> for Nsec3param<O>
-where O: AsRef<[u8]> + Convert<Other> {
+impl<O, Other> ConvertOctets<Nsec3param<Other>> for Nsec3param<O>
+where O: AsRef<[u8]> + ConvertOctets<Other> {
     fn convert(&self) -> Result<Nsec3param<Other>, ShortBuf> {
         Ok(Nsec3param::new(
             self.hash_algorithm,

--- a/src/rdata/rfc7344.rs
+++ b/src/rdata/rfc7344.rs
@@ -7,7 +7,7 @@ use core::cmp::Ordering;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -121,7 +121,22 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Cdnskey<Octets> {
 }
 
 
-//--- ParseAll and Compose
+//--- Convert
+
+impl<O, Other> Convert<Cdnskey<Other>> for Cdnskey<O>
+where O: Convert<Other> {
+    fn convert(&self) -> Result<Cdnskey<Other>, ShortBuf> {
+        Ok(Cdnskey::new(
+            self.flags,
+            self.protocol,
+            self.algorithm,
+            self.public_key.convert()?,
+        ))
+    }
+}
+
+
+//--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Cdnskey<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
@@ -318,6 +333,21 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Cds<Octets> {
         self.algorithm.hash(state);
         self.digest_type.hash(state);
         self.digest.as_ref().hash(state);
+    }
+}
+
+
+//--- Convert
+
+impl<O, Other> Convert<Cds<Other>> for Cds<O>
+where O: Convert<Other> {
+    fn convert(&self) -> Result<Cds<Other>, ShortBuf> {
+        Ok(Cds::new(
+            self.key_tag,
+            self.algorithm,
+            self.digest_type,
+            self.digest.convert()?,
+        ))
     }
 }
 

--- a/src/rdata/rfc7344.rs
+++ b/src/rdata/rfc7344.rs
@@ -7,7 +7,7 @@ use core::cmp::Ordering;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::octets::{
-    Compose, Convert, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, ConvertOctets, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -121,10 +121,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Cdnskey<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Cdnskey<Other>> for Cdnskey<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<Cdnskey<Other>> for Cdnskey<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<Cdnskey<Other>, ShortBuf> {
         Ok(Cdnskey::new(
             self.flags,
@@ -337,10 +337,10 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Cds<Octets> {
 }
 
 
-//--- Convert
+//--- ConvertOctets
 
-impl<O, Other> Convert<Cds<Other>> for Cds<O>
-where O: Convert<Other> {
+impl<O, Other> ConvertOctets<Cds<Other>> for Cds<O>
+where O: ConvertOctets<Other> {
     fn convert(&self) -> Result<Cds<Other>, ShortBuf> {
         Ok(Cds::new(
             self.key_tag,

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -372,7 +372,7 @@ impl<N> FamilyName<N> {
     ) -> Result<Record<N, Dnskey<Octets>>, K::Error>
     where N: Clone {
         key.dnskey().map(|dnskey| {
-            self.clone().into_record(ttl, dnskey.convert())
+            self.clone().into_record(ttl, dnskey.into_dnskey())
         })
     }
 


### PR DESCRIPTION
This trait forms a basis for converting structured types built on top
of octets such as CharStr, Dname, RDATA, and Record types.

#68