### PR TITLE
Prepare for release 0.5.3/0.5.1.

### DIFF
--- a/domain-resolv/Cargo.toml
+++ b/domain-resolv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain-resolv"
-version = "0.5.0-bis"
+version = "0.5.1"
 edition = "2018"
 authors = ["Martin Hoffmann <hn@nvnc.de>"]
 description = "An asynchronous DNS stub resolver."
@@ -28,7 +28,7 @@ tokio-tls = "^0.3.0"
 
 [dependencies.domain]
 path = "../domain"
-version = "0.5.2-bis"
+version = "0.5.3"
 features = ["bytes", "smallvec", "std"]
 
 [features]

--- a/domain-resolv/Changelog.md
+++ b/domain-resolv/Changelog.md
@@ -1,7 +1,6 @@
 # Change Log
 
-
-## Unreleased Next Version
+## 0.5.1
 
 New
 
@@ -10,7 +9,7 @@ New
 
 Bug Fixes
 
-* The receiver buffer size was smaller than the size advertised in a request,
+* The receive buffer size was smaller than the size advertised in a request,
   resulting to very long UDP responses being cut off. ([#71])
 
 [#71]: https://github.com/NLnetLabs/domain/pull/71

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain"
-version = "0.5.2-bis"
+version = "0.5.3"
 edition = "2018"
 authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]
 description = "A DNS library for Rust."

--- a/domain/Changelog.md
+++ b/domain/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased next version
+## 0.5.3
 
 Breaking Changes
 

--- a/domain/Changelog.md
+++ b/domain/Changelog.md
@@ -2,8 +2,6 @@
 
 ## 0.5.3
 
-Breaking Changes
-
 New
 
 * `validate`: enable 1024 bit RSASHA512 as supported algorithm.


### PR DESCRIPTION
Release 0.5.3 of `domain` and 0.5.1 of `domain-resolv`.