### PR TITLE
Fixed a TXT wireformat parser bug and allow calling rtype() on enum record data types

### DIFF
--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -242,11 +242,19 @@ macro_rules! rdata_types {
 
         //--- RecordData and ParseRecordData
 
+        impl<'a, O, N> $crate::base::rdata::RecordData for &'a MasterRecordData<O, N>
+        where O: AsRef<[u8]>, N: $crate::base::name::ToDname
+        {
+            fn rtype(&self) -> $crate::base::iana::Rtype {
+                MasterRecordData::rtype(self)
+            }
+        }
+
         impl<O, N> $crate::base::rdata::RecordData for MasterRecordData<O, N>
         where O: AsRef<[u8]>, N: $crate::base::name::ToDname
         {
             fn rtype(&self) -> $crate::base::iana::Rtype {
-                self.rtype()
+                MasterRecordData::rtype(self)
             }
         }
 
@@ -353,7 +361,6 @@ macro_rules! rdata_types {
                 }
             }
         }
-
 
 
         //------------- AllRecordData ----------------------------------------
@@ -569,6 +576,13 @@ macro_rules! rdata_types {
         //--- RecordData and ParseRecordData
 
         impl<O, N> $crate::base::rdata::RecordData for AllRecordData<O, N>
+        where O: AsRef<[u8]>, N: $crate::base::name::ToDname {
+            fn rtype(&self) -> $crate::base::iana::Rtype {
+                self.rtype()
+            }
+        }
+
+        impl<'a, O, N> $crate::base::rdata::RecordData for &'a AllRecordData<O, N>
         where O: AsRef<[u8]>, N: $crate::base::name::ToDname {
             fn rtype(&self) -> $crate::base::iana::Rtype {
                 match *self {


### PR DESCRIPTION
There is an error currently which checks remaining bytes of the parent parser, which has already been consumed, so the TXT RDATA elements are not actually checked. This lets malformed data past the parser and crashes later.