### PR TITLE
Merge IntoOctets into OctetsBuilder.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## Unreleased 0.6.0
+
+Breaking
+
+* The crate `domain-resolv` has been merged into this crate as the
+  `domain::resolv` crate. It requires the `resolv` feature to be enabled.
+  The `sync` feature from `domain-resolv` has been renamed to
+  `resolv-sync`. ([#74])
+* The trait `domain::base::octets::IntoOctets` has been merged into
+  `domain::base::octets::OctetsBuilder`. It’s method `into_octets` is now
+  available as `freeze` on `OctetsBuilder. ([#75])
+
+Bug Fixes
+
+New
+
+Other Changes
+
+[#74]: https://github.com/NLnetLabs/domain/pull/74
+[#75]: https://github.com/NLnetLabs/domain/pull/75
+
+
 ## 0.5.3
 
 New
@@ -10,8 +32,6 @@ New
 Bug Fixes
 
 * Various minor fixes for building in no-std mode. ([#72])
-
-Other Changes
 
 [#67]: https://github.com/NLnetLabs/domain/pull/67
 [#72]: https://github.com/NLnetLabs/domain/pull/72

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -7,8 +7,8 @@ use core::cmp::Ordering;
 #[cfg(feature = "std")] use std::vec::Vec;
 #[cfg(feature = "bytes")] use bytes::Bytes;
 use super::super::octets::{
-    Compose, IntoBuilder, IntoOctets, OctetsBuilder, OctetsExt, OctetsRef,
-    ParseError, ShortBuf
+    Compose, IntoBuilder, OctetsBuilder, OctetsExt, OctetsRef, ParseError,
+    ShortBuf
 };
 use super::builder::{DnameBuilder, PushError};
 use super::chain::{Chain, LongChainError};
@@ -222,12 +222,11 @@ impl<Octets> RelativeDname<Octets> {
     pub fn into_absolute(
         self
     ) -> Result<
-        Dname<<<Octets as IntoBuilder>::Builder as IntoOctets>::Octets>,
+        Dname<<<Octets as IntoBuilder>::Builder as OctetsBuilder>::Octets>,
         PushError
     >
     where
         Octets: IntoBuilder,
-        <Octets as IntoBuilder>::Builder: IntoOctets,
     {
         self.into_builder().into_dname()
     }

--- a/src/base/name/traits.rs
+++ b/src/base/name/traits.rs
@@ -5,7 +5,7 @@
 use core::cmp;
 #[cfg(feature = "std")] use std::borrow::Cow;
 #[cfg(feature = "bytes")] use bytes::Bytes;
-use super::super::octets::{Compose, EmptyBuilder, FromBuilder, IntoOctets};
+use super::super::octets::{Compose, EmptyBuilder, FromBuilder, OctetsBuilder};
 use super::builder::PushError;
 use super::chain::{Chain, LongChainError};
 use super::dname::Dname;
@@ -113,13 +113,13 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     fn to_dname<Octets>(&self) -> Result<Dname<Octets>, PushError>
     where
         Octets: FromBuilder,
-        <Octets as FromBuilder>::Builder: EmptyBuilder
+        <Octets as FromBuilder>::Builder: OctetsBuilder + EmptyBuilder
     {
         let mut builder = Octets::Builder::with_capacity(self.len());
         for label in self.iter_labels() {
             label.build(&mut builder)?;
         }
-        Ok(unsafe { Dname::from_octets_unchecked(builder.into_octets()) })
+        Ok(unsafe { Dname::from_octets_unchecked(builder.freeze()) })
     }
 
     /// Returns an octets slice of the content if possible.
@@ -321,7 +321,7 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
             label.build(&mut builder)?;
         }
         Ok(unsafe {
-            RelativeDname::from_octets_unchecked(builder.into_octets()) 
+            RelativeDname::from_octets_unchecked(builder.freeze()) 
         })
     }
 

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -10,8 +10,7 @@ use core::{fmt, hash, str};
     CharSource, Scan, Scanner, ScanError
 };
 use super::super::octets::{
-    Compose, EmptyBuilder, FromBuilder, IntoBuilder, IntoOctets,
-    OctetsBuilder, ShortBuf
+    Compose, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, ShortBuf
 };
 #[cfg(feature = "master")] use super::super::str::Symbol;
 use super::builder::{DnameBuilder, FromStrError, PushError};
@@ -168,12 +167,12 @@ impl<Octets> UncertainDname<Octets> {
     pub fn into_absolute(
         self
     ) -> Result<
-        Dname<<<Octets as IntoBuilder>::Builder as IntoOctets>::Octets>,
+        Dname<<<Octets as IntoBuilder>::Builder as OctetsBuilder>::Octets>,
         PushError
     >
     where
         Octets: AsRef<[u8]> + IntoBuilder,
-        <Octets as IntoBuilder>::Builder: IntoOctets<Octets = Octets>,
+        <Octets as IntoBuilder>::Builder: OctetsBuilder<Octets = Octets>,
     {
         match self {
             UncertainDname::Absolute(name) => Ok(name),

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -16,8 +16,8 @@ use crate::base::str::Symbol;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::net::Ipv4Addr;
 use crate::base::octets::{
-    Compose, EmptyBuilder, FromBuilder, IntoOctets, OctetsBuilder,
-    OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsRef, Parse,
+    ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 use crate::base::serial::Serial;
@@ -1218,7 +1218,7 @@ impl<Octets: AsRef<[u8]>> Txt<Octets> {
         for item in self.iter() {
             res.append_slice(item)?;
         }
-        Ok(res.into_octets())
+        Ok(res.freeze())
     }
 }
 
@@ -1442,15 +1442,12 @@ impl<Builder: OctetsBuilder> TxtBuilder<Builder> {
         Ok(())
     }
 
-    pub fn finish(mut self) -> Txt<Builder::Octets>
-    where
-        Builder: IntoOctets,
-    {
+    pub fn finish(mut self) -> Txt<Builder::Octets> {
         if let Some(start) = self.start {
             let last_slice_len = self.builder.len() - (start + 1);
             self.builder.as_mut()[start] = last_slice_len as u8;
         }
-        Txt(self.builder.into_octets())
+        Txt(self.builder.freeze())
     }
 }
 

--- a/src/rdata/rfc4034.rs
+++ b/src/rdata/rfc4034.rs
@@ -13,8 +13,8 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, EmptyBuilder, FormError, FromBuilder, IntoOctets, OctetsBuilder,
-    OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsRef,
+    Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::{RtypeRecordData};
 use crate::base::serial::Serial;
@@ -1388,8 +1388,7 @@ impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
         Ok(&mut self.buf.as_mut()[pos..pos + 34])
     }
 
-    pub fn finalize(mut self) -> RtypeBitmap<Builder::Octets>
-    where Builder: IntoOctets {
+    pub fn finalize(mut self) -> RtypeBitmap<Builder::Octets> {
         let mut src_pos = 0;
         let mut dst_pos = 0;
         while src_pos < self.buf.as_ref().len() {
@@ -1408,7 +1407,7 @@ impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
             src_pos += 34;
         }
         self.buf.truncate(dst_pos);
-        RtypeBitmap(self.buf.into_octets())
+        RtypeBitmap(self.buf.freeze())
     }
 }
 


### PR DESCRIPTION
This merges the `domain::base::octets::IntoOctets` into `domain::base::octets::OctetsBuilder` and free up the name for use in octets conversion. The method `IntoOctets::into_octets` has been renamed to `OctetsBuilder::freeze` to also free up the method name.