### PR TITLE
Introduce OctetsFrom and OctetsInto.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,11 @@ Breaking
   `domain::base::octets::OctetsBuilder`. It’s method `into_octets` is now
   available as `freeze` on `OctetsBuilder. ([#75])
 
+* Supprt for extended errors defined in [RFC 8914]. ([#79] by [@xofyarg])
+* New traits `domain::base::octets::OctetsFrom` and `OctetsInto` to
+  convert types that are generic over octets sequences between different
+  octets sequences. ([#77])
+
 Bug Fixes
 
 * Fix domain name compressors when giving a root label only. ([#76]
@@ -24,13 +29,13 @@ Bug Fixes
 
 New
 
-* Supprt for extended errors defined in [RFC 8914]. ([#79] by [@xofyarg])
 
 Other Changes
 
 [#74]: https://github.com/NLnetLabs/domain/pull/74
 [#75]: https://github.com/NLnetLabs/domain/pull/75
 [#76]: https://github.com/NLnetLabs/domain/pull/76
+[#77]: https://github.com/NLnetLabs/domain/pull/77
 [#79]: https://github.com/NLnetLabs/domain/pull/79
 [#80]: https://github.com/NLnetLabs/domain/pull/80
 [@vavrusa]: https://github.com/vavrusa

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,12 +23,17 @@ Bug Fixes
 
 New
 
+* Supprt for extended errors defined in [RFC 8914]. ([#79] by [@xofyarg]).
+
 Other Changes
 
 [#74]: https://github.com/NLnetLabs/domain/pull/74
 [#75]: https://github.com/NLnetLabs/domain/pull/75
 [#76]: https://github.com/NLnetLabs/domain/pull/76
+[#79]: https://github.com/NLnetLabs/domain/pull/79
 [@vavrusa]: https://github.com/vavrusa
+[@xofyarg]: https://github.com/xofyarg
+[RFC 8914]: https://tools.ietf.org/html/rfc8914
 
 
 ## 0.5.3

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,10 +20,11 @@ Bug Fixes
   by [@vavrusa])
 * Fix canonical comparison of TXT RDATA by taking the length labels into
   account. ([#76] by [@vavrusa])
+* Fix parsed not rejecting of malformed TXT RDATA. ([#80] by [@vavrusa])
 
 New
 
-* Supprt for extended errors defined in [RFC 8914]. ([#79] by [@xofyarg]).
+* Supprt for extended errors defined in [RFC 8914]. ([#79] by [@xofyarg])
 
 Other Changes
 
@@ -31,6 +32,7 @@ Other Changes
 [#75]: https://github.com/NLnetLabs/domain/pull/75
 [#76]: https://github.com/NLnetLabs/domain/pull/76
 [#79]: https://github.com/NLnetLabs/domain/pull/79
+[#80]: https://github.com/NLnetLabs/domain/pull/80
 [@vavrusa]: https://github.com/vavrusa
 [@xofyarg]: https://github.com/xofyarg
 [RFC 8914]: https://tools.ietf.org/html/rfc8914

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -33,8 +33,8 @@ use core::{cmp, fmt, hash, ops, str};
 };
 use super::cmp::CanonicalOrd;
 use super::octets::{
-    Compose, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsRef,
-    Parse, ParseError, Parser, ShortBuf
+    Compose, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsFrom,
+    OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 use super::str::{BadSymbol, Symbol, SymbolError};
 
@@ -159,6 +159,20 @@ impl CharStr<[u8]> {
                 &*(slice as *const [u8] as *const CharStr<[u8]>)
             })
         }
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets> OctetsFrom<CharStr<SrcOctets>> for CharStr<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: CharStr<SrcOctets>) -> Result<Self, ShortBuf> {
+        Octets::octets_from(source.0).map(|octets| {
+            unsafe {
+                Self::from_octets_unchecked(octets)
+            }
+        })
     }
 }
 

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -17,7 +17,7 @@ use super::iana::{Class, Rcode, Rtype};
 use super::message_builder::{AdditionalBuilder, AnswerBuilder};
 use super::name::ParsedDname;
 use super::octets::{
-    OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf
 };
 use super::opt::{Opt, OptRecord};
 use super::question::Question;
@@ -593,6 +593,20 @@ impl<Octets> AsRef<Octets> for Message<Octets> {
 impl<Octets: AsRef<[u8]>> AsRef<[u8]> for Message<Octets> {
     fn as_ref(&self) -> &[u8] {
         self.octets.as_ref()
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets> OctetsFrom<Message<SrcOctets>> for Message<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: Message<SrcOctets>) -> Result<Self, ShortBuf> {
+        Octets::octets_from(source.octets).map(|octets| {
+            unsafe {
+                Self::from_octets_unchecked(octets)
+            }
+        })
     }
 }
 

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -12,7 +12,7 @@ use core::str::FromStr;
 use super::super::cmp::CanonicalOrd;
 use super::super::octets::{
     Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsExt,
-    OctetsRef, Parse, Parser, ParseError, ShortBuf
+    OctetsFrom, OctetsRef, Parse, Parser, ParseError, ShortBuf
 };
 use super::builder::{DnameBuilder, FromStrError};
 use super::label::{Label, LabelTypeError, SplitLabelError};
@@ -584,6 +584,20 @@ impl<Octets: ?Sized> ops::Deref for Dname<Octets> {
 impl<Octets: AsRef<T> + ?Sized, T: ?Sized> AsRef<T> for Dname<Octets> {
     fn as_ref(&self) -> &T {
         self.0.as_ref()
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets> OctetsFrom<Dname<SrcOctets>> for Dname<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: Dname<SrcOctets>) -> Result<Self, ShortBuf> {
+        Octets::octets_from(source.0).map(|octets| {
+            unsafe {
+                Self::from_octets_unchecked(octets)
+            }
+        })
     }
 }
 

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -7,8 +7,8 @@ use core::cmp::Ordering;
 #[cfg(feature = "std")] use std::vec::Vec;
 #[cfg(feature = "bytes")] use bytes::Bytes;
 use super::super::octets::{
-    Compose, IntoBuilder, OctetsBuilder, OctetsExt, OctetsRef, ParseError,
-    ShortBuf
+    Compose, IntoBuilder, OctetsBuilder, OctetsExt, OctetsFrom, OctetsRef,
+    ParseError, ShortBuf
 };
 use super::builder::{DnameBuilder, PushError};
 use super::chain::{Chain, LongChainError};
@@ -565,6 +565,21 @@ impl<Octets: ?Sized> ops::Deref for RelativeDname<Octets> {
 impl<Octets: AsRef<T> + ?Sized, T: ?Sized> AsRef<T> for RelativeDname<Octets> {
     fn as_ref(&self) -> &T {
         self.0.as_ref()
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets>
+OctetsFrom<RelativeDname<SrcOctets>> for RelativeDname<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: RelativeDname<SrcOctets>) -> Result<Self, ShortBuf> {
+        Octets::octets_from(source.0).map(|octets| {
+            unsafe {
+                Self::from_octets_unchecked(octets)
+            }
+        })
     }
 }
 

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -47,7 +47,8 @@ use super::iana::{OptionCode, OptRcode, Rtype};
 use super::header::Header;
 use super::name::ToDname;
 use super::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf
 };
 use super::rdata::RtypeRecordData;
 use super::record::Record;
@@ -100,6 +101,16 @@ impl<Octets: AsRef<[u8]>> Opt<Octets> {
         Data: for<'a> ParseOptData<&'a Octets>
     {
         OptIter::new(&self.octets)
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets> OctetsFrom<Opt<SrcOctets>> for Opt<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: Opt<SrcOctets>) -> Result<Self, ShortBuf> {
+        Octets::octets_from(source.octets).map(|octets| Opt { octets })
     }
 }
 
@@ -406,6 +417,22 @@ impl<Octets> OptRecord<Octets> {
 impl<Octets, N: ToDname> From<Record<N, Opt<Octets>>> for OptRecord<Octets> {
     fn from(record: Record<N, Opt<Octets>>) -> Self {
         Self::from_record(record)
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets> OctetsFrom<OptRecord<SrcOctets>> for OptRecord<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: OptRecord<SrcOctets>) -> Result<Self, ShortBuf> {
+        Ok(OptRecord {
+            udp_payload_size: source.udp_payload_size,
+            ext_rcode: source.ext_rcode,
+            version: source.version,
+            flags: source.flags,
+            data: Opt::octets_from(source.data)?,
+        })
     }
 }
 

--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -10,7 +10,8 @@ use super::cmp::CanonicalOrd;
 use super::iana::{Class, Rtype};
 use super::name::{ParsedDname, ToDname};
 use super::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, Parser, ParseError, ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, Parser, ParseError,
+    ShortBuf
 };
 
 
@@ -42,7 +43,7 @@ pub struct Question<N> {
 
 /// # Creation and Conversion
 ///
-impl<N: ToDname> Question<N> {
+impl<N> Question<N> {
     /// Creates a new question from its three componets.
     pub fn new(qname: N, qtype: Rtype, qclass: Class) -> Self {
         Question { qname, qtype, qclass }
@@ -91,6 +92,19 @@ impl<N: ToDname> From<(N, Rtype, Class)> for Question<N> {
 impl<N: ToDname> From<(N, Rtype)> for Question<N> {
     fn from((name, rtype): (N, Rtype)) -> Self {
         Question::new(name, rtype, Class::In)
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Name, SrcName> OctetsFrom<Question<SrcName>> for Question<Name>
+where Name: OctetsFrom<SrcName> {
+    fn octets_from(source: Question<SrcName>) -> Result<Self, ShortBuf> {
+        Ok(Question::new(
+            Name::octets_from(source.qname)?,
+            source.qtype, source.qclass
+        ))
     }
 }
 

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -31,7 +31,8 @@ use core::cmp::Ordering;
 use super::cmp::CanonicalOrd;
 use super::iana::Rtype;
 use super::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf
 };
 
 
@@ -216,6 +217,22 @@ impl UnknownRecordData<Bytes> {
             )?
         }
         Ok(UnknownRecordData::from_octets(rtype, res.freeze()))
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets>
+OctetsFrom<UnknownRecordData<SrcOctets>> for UnknownRecordData<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(
+        source: UnknownRecordData<SrcOctets>
+    ) -> Result<Self, ShortBuf> {
+        Ok(UnknownRecordData {
+            rtype: source.rtype,
+            data: Octets::octets_from(source.data)?
+        })
     }
 }
 

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -905,3 +905,28 @@ impl<N, D> From<ShortBuf> for RecordParseError<N, D> {
     }
 }
 
+
+//============ Testing ======================================================
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    #[cfg(features = "bytes")]
+    fn ds_octets_into() {
+        use crate::name::Dname;
+        use crate::octets::OctetsInto;
+        use crate::base::iana::{DigestAlg, Rtype, SecAlg};
+        use crate::rdata::Ds;
+
+        let ds: Record<Dname<&[u8]>, Ds<&[u8]>> = Record::new(
+            "a.example".parse().unwrap(), Class::In, 86400,
+            Ds::new(12, SecAlg::RsaSha256, b"something")
+        );
+        let ds_bytes: Record<Dname<Bytes>, Ds<Bytes>>
+            = ds.octets_into().unwrap();
+        assert_eq!(ds.owner(), ds_bytes.owner());
+        asswer_eq!(ds.data().digest(), ds_bytes.data().digest());
+    }
+}
+

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -60,6 +60,39 @@ macro_rules! rdata_types {
         }
 
 
+        //--- OctetsFrom
+
+        impl<Octets, SrcOctets, Name, SrcName>
+            $crate::base::octets::OctetsFrom<
+                MasterRecordData<SrcOctets, SrcName>
+            >
+            for MasterRecordData<Octets, Name>
+        where
+            Octets: $crate::base::octets::OctetsFrom<SrcOctets>,
+            Name: $crate::base::octets::OctetsFrom<SrcName>
+        {
+            fn octets_from(
+                source: MasterRecordData<SrcOctets, SrcName>
+            ) -> Result<Self, $crate::base::octets::ShortBuf> {
+                match source {
+                    $( $( $(
+                        MasterRecordData::$mtype(inner) => {
+                            $mtype::octets_from(inner).map(
+                                MasterRecordData::$mtype
+                            )
+                        }
+                    )* )* )*
+                    MasterRecordData::Other(inner) => {
+                        $crate::base::rdata::
+                        UnknownRecordData::octets_from(inner).map(
+                            MasterRecordData::Other
+                        )
+                    }
+                }
+            }
+        }
+
+
         //--- From
 
         $( $( $(
@@ -449,6 +482,51 @@ macro_rules! rdata_types {
         }
 
 
+        //--- OctetsFrom
+
+        impl<Octets, SrcOctets, Name, SrcName>
+            $crate::base::octets::OctetsFrom<
+                AllRecordData<SrcOctets, SrcName>
+            >
+            for AllRecordData<Octets, Name>
+        where
+            Octets: $crate::base::octets::OctetsFrom<SrcOctets>,
+            Name: $crate::base::octets::OctetsFrom<SrcName>
+        {
+            fn octets_from(
+                source: AllRecordData<SrcOctets, SrcName>
+            ) -> Result<Self, $crate::base::octets::ShortBuf> {
+                match source {
+                    $( $( $(
+                        AllRecordData::$mtype(inner) => {
+                            $mtype::octets_from(inner).map(
+                                AllRecordData::$mtype
+                            )
+                        }
+                    )* )* )*
+                    $( $( $(
+                        AllRecordData::$ptype(inner) => {
+                            $ptype::octets_from(inner).map(
+                                AllRecordData::$ptype
+                            )
+                        }
+                    )* )* )*
+                    AllRecordData::Opt(inner) => {
+                        $crate::base::opt::Opt::octets_from(inner).map(
+                            AllRecordData::Opt
+                        )
+                    }
+                    AllRecordData::Other(inner) => {
+                        $crate::base::rdata::
+                        UnknownRecordData::octets_from(inner).map(
+                            AllRecordData::Other
+                        )
+                    }
+                }
+            }
+        }
+
+
         //--- PartialEq and Eq
 
         impl<O, OO, N, NN> PartialEq<AllRecordData<OO, NN>>
@@ -741,6 +819,18 @@ macro_rules! dname_type {
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 N::from_str(s).map(Self::new)
+            }
+        }
+
+
+        //--- OctetsFrom
+
+        impl<Name, SrcName> OctetsFrom<$target<SrcName>> for $target<Name>
+        where Name: OctetsFrom<SrcName> {
+            fn octets_from(source: $target<SrcName>) -> Result<Self, ShortBuf> {
+                Name::octets_from(source.$field).map(|name| {
+                    Self::new(name)
+                })
             }
         }
 

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -1552,6 +1552,7 @@ impl<Builder: OctetsBuilder + EmptyBuilder> Default for TxtBuilder<Builder> {
     }
 }
 
+
 //============ Testing ======================================================
 
 #[cfg(test)]
@@ -1559,6 +1560,36 @@ impl<Builder: OctetsBuilder + EmptyBuilder> Default for TxtBuilder<Builder> {
 mod test {
     use std::vec::Vec;
     use super::*;
+
+    #[test]
+    #[cfg(features = "bytes")]
+    fn hinfo_octets_into() {
+        use crate::octets::OctetsInto;
+
+        let hinfo: Hinfo<Vec<u8>> = Hinfo::new(
+            "1234".parse().unwrap(),
+            "abcd".parse().unwrap()
+        );
+        let hinfo_bytes: Hinfo<bytes::Bytes> = hinfo.octets_into().unwrap();
+        assert_eq!(hinfo.cpu(), hinfo_bytes.cpu());
+        assert_eq!(hinfo.os(), hinfo_bytes.os());
+    }
+
+    #[test]
+    #[cfg(features = "bytes")]
+    fn minfo_octets_into() {
+        use crate::base::Dname;
+        use crate::octets::OctetsInto;
+
+        let minfo: Minfo<Dname<Vec<u8>>> = Minfo::new(
+            "a.example".parse().unwrap(),
+            "b.example".parse().unwrap()
+        );
+        let minfo_bytes: Minfo<Dname<bytes::Bytes>> =
+            minfo.octets_into().unwrap();
+        assert_eq!(minfo.rmailbx(), minfo_bytes.rmailbx());
+        assert_eq!(minfo.emailbx(), minfo_bytes.emailbx());
+    }
 
     #[test]
     fn txt_from_slice() {

--- a/src/rdata/rfc2782.rs
+++ b/src/rdata/rfc2782.rs
@@ -10,7 +10,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, Parser, ParseError,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, Parser, ParseError,
     ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
@@ -54,6 +54,19 @@ impl<N> Srv<N> {
 
     pub fn target(&self) -> &N {
         &self.target
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Name, SrcName> OctetsFrom<Srv<SrcName>> for Srv<Name>
+where Name: OctetsFrom<SrcName> {
+    fn octets_from(source: Srv<SrcName>) -> Result<Self, ShortBuf> {
+        Ok(Srv::new(
+            source.priority, source.weight, source.port,
+            Name::octets_from(source.target)?
+        ))
     }
 }
 

--- a/src/rdata/rfc3596.rs
+++ b/src/rdata/rfc3596.rs
@@ -10,7 +10,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::net::Ipv6Addr;
 use crate::base::octets::{
-    Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, Parse, ParseError, Parser, ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -55,6 +55,15 @@ impl core::str::FromStr for Aaaa {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ipv6Addr::from_str(s).map(Aaaa::new)
+    }
+}
+
+
+//--- OctetsFrom
+
+impl OctetsFrom<Aaaa> for Aaaa {
+    fn octets_from(source: Aaaa) -> Result<Self, ShortBuf> {
+        Ok(source)
     }
 }
 

--- a/src/rdata/rfc5155.rs
+++ b/src/rdata/rfc5155.rs
@@ -11,7 +11,8 @@ use crate::base::charstr::CharStr;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Nsec3HashAlg, Rtype};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -71,6 +72,21 @@ impl<Octets> Nsec3<Octets> {
 
     pub fn types(&self) -> &RtypeBitmap<Octets> {
         &self.types
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets> OctetsFrom<Nsec3<SrcOctets>> for Nsec3<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: Nsec3<SrcOctets>) -> Result<Self, ShortBuf> {
+        Ok(Nsec3::new(
+            source.hash_algorithm, source.flags, source.iterations,
+            CharStr::octets_from(source.salt)?,
+            CharStr::octets_from(source.next_owner)?,
+            RtypeBitmap::octets_from(source.types)?,
+        ))
     }
 }
 
@@ -317,6 +333,20 @@ impl<Octets> Nsec3param<Octets> {
 
     pub fn salt(&self) -> &CharStr<Octets> {
         &self.salt
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets>
+    OctetsFrom<Nsec3param<SrcOctets>> for Nsec3param<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: Nsec3param<SrcOctets>) -> Result<Self, ShortBuf> {
+        Ok(Nsec3param::new(
+            source.hash_algorithm, source.flags, source.iterations,
+            CharStr::octets_from(source.salt)?,
+        ))
     }
 }
 

--- a/src/rdata/rfc6672.rs
+++ b/src/rdata/rfc6672.rs
@@ -1,7 +1,10 @@
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
-use crate::base::octets::{Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf};
+use crate::base::octets::{
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf
+};
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature = "master")]
 use crate::master::scan::{CharSource, Scan, ScanError, Scanner};

--- a/src/rdata/rfc7344.rs
+++ b/src/rdata/rfc7344.rs
@@ -7,7 +7,8 @@ use core::cmp::Ordering;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature="master")] use crate::master::scan::{
@@ -55,6 +56,19 @@ impl<Octets> Cdnskey<Octets> {
 
     pub fn public_key(&self) -> &Octets {
         &self.public_key
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets> OctetsFrom<Cdnskey<SrcOctets>> for Cdnskey<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: Cdnskey<SrcOctets>) -> Result<Self, ShortBuf> {
+        Ok(Cdnskey::new(
+            source.flags, source.protocol, source.algorithm,
+            Octets::octets_from(source.public_key)?,
+        ))
     }
 }
 
@@ -244,6 +258,19 @@ impl<Octets> Cds<Octets> {
 
     pub fn into_digest(self) -> Octets {
         self.digest
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<Octets, SrcOctets> OctetsFrom<Cds<SrcOctets>> for Cds<Octets>
+where Octets: OctetsFrom<SrcOctets> {
+    fn octets_from(source: Cds<SrcOctets>) -> Result<Self, ShortBuf> {
+        Ok(Cds::new(
+            source.key_tag, source.algorithm, source.digest_type,
+            Octets::octets_from(source.digest)?,
+        ))
     }
 }
 

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -56,7 +56,7 @@ const RETRY_RANDOM_PORT: usize = 10;
 /// A DNS stub resolver.
 ///
 /// This type collects all information making it possible to start DNS
-/// queries. You can create a new resoler using the system’s configuration
+/// queries. You can create a new resolver using the system’s configuration
 /// using the [`new()`] associate function or using your own configuration
 /// with [`from_conf()`].
 ///


### PR DESCRIPTION
This continues from PR #69.

I think I have implemented `OctetsFrom` for all relevant types with `OctetsInto` automatically available for them via a blanket impl. @vavrusa, can you have a look and let me know if this works for you or what needs changing?