### PR TITLE
cargo fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       run: rustup component add clippy
     - if: matrix.rust != 'nightly'
       run: cargo clippy --all-features -- -D warnings
+    - if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
+      run: cargo fmt --all -- --check
     - run: cargo build --no-default-features --verbose
     - run: cargo test --features="master resolv resolv-sync sign tsig validate" --verbose
 

--- a/examples/download-rust-lang.rs
+++ b/examples/download-rust-lang.rs
@@ -2,27 +2,28 @@ use std::str::FromStr;
 
 use domain::base::name::Dname;
 use domain::resolv::StubResolver;
-use tokio::net::TcpStream;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
 use tokio_native_tls::native_tls::TlsConnector;
 
 #[tokio::main]
 async fn main() {
     let resolver = StubResolver::new();
-    let addr = match resolver.lookup_host(
-        &Dname::<Vec<u8>>::from_str("www.rust-lang.org").unwrap()
-    ).await {
+    let addr = match resolver
+        .lookup_host(&Dname::<Vec<u8>>::from_str("www.rust-lang.org").unwrap())
+        .await
+    {
         Ok(addr) => addr,
         Err(err) => {
             eprintln!("DNS query failed: {}", err);
-            return
+            return;
         }
     };
     let addr = match addr.port_iter(443).next() {
         Some(addr) => addr,
         None => {
             eprintln!("Failed to resolve www.rust-lang.org");
-            return
+            return;
         }
     };
     let socket = match TcpStream::connect(&addr).await {
@@ -46,15 +47,19 @@ async fn main() {
             return;
         }
     };
-    if let Err(err) = socket.write_all(
-        "\
+    if let Err(err) = socket
+        .write_all(
+            "\
             GET / HTTP/1.0\r\n\
             Host: www.rust-lang.org\r\n\
             \r\n\
-        ".as_bytes()
-    ).await {
+        "
+            .as_bytes(),
+        )
+        .await
+    {
         eprintln!("Failed to send request: {}", err);
-        return
+        return;
     };
     let mut response = Vec::new();
     if let Err(err) = socket.read_to_end(&mut response).await {

--- a/examples/download-rust-lang.rs
+++ b/examples/download-rust-lang.rs
@@ -10,7 +10,9 @@ use tokio_native_tls::native_tls::TlsConnector;
 async fn main() {
     let resolver = StubResolver::new();
     let addr = match resolver
-        .lookup_host(&Dname::<Vec<u8>>::from_str("www.rust-lang.org").unwrap())
+        .lookup_host(
+            &Dname::<Vec<u8>>::from_str("www.rust-lang.org").unwrap(),
+        )
         .await
     {
         Ok(addr) => addr,
@@ -33,13 +35,15 @@ async fn main() {
             return;
         }
     };
-    let cx = tokio_native_tls::TlsConnector::from(match TlsConnector::builder().build() {
-        Ok(cx) => cx,
-        Err(err) => {
-            eprintln!("Creating TLS context failed: {}", err);
-            return;
-        }
-    });
+    let cx = tokio_native_tls::TlsConnector::from(
+        match TlsConnector::builder().build() {
+            Ok(cx) => cx,
+            Err(err) => {
+                eprintln!("Creating TLS context failed: {}", err);
+                return;
+            }
+        },
+    );
     let mut socket = match cx.connect("www.rust-lang.org", socket).await {
         Ok(socket) => socket,
         Err(err) => {

--- a/examples/lookup.rs
+++ b/examples/lookup.rs
@@ -6,8 +6,12 @@ use std::str::FromStr;
 
 async fn forward(resolver: &StubResolver, name: UncertainDname<Vec<u8>>) {
     let answer = match name {
-        UncertainDname::Absolute(ref name) => resolver.lookup_host(name).await,
-        UncertainDname::Relative(ref name) => resolver.search_host(name).await,
+        UncertainDname::Absolute(ref name) => {
+            resolver.lookup_host(name).await
+        }
+        UncertainDname::Relative(ref name) => {
+            resolver.search_host(name).await
+        }
     };
     match answer {
         Ok(answer) => {

--- a/examples/readzone.rs
+++ b/examples/readzone.rs
@@ -2,8 +2,8 @@
 
 #[cfg(feature = "master")]
 fn main() {
-    use std::env;
     use domain::master::reader::Reader;
+    use std::env;
 
     for arg in env::args().skip(1) {
         print!("{}: ", arg);
@@ -23,13 +23,11 @@ fn main() {
         }
         if err {
             println!("");
-        }
-        else {
+        } else {
             println!("{} items.", items)
         }
     }
 }
 
 #[cfg(not(feature = "master"))]
-fn main() {
-} 
+fn main() {}

--- a/examples/resolv-sync.rs
+++ b/examples/resolv-sync.rs
@@ -1,25 +1,25 @@
-use std::env;
-use std::str::FromStr;
-use domain::base::Rtype;
 use domain::base::name::Dname;
+use domain::base::Rtype;
 use domain::rdata::AllRecordData;
 use domain::resolv::StubResolver;
+use std::env;
+use std::str::FromStr;
 
 fn main() {
     let mut args = env::args().skip(1);
-    let name = args.next().and_then(|arg| Dname::<Vec<_>>::from_str(&arg).ok());
+    let name = args
+        .next()
+        .and_then(|arg| Dname::<Vec<_>>::from_str(&arg).ok());
     let rtype = args.next().and_then(|arg| Rtype::from_str(&arg).ok());
     let (name, rtype) = match (name, rtype) {
         (Some(name), Some(rtype)) => (name, rtype),
         _ => {
             println!("Usage: sync <domain> <record type>");
-            return
+            return;
         }
     };
-    
-    let res = StubResolver::run(move |stub| async move {
-        stub.query((name, rtype)).await
-    });
+
+    let res = StubResolver::run(move |stub| async move { stub.query((name, rtype)).await });
     let res = res.unwrap();
     let res = res.answer().unwrap().limit_to::<AllRecordData<_, _>>();
     for record in res {
@@ -27,4 +27,3 @@ fn main() {
         println!("{}", record);
     }
 }
-

--- a/examples/resolv-sync.rs
+++ b/examples/resolv-sync.rs
@@ -19,7 +19,9 @@ fn main() {
         }
     };
 
-    let res = StubResolver::run(move |stub| async move { stub.query((name, rtype)).await });
+    let res = StubResolver::run(move |stub| async move {
+        stub.query((name, rtype)).await
+    });
     let res = res.unwrap();
     let res = res.answer().unwrap().limit_to::<AllRecordData<_, _>>();
     for record in res {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 78

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -25,19 +25,19 @@
 //! [`CharStrBuilder`]: struct.CharStrMut.html
 //! [RFC 1035]: https://tools.ietf.org/html/rfc1035
 
-use core::{cmp, fmt, hash, ops, str};
-#[cfg(feature = "std")] use std::vec::Vec;
-#[cfg(feature = "bytes")] use bytes::{Bytes, BytesMut};
-#[cfg(feature="master")] use crate::master::scan::{
-    CharSource, Scan, Scanner, ScanError, SyntaxError
-};
 use super::cmp::CanonicalOrd;
 use super::octets::{
-    Compose, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsFrom,
-    OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsFrom, OctetsRef, Parse,
+    ParseError, Parser, ShortBuf,
 };
 use super::str::{BadSymbol, Symbol, SymbolError};
-
+#[cfg(feature = "master")]
+use crate::master::scan::{CharSource, Scan, ScanError, Scanner, SyntaxError};
+#[cfg(feature = "bytes")]
+use bytes::{Bytes, BytesMut};
+use core::{cmp, fmt, hash, ops, str};
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 //------------ CharStr -------------------------------------------------------
 
@@ -56,94 +56,113 @@ pub struct CharStr<Octets: ?Sized>(Octets);
 impl<Octets: ?Sized> CharStr<Octets> {
     /// Creates a new empty character string.
     pub fn empty() -> Self
-    where Octets: From<&'static [u8]> {
+    where
+        Octets: From<&'static [u8]>,
+    {
         CharStr(b"".as_ref().into())
     }
 
-    /// Creates a new character string from an octets value. 
+    /// Creates a new character string from an octets value.
     ///
     /// Returns succesfully if `octets` can indeed be used as a
     /// character string, i.e., it is not longer than 255 bytes.
     pub fn from_octets(octets: Octets) -> Result<Self, CharStrError>
-    where Octets: AsRef<[u8]> + Sized {
-        if octets.as_ref().len() > 255 { Err(CharStrError) }
-        else { Ok(unsafe { Self::from_octets_unchecked(octets) })}
+    where
+        Octets: AsRef<[u8]> + Sized,
+    {
+        if octets.as_ref().len() > 255 {
+            Err(CharStrError)
+        } else {
+            Ok(unsafe { Self::from_octets_unchecked(octets) })
+        }
     }
 
     /// Creates a character string from octets without length check.
     ///
     /// As this can break the guarantees made by the type, it is unsafe.
     unsafe fn from_octets_unchecked(octets: Octets) -> Self
-    where Octets: Sized {
+    where
+        Octets: Sized,
+    {
         CharStr(octets)
     }
 
     /// Creates a new empty builder for this character string type.
     pub fn builder() -> CharStrBuilder<Octets::Builder>
-    where Octets: IntoBuilder, Octets::Builder: EmptyBuilder {
+    where
+        Octets: IntoBuilder,
+        Octets::Builder: EmptyBuilder,
+    {
         CharStrBuilder::new()
     }
 
     /// Converts the character string into a builder.
     pub fn into_builder(self) -> CharStrBuilder<Octets::Builder>
-    where Octets: IntoBuilder + Sized {
-        unsafe {
-            CharStrBuilder::from_builder_unchecked(
-                IntoBuilder::into_builder(self.0)
-            )
-        }
+    where
+        Octets: IntoBuilder + Sized,
+    {
+        unsafe { CharStrBuilder::from_builder_unchecked(IntoBuilder::into_builder(self.0)) }
     }
 
     /// Converts the character string into its underlying octets value.
     pub fn into_octets(self) -> Octets
-    where Octets: Sized {
+    where
+        Octets: Sized,
+    {
         self.0
     }
 
     /// Returns a character string atop a slice of the content.
     pub fn for_slice(&self) -> CharStr<&[u8]>
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         unsafe { CharStr::from_octets_unchecked(self.0.as_ref()) }
     }
 
     /// Returns a character string atop a mutable slice of the content.
     pub fn for_slice_mut(&mut self) -> CharStr<&mut [u8]>
-    where Octets: AsMut<[u8]> {
+    where
+        Octets: AsMut<[u8]>,
+    {
         unsafe { CharStr::from_octets_unchecked(self.0.as_mut()) }
     }
 
     /// Returns a reference to a slice of the character string’s data.
     pub fn as_slice(&self) -> &[u8]
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         self.0.as_ref()
     }
 
     /// Returns a reference to a mutable slice of the character string’s data.
     pub fn as_slice_mut(&mut self) -> &mut [u8]
-    where Octets: AsMut<[u8]> {
+    where
+        Octets: AsMut<[u8]>,
+    {
         self.0.as_mut()
     }
 }
 
-#[cfg(feature="bytes")]
+#[cfg(feature = "bytes")]
 impl CharStr<Bytes> {
     /// Creates a new character string from a bytes value.
     ///
     /// Returns succesfully if the bytes slice can indeed be used as a
     /// character string, i.e., it is not longer than 255 bytes.
     pub fn from_bytes(bytes: Bytes) -> Result<Self, CharStrError> {
-        if bytes.len() > 255 { Err(CharStrError) }
-        else { Ok(unsafe { Self::from_octets_unchecked(bytes) })}
+        if bytes.len() > 255 {
+            Err(CharStrError)
+        } else {
+            Ok(unsafe { Self::from_octets_unchecked(bytes) })
+        }
     }
 
     /// Scans a character string given as a word of hexadecimal digits.
-    #[cfg(feature="master")]
-    pub fn scan_hex<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
-        scanner.scan_hex_word(|b| unsafe {
-            Ok(CharStr::from_octets_unchecked(b))
-        })
+    #[cfg(feature = "master")]
+    pub fn scan_hex<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+        scanner.scan_hex_word(|b| unsafe { Ok(CharStr::from_octets_unchecked(b)) })
     }
 }
 
@@ -153,45 +172,38 @@ impl CharStr<[u8]> {
     /// If the byte slice is longer than 255 bytes, the function will return
     /// an error.
     pub fn from_slice(slice: &[u8]) -> Result<&Self, CharStrError> {
-        if slice.len() > 255 { Err(CharStrError) }
-        else { 
-            Ok(unsafe {
-                &*(slice as *const [u8] as *const CharStr<[u8]>)
-            })
+        if slice.len() > 255 {
+            Err(CharStrError)
+        } else {
+            Ok(unsafe { &*(slice as *const [u8] as *const CharStr<[u8]>) })
         }
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<CharStr<SrcOctets>> for CharStr<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: CharStr<SrcOctets>) -> Result<Self, ShortBuf> {
-        Octets::octets_from(source.0).map(|octets| {
-            unsafe {
-                Self::from_octets_unchecked(octets)
-            }
-        })
+        Octets::octets_from(source.0).map(|octets| unsafe { Self::from_octets_unchecked(octets) })
     }
 }
-
 
 //--- FromStr
 
 impl<Octets> str::FromStr for CharStr<Octets>
 where
     Octets: FromBuilder,
-    <Octets as FromBuilder>::Builder:
-        OctetsBuilder<Octets = Octets> + EmptyBuilder,
+    <Octets as FromBuilder>::Builder: OctetsBuilder<Octets = Octets> + EmptyBuilder,
 {
     type Err = FromStrError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Most likely, everything is ASCII so take `s`’s length as capacity.
-        let mut builder = 
-            CharStrBuilder::<<Octets as FromBuilder>::Builder>
-            ::with_capacity(s.len());
+        let mut builder =
+            CharStrBuilder::<<Octets as FromBuilder>::Builder>::with_capacity(s.len());
         let mut chars = s.chars();
         while let Some(symbol) = Symbol::from_chars(&mut chars)? {
             if builder.len() == 255 {
@@ -202,7 +214,6 @@ where
         Ok(builder.finish())
     }
 }
-
 
 //--- Deref and AsRef
 
@@ -232,70 +243,80 @@ impl<Octets: AsMut<U> + ?Sized, U: ?Sized> AsMut<U> for CharStr<Octets> {
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<T, U> PartialEq<U> for CharStr<T>
-where T: AsRef<[u8]> + ?Sized, U: AsRef<[u8]> + ?Sized {
+where
+    T: AsRef<[u8]> + ?Sized,
+    U: AsRef<[u8]> + ?Sized,
+{
     fn eq(&self, other: &U) -> bool {
         self.as_slice().eq_ignore_ascii_case(other.as_ref())
     }
 }
 
-impl<T: AsRef<[u8]> + ?Sized> Eq for CharStr<T> { }
-
+impl<T: AsRef<[u8]> + ?Sized> Eq for CharStr<T> {}
 
 //--- PartialOrd, Ord, and CanonicalOrd
 
 impl<T, U> PartialOrd<U> for CharStr<T>
-where T: AsRef<[u8]> + ?Sized, U: AsRef<[u8]> + ?Sized {
+where
+    T: AsRef<[u8]> + ?Sized,
+    U: AsRef<[u8]> + ?Sized,
+{
     fn partial_cmp(&self, other: &U) -> Option<cmp::Ordering> {
-        self.0.as_ref().iter().map(
-            u8::to_ascii_lowercase
-        ).partial_cmp(
-            other.as_ref().iter().map(u8::to_ascii_lowercase)
-        )
+        self.0
+            .as_ref()
+            .iter()
+            .map(u8::to_ascii_lowercase)
+            .partial_cmp(other.as_ref().iter().map(u8::to_ascii_lowercase))
     }
 }
 
 impl<T: AsRef<[u8]> + ?Sized> Ord for CharStr<T> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.0.as_ref().iter().map(u8::to_ascii_lowercase)
+        self.0
+            .as_ref()
+            .iter()
+            .map(u8::to_ascii_lowercase)
             .cmp(other.0.as_ref().iter().map(u8::to_ascii_lowercase))
     }
 }
 
 impl<T, U> CanonicalOrd<CharStr<U>> for CharStr<T>
-where T: AsRef<[u8]> + ?Sized, U: AsRef<[u8]> + ?Sized {
+where
+    T: AsRef<[u8]> + ?Sized,
+    U: AsRef<[u8]> + ?Sized,
+{
     fn canonical_cmp(&self, other: &CharStr<U>) -> cmp::Ordering {
         match self.0.as_ref().len().cmp(&other.0.as_ref().len()) {
-            cmp::Ordering::Equal => { }
-            other => return other
+            cmp::Ordering::Equal => {}
+            other => return other,
         }
         self.as_slice().cmp(other.as_slice())
     }
 }
 
-
 //--- Hash
 
 impl<T: AsRef<[u8]> + ?Sized> hash::Hash for CharStr<T> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.0.as_ref().iter().map(u8::to_ascii_lowercase)
+        self.0
+            .as_ref()
+            .iter()
+            .map(u8::to_ascii_lowercase)
             .for_each(|ch| ch.hash(state))
     }
 }
-
-
 
 //--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for CharStr<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = parser.parse_u8()? as usize;
-        parser.parse_octets(len).map(|bytes| {
-            unsafe { Self::from_octets_unchecked(bytes) }
-        })
+        parser
+            .parse_octets(len)
+            .map(|bytes| unsafe { Self::from_octets_unchecked(bytes) })
     }
 
     fn skip(parser: &mut Parser<Ref>) -> Result<(), ParseError> {
@@ -305,10 +326,7 @@ impl<Ref: OctetsRef> Parse<Ref> for CharStr<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]> + ?Sized> Compose for CharStr<Octets> {
-    fn compose<Target: OctetsBuilder>(
-        &self,
-        target: &mut Target
-    ) -> Result<(), ShortBuf> {
+    fn compose<Target: OctetsBuilder>(&self, target: &mut Target) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             (self.as_ref().len() as u8).compose(target)?;
             target.append_slice(self.as_ref())
@@ -316,18 +334,15 @@ impl<Octets: AsRef<[u8]> + ?Sized> Compose for CharStr<Octets> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for CharStr<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>)
-                           -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         scanner.scan_byte_phrase(|res| {
             if res.len() > 255 {
                 Err(SyntaxError::LongCharStr)
-            }
-            else {
+            } else {
                 Ok(unsafe { CharStr::from_octets_unchecked(res) })
             }
         })
@@ -361,7 +376,6 @@ impl<T: AsRef<[u8]> + ?Sized> fmt::UpperHex for CharStr<T> {
     }
 }
 
-
 //--- IntoIterator
 
 impl<T: AsRef<[u8]>> IntoIterator for CharStr<T> {
@@ -382,7 +396,6 @@ impl<'a, T: AsRef<[u8]> + ?Sized + 'a> IntoIterator for &'a CharStr<T> {
     }
 }
 
-
 //--- Debug
 
 impl<T: AsRef<[u8]> + ?Sized> fmt::Debug for CharStr<T> {
@@ -390,7 +403,6 @@ impl<T: AsRef<[u8]> + ?Sized> fmt::Debug for CharStr<T> {
         write!(f, "CharStr(\"{:?}\")", self.0.as_ref())
     }
 }
-
 
 //------------ CharStrBuilder ------------------------------------------------
 
@@ -430,8 +442,7 @@ impl<Builder: OctetsBuilder> CharStrBuilder<Builder> {
     pub fn from_builder(builder: Builder) -> Result<Self, CharStrError> {
         if builder.as_ref().len() > 255 {
             Err(CharStrError)
-        }
-        else {
+        } else {
             Ok(unsafe { Self::from_builder_unchecked(builder) })
         }
     }
@@ -450,7 +461,7 @@ impl CharStrBuilder<Vec<u8>> {
     }
 }
 
-#[cfg(feature="bytes")]
+#[cfg(feature = "bytes")]
 impl CharStrBuilder<BytesMut> {
     /// Creates a new empty builder for a bytes value.
     pub fn new_bytes() -> Self {
@@ -475,7 +486,6 @@ impl<Builder: OctetsBuilder> CharStrBuilder<Builder> {
     }
 }
 
-
 //--- Default
 
 impl<Builder: EmptyBuilder> Default for CharStrBuilder<Builder> {
@@ -484,7 +494,6 @@ impl<Builder: EmptyBuilder> Default for CharStrBuilder<Builder> {
     }
 }
 
-
 //--- OctetsBuilder
 
 impl<Builder: OctetsBuilder> OctetsBuilder for CharStrBuilder<Builder> {
@@ -492,7 +501,7 @@ impl<Builder: OctetsBuilder> OctetsBuilder for CharStrBuilder<Builder> {
 
     fn append_slice(&mut self, slice: &[u8]) -> Result<(), ShortBuf> {
         if self.0.len() + slice.len() > 255 {
-            return Err(ShortBuf)
+            return Err(ShortBuf);
         }
         self.0.append_slice(slice)
     }
@@ -506,7 +515,6 @@ impl<Builder: OctetsBuilder> OctetsBuilder for CharStrBuilder<Builder> {
     }
 }
 
-
 //--- Deref and DerefMut
 
 impl<Builder: AsRef<[u8]>> ops::Deref for CharStrBuilder<Builder> {
@@ -518,12 +526,13 @@ impl<Builder: AsRef<[u8]>> ops::Deref for CharStrBuilder<Builder> {
 }
 
 impl<Builder> ops::DerefMut for CharStrBuilder<Builder>
-where Builder: AsRef<[u8]> + AsMut<[u8]> {
+where
+    Builder: AsRef<[u8]> + AsMut<[u8]>,
+{
     fn deref_mut(&mut self) -> &mut [u8] {
         self.0.as_mut()
     }
 }
-
 
 //--- AsRef and AsMut
 
@@ -539,7 +548,6 @@ impl<Builder: AsMut<[u8]>> AsMut<[u8]> for CharStrBuilder<Builder> {
     }
 }
 
-
 //------------ IntoIter ------------------------------------------------------
 
 /// The iterator type for `IntoIterator` for a character string itself.
@@ -554,7 +562,7 @@ impl<T: AsRef<[u8]>> IntoIter<T> {
         IntoIter {
             len: octets.as_ref().len(),
             octets,
-            pos: 0
+            pos: 0,
         }
     }
 }
@@ -565,15 +573,13 @@ impl<T: AsRef<[u8]>> Iterator for IntoIter<T> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos == self.len {
             None
-        }
-        else {
+        } else {
             let res = self.octets.as_ref()[self.pos];
             self.pos += 1;
             Some(res)
         }
     }
 }
-
 
 //------------ Iter ----------------------------------------------------------
 
@@ -598,7 +604,6 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-
 //============ Error Types ===================================================
 
 //------------ CharStrError --------------------------------------------------
@@ -616,8 +621,7 @@ impl fmt::Display for CharStrError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for CharStrError { }
-
+impl std::error::Error for CharStrError {}
 
 //------------ FromStrError --------------------------------------------
 
@@ -649,7 +653,6 @@ pub enum FromStrError {
     ShortBuf,
 }
 
-
 //--- From
 
 impl From<SymbolError> for FromStrError {
@@ -673,64 +676,54 @@ impl From<ShortBuf> for FromStrError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for FromStrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            FromStrError::ShortInput
-                => f.write_str("unexpected end of input"),
-            FromStrError::LongString
-                => f.write_str("character string with more than 255 octets"),
-            FromStrError::BadEscape
-                => f.write_str("illegal escape sequence"),
-            FromStrError::BadSymbol(symbol)
-                => write!(f, "illegal character '{}'", symbol),
-            FromStrError::ShortBuf
-                => ShortBuf.fmt(f)
+            FromStrError::ShortInput => f.write_str("unexpected end of input"),
+            FromStrError::LongString => f.write_str("character string with more than 255 octets"),
+            FromStrError::BadEscape => f.write_str("illegal escape sequence"),
+            FromStrError::BadSymbol(symbol) => write!(f, "illegal character '{}'", symbol),
+            FromStrError::ShortBuf => ShortBuf.fmt(f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for FromStrError { }
-
+impl std::error::Error for FromStrError {}
 
 //============ Testing ======================================================
 
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod test {
-    use std::vec::Vec;
     use super::*;
+    use std::vec::Vec;
 
     type CharStrRef<'a> = CharStr<&'a [u8]>;
 
     #[test]
     fn from_slice() {
-        assert_eq!(
-            CharStr::from_slice(b"01234").unwrap().as_slice(),
-            b"01234"
-        );
+        assert_eq!(CharStr::from_slice(b"01234").unwrap().as_slice(), b"01234");
         assert_eq!(CharStr::from_slice(b"").unwrap().as_slice(), b"");
         assert!(CharStr::from_slice(&vec![0; 255]).is_ok());
         assert!(CharStr::from_slice(&vec![0; 256]).is_err());
     }
 
     #[test]
-    #[cfg(feature="bytes")]
+    #[cfg(feature = "bytes")]
     fn from_bytes() {
         assert_eq!(
-            CharStr::from_bytes(
-                bytes::Bytes::from_static(b"01234")
-            ).unwrap().as_slice(),
+            CharStr::from_bytes(bytes::Bytes::from_static(b"01234"))
+                .unwrap()
+                .as_slice(),
             b"01234"
         );
         assert_eq!(
-            CharStr::from_bytes(
-                bytes::Bytes::from_static(b"")
-            ).unwrap().as_slice(),
+            CharStr::from_bytes(bytes::Bytes::from_static(b""))
+                .unwrap()
+                .as_slice(),
             b""
         );
         assert!(CharStr::from_bytes(vec![0; 255].into()).is_ok());
@@ -815,9 +808,9 @@ mod test {
 
     fn is_ord(l: &[u8], r: &[u8], order: cmp::Ordering) {
         assert_eq!(
-            CharStr::from_slice(l).unwrap().cmp(
-                &CharStr::from_slice(r).unwrap()
-            ),
+            CharStr::from_slice(l)
+                .unwrap()
+                .cmp(&CharStr::from_slice(r).unwrap()),
             order
         )
     }
@@ -843,9 +836,7 @@ mod test {
         assert_eq!(o.len(), 255);
         assert!(o.append_slice(b"f").is_err());
 
-        let mut o = CharStrBuilder::from_builder(
-            vec![b'f', b'o', b'o']
-        ).unwrap();
+        let mut o = CharStrBuilder::from_builder(vec![b'f', b'o', b'o']).unwrap();
         o.append_slice(b"bar").unwrap();
         assert_eq!(o.as_ref(), b"foobar");
         assert!(o.append_slice(&[0u8; 250][..]).is_err());
@@ -853,4 +844,3 @@ mod test {
         assert_eq!(o.len(), 255);
     }
 }
-

--- a/src/base/cmp.rs
+++ b/src/base/cmp.rs
@@ -19,7 +19,6 @@
 
 use core::cmp::Ordering;
 
-
 /// A trait for the canonical sort order of values.
 ///
 /// The canonical sort order is used in DNS security when multiple values are
@@ -99,4 +98,3 @@ pub trait CanonicalOrd<Rhs: ?Sized = Self> {
         )
     }
 }
-

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -18,13 +18,10 @@
 //! [`HeaderSection`]: struct.HeaderSection.html
 //! [RFC 1035]: https://tools.ietf.org/html/rfc1035
 
-use core::mem;
-use core::convert::TryInto;
 use super::iana::{Opcode, Rcode};
-use super::octets::{
-    Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf
-};
-
+use super::octets::{Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf};
+use core::convert::TryInto;
+use core::mem;
 
 //------------ Header --------------------------------------------------
 
@@ -58,7 +55,7 @@ use super::octets::{
 /// The basic structure and most of the fields re defined in [RFC 1035],
 /// except for the AD and CD flags, which are defined in [RFC 4035].
 ///
-/// [Field Access]: #field-access 
+/// [Field Access]: #field-access
 /// [`for_message_slice`]: #method.for_message_slice
 /// [`for_message_slice_mut`]: #method.for_message_slice_mut
 /// [`new`]: #method.new
@@ -69,7 +66,7 @@ pub struct Header {
     /// The actual header in its wire format representation.
     ///
     /// This means that the ID field is in big endian.
-    inner: [u8; 4]
+    inner: [u8; 4],
 }
 
 /// # Creation and Conversion
@@ -113,7 +110,6 @@ impl Header {
     }
 }
 
-
 /// # Field Access
 ///
 impl Header {
@@ -138,7 +134,9 @@ impl Header {
     }
 
     /// Sets the value of the ID field to a randomly chosen number.
-    pub fn set_random_id(&mut self) { self.set_id(::rand::random()) }
+    pub fn set_random_id(&mut self) {
+        self.set_id(::rand::random())
+    }
 
     /// Returns whether the QR bit is set.
     ///
@@ -146,11 +144,15 @@ impl Header {
     /// a response (`true`). In other words, this bit is actually stating
     /// whether the message is *not* a query. So, perhaps it might be good
     /// to read ‘QR’ as ‘query response.’
-    pub fn qr(self) -> bool { self.get_bit(2, 7) }
+    pub fn qr(self) -> bool {
+        self.get_bit(2, 7)
+    }
 
     /// Sets the value of the QR bit.
     ///
-    pub fn set_qr(&mut self, set: bool) { self.set_bit(2, 7, set) }
+    pub fn set_qr(&mut self, set: bool) {
+        self.set_bit(2, 7, set)
+    }
 
     /// Returns the value of the Opcode field.
     ///
@@ -174,12 +176,16 @@ impl Header {
     ///
     /// Using this bit, a name server generating a response states whether
     /// it is authoritative for the requested domain name, ie., whether this
-    /// response is an *authoritative answer.* The field has no meaning in 
+    /// response is an *authoritative answer.* The field has no meaning in
     /// a query.
-    pub fn aa(self) -> bool { self.get_bit(2, 2) }
+    pub fn aa(self) -> bool {
+        self.get_bit(2, 2)
+    }
 
     /// Sets the value of the AA bit.
-    pub fn set_aa(&mut self, set: bool) { self.set_bit(2, 2, set) }
+    pub fn set_aa(&mut self, set: bool) {
+        self.set_bit(2, 2, set)
+    }
 
     /// Returns whether the TC bit is set.
     ///
@@ -188,10 +194,14 @@ impl Header {
     /// datagram transports such as UDP to signal that the answer didn’t
     /// fit into a response and the query should be tried again using a
     /// stream transport such as TCP.
-    pub fn tc(self) -> bool { self.get_bit(2, 1) }
+    pub fn tc(self) -> bool {
+        self.get_bit(2, 1)
+    }
 
     /// Sets the value of the TC bit.
-    pub fn set_tc(&mut self, set: bool) { self.set_bit(2, 1, set) }
+    pub fn set_tc(&mut self, set: bool) {
+        self.set_bit(2, 1, set)
+    }
 
     /// Returns whether the RD bit is set.
     ///
@@ -199,48 +209,68 @@ impl Header {
     /// server to try and recursively gather a response if it doesn’t have
     /// the data available locally. The bit’s value is copied into the
     /// response.
-    pub fn rd(self) -> bool { self.get_bit(2, 0) }
+    pub fn rd(self) -> bool {
+        self.get_bit(2, 0)
+    }
 
     /// Sets the value of the RD bit.
-    pub fn set_rd(&mut self, set: bool) { self.set_bit(2, 0, set) }
+    pub fn set_rd(&mut self, set: bool) {
+        self.set_bit(2, 0, set)
+    }
 
     /// Returns whether the RA bit is set.
     ///
     /// In a response, the *recursion available* bit denotes whether the
     /// responding name server supports recursion. It has no meaning in
     /// a query.
-    pub fn ra(self) -> bool { self.get_bit(3, 7) }
+    pub fn ra(self) -> bool {
+        self.get_bit(3, 7)
+    }
 
     /// Sets the value of the RA bit.
-    pub fn set_ra(&mut self, set: bool) { self.set_bit(3, 7, set) }
+    pub fn set_ra(&mut self, set: bool) {
+        self.set_bit(3, 7, set)
+    }
 
     /// Returns whether the reserved bit is set.
     ///
     /// This bit must be `false` in all queries and responses.
-    pub fn z(self) -> bool { self.get_bit(3, 6) }
+    pub fn z(self) -> bool {
+        self.get_bit(3, 6)
+    }
 
     /// Sets the value of the reserved bit.
-    pub fn set_z(&mut self, set: bool) { self.set_bit(3, 6, set) }
+    pub fn set_z(&mut self, set: bool) {
+        self.set_bit(3, 6, set)
+    }
 
     /// Returns whether the AD bit is set.
     ///
     /// The *authentic data* bit is used by security-aware recursive name
     /// servers to indicate that it considers all RRsets in its response are
     /// authentic, i.e., have successfully passed DNSSEC validation.
-    pub fn ad(self) -> bool { self.get_bit(3, 5) }
+    pub fn ad(self) -> bool {
+        self.get_bit(3, 5)
+    }
 
     /// Sets the value of the AD bit.
-    pub fn set_ad(&mut self, set: bool) { self.set_bit(3, 5, set) }
+    pub fn set_ad(&mut self, set: bool) {
+        self.set_bit(3, 5, set)
+    }
 
     /// Returns whether the CD bit is set.
     ///
     /// The *checking disabled* bit is used by a security-aware resolver
     /// to indicate that it does not want upstream name servers to perform
     /// verification but rather would like to verify everything itself.
-    pub fn cd(self) -> bool { self.get_bit(3, 4) }
+    pub fn cd(self) -> bool {
+        self.get_bit(3, 4)
+    }
 
     /// Sets the value of the CD bit.
-    pub fn set_cd(&mut self, set: bool) { self.set_bit(3, 4, set) }
+    pub fn set_cd(&mut self, set: bool) {
+        self.set_bit(3, 4, set)
+    }
 
     /// Returns the value of the RCODE field.
     ///
@@ -258,7 +288,6 @@ impl Header {
         self.inner[3] = self.inner[3] & 0xF0 | (rcode.to_int() & 0x0F);
     }
 
-
     //--- Internal helpers
 
     /// Returns the value of the bit at the given position.
@@ -272,11 +301,13 @@ impl Header {
 
     /// Sets or resets the given bit.
     fn set_bit(&mut self, offset: usize, bit: usize, set: bool) {
-        if set { self.inner[offset] |= 1 << bit }
-        else { self.inner[offset] &= !(1 << bit) }
+        if set {
+            self.inner[offset] |= 1 << bit
+        } else {
+            self.inner[offset] &= !(1 << bit)
+        }
     }
-} 
-
+}
 
 //------------ HeaderCounts -------------------------------------------------
 
@@ -315,7 +346,7 @@ pub struct HeaderCounts {
     /// The actual headers in their wire-format representation.
     ///
     /// Ie., all values are stored big endian.
-    inner: [u8; 8]
+    inner: [u8; 8],
 }
 
 /// # Creation and Conversion
@@ -330,16 +361,13 @@ impl HeaderCounts {
     ///
     /// The slice `message` mut be the whole message, i.e., start with the
     /// bytes of the [`Header`](struct.Header.html).
-    /// 
+    ///
     /// # Panics
     ///
     /// This function panics if the octets slice is shorter than 24 octets.
     pub fn for_message_slice(message: &[u8]) -> &Self {
         assert!(message.len() >= mem::size_of::<HeaderSection>());
-        unsafe {
-            &*((message[mem::size_of::<Header>()..].as_ptr())
-                                                      as *const HeaderCounts)
-        }
+        unsafe { &*((message[mem::size_of::<Header>()..].as_ptr()) as *const HeaderCounts) }
     }
 
     /// Creates a mutable counts reference from the octets slice of a message.
@@ -352,10 +380,7 @@ impl HeaderCounts {
     /// This function panics if the octets slice is shorter than 24 octets.
     pub fn for_message_slice_mut(message: &mut [u8]) -> &mut Self {
         assert!(message.len() >= mem::size_of::<HeaderSection>());
-        unsafe {
-            &mut *((message[mem::size_of::<Header>()..].as_ptr())
-                                                         as *mut HeaderCounts)
-        }
+        unsafe { &mut *((message[mem::size_of::<Header>()..].as_ptr()) as *mut HeaderCounts) }
     }
 
     /// Returns a reference to the raw octets slice of the header counts.
@@ -373,7 +398,6 @@ impl HeaderCounts {
         self.as_slice_mut().copy_from_slice(counts.as_slice())
     }
 }
-
 
 /// # Field Access
 ///
@@ -403,7 +427,7 @@ impl HeaderCounts {
                 self.set_qdcount(count);
                 Ok(())
             }
-            None => Err(ShortBuf)
+            None => Err(ShortBuf),
         }
     }
 
@@ -417,7 +441,6 @@ impl HeaderCounts {
         assert!(count > 0);
         self.set_qdcount(count - 1);
     }
-
 
     /// Returns the value of the ANCOUNT field.
     ///
@@ -442,7 +465,7 @@ impl HeaderCounts {
                 self.set_ancount(count);
                 Ok(())
             }
-            None => Err(ShortBuf)
+            None => Err(ShortBuf),
         }
     }
 
@@ -474,13 +497,13 @@ impl HeaderCounts {
     ///
     /// If increasing the counter would result in an overflow, returns an
     /// error.
-    pub fn inc_nscount(&mut self) -> Result<(), ShortBuf>{
+    pub fn inc_nscount(&mut self) -> Result<(), ShortBuf> {
         match self.nscount().checked_add(1) {
             Some(count) => {
                 self.set_nscount(count);
                 Ok(())
             }
-            None => Err(ShortBuf)
+            None => Err(ShortBuf),
         }
     }
 
@@ -512,13 +535,13 @@ impl HeaderCounts {
     ///
     /// If increasing the counter would result in an overflow, returns an
     /// error.
-    pub fn inc_arcount(&mut self) -> Result <(), ShortBuf> {
+    pub fn inc_arcount(&mut self) -> Result<(), ShortBuf> {
         match self.arcount().checked_add(1) {
             Some(count) => {
                 self.set_arcount(count);
                 Ok(())
             }
-            None => Err(ShortBuf)
+            None => Err(ShortBuf),
         }
     }
 
@@ -532,7 +555,6 @@ impl HeaderCounts {
         assert!(count > 0);
         self.set_arcount(count - 1);
     }
-
 
     //--- Count fields in UPDATE messages
 
@@ -587,15 +609,12 @@ impl HeaderCounts {
     pub fn set_adcount(&mut self, value: u16) {
         self.set_arcount(value)
     }
-   
 
     //--- Internal helpers
 
     /// Returns the value of the 16 bit integer starting at a given offset.
     fn get_u16(self, offset: usize) -> u16 {
-        u16::from_be_bytes(
-            self.inner[offset..offset + 2].try_into().unwrap()
-        )
+        u16::from_be_bytes(self.inner[offset..offset + 2].try_into().unwrap())
     }
 
     /// Sets the value of the 16 bit integer starting at a given offset.
@@ -603,7 +622,6 @@ impl HeaderCounts {
         self.inner[offset..offset + 2].copy_from_slice(&value.to_be_bytes())
     }
 }
-
 
 //------------ HeaderSection -------------------------------------------------
 
@@ -623,7 +641,7 @@ impl HeaderCounts {
 /// [`new`]: #method.new
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HeaderSection {
-    inner: [u8; 12]
+    inner: [u8; 12],
 }
 
 /// # Creation and Conversion
@@ -665,7 +683,6 @@ impl HeaderSection {
     }
 }
 
-
 /// # Access to Header and Counts
 ///
 impl HeaderSection {
@@ -676,7 +693,7 @@ impl HeaderSection {
 
     /// Returns a mutable reference to the header.
     pub fn header_mut(&mut self) -> &mut Header {
-        Header::for_message_slice_mut(&mut self. inner)
+        Header::for_message_slice_mut(&mut self.inner)
     }
 
     /// Returns a reference to the header counts.
@@ -689,7 +706,6 @@ impl HeaderSection {
         HeaderCounts::for_message_slice_mut(&mut self.inner)
     }
 }
-
 
 //--- AsRef and AsMut
 
@@ -717,7 +733,6 @@ impl AsMut<HeaderCounts> for HeaderSection {
     }
 }
 
-
 //--- Parse and Compose
 
 impl<Ref: AsRef<[u8]>> Parse<Ref> for HeaderSection {
@@ -733,21 +748,17 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for HeaderSection {
 }
 
 impl Compose for HeaderSection {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&self.inner)
     }
 }
-
 
 //============ Testing ======================================================
 
 #[cfg(test)]
 mod test {
-    use crate::base::iana::{Opcode, Rcode};
     use super::*;
+    use crate::base::iana::{Opcode, Rcode};
 
     #[test]
     #[cfg(feature = "std")]
@@ -756,19 +767,27 @@ mod test {
 
         let header = b"\x01\x02\x00\x00\x12\x34\x56\x78\x9a\xbc\xde\xf0";
         let mut vec = Vec::from(&header[..]);
-        assert_eq!(Header::for_message_slice(header).as_slice(),
-                   b"\x01\x02\x00\x00");
-        assert_eq!(Header::for_message_slice_mut(vec.as_mut()).as_slice(),
-                   b"\x01\x02\x00\x00");
-        assert_eq!(HeaderCounts::for_message_slice(header).as_slice(),
-                   b"\x12\x34\x56\x78\x9a\xbc\xde\xf0");
-        assert_eq!(HeaderCounts::for_message_slice_mut(vec.as_mut()).as_slice(),
-                   b"\x12\x34\x56\x78\x9a\xbc\xde\xf0");
-        assert_eq!(HeaderSection::for_message_slice(header).as_slice(),
-                   header);
-        assert_eq!(HeaderSection::for_message_slice_mut(vec.as_mut())
-                                 .as_slice(),
-                   header);
+        assert_eq!(
+            Header::for_message_slice(header).as_slice(),
+            b"\x01\x02\x00\x00"
+        );
+        assert_eq!(
+            Header::for_message_slice_mut(vec.as_mut()).as_slice(),
+            b"\x01\x02\x00\x00"
+        );
+        assert_eq!(
+            HeaderCounts::for_message_slice(header).as_slice(),
+            b"\x12\x34\x56\x78\x9a\xbc\xde\xf0"
+        );
+        assert_eq!(
+            HeaderCounts::for_message_slice_mut(vec.as_mut()).as_slice(),
+            b"\x12\x34\x56\x78\x9a\xbc\xde\xf0"
+        );
+        assert_eq!(HeaderSection::for_message_slice(header).as_slice(), header);
+        assert_eq!(
+            HeaderSection::for_message_slice_mut(vec.as_mut()).as_slice(),
+            header
+        );
     }
 
     #[test]
@@ -817,7 +836,9 @@ mod test {
 
     #[test]
     fn counts() {
-        let mut c = HeaderCounts { inner: [ 1, 2, 3, 4, 5, 6, 7, 8 ] };
+        let mut c = HeaderCounts {
+            inner: [1, 2, 3, 4, 5, 6, 7, 8],
+        };
         assert_eq!(c.qdcount(), 0x0102);
         assert_eq!(c.ancount(), 0x0304);
         assert_eq!(c.nscount(), 0x0506);
@@ -826,17 +847,19 @@ mod test {
         c.inc_ancount().unwrap();
         c.inc_nscount().unwrap();
         c.inc_arcount().unwrap();
-        assert_eq!(c.inner, [ 1, 3, 3, 5, 5, 7, 7, 9 ]);
+        assert_eq!(c.inner, [1, 3, 3, 5, 5, 7, 7, 9]);
         c.set_qdcount(0x0807);
         c.set_ancount(0x0605);
         c.set_nscount(0x0403);
         c.set_arcount(0x0201);
-        assert_eq!(c.inner, [ 8, 7, 6, 5, 4, 3, 2, 1 ]);
+        assert_eq!(c.inner, [8, 7, 6, 5, 4, 3, 2, 1]);
     }
 
     #[test]
     fn update_counts() {
-        let mut c = HeaderCounts { inner: [ 1, 2, 3, 4, 5, 6, 7, 8 ] };
+        let mut c = HeaderCounts {
+            inner: [1, 2, 3, 4, 5, 6, 7, 8],
+        };
         assert_eq!(c.zocount(), 0x0102);
         assert_eq!(c.prcount(), 0x0304);
         assert_eq!(c.upcount(), 0x0506);
@@ -845,13 +868,13 @@ mod test {
         c.set_prcount(0x0605);
         c.set_upcount(0x0403);
         c.set_adcount(0x0201);
-        assert_eq!(c.inner, [ 8, 7, 6, 5, 4, 3, 2, 1 ]);
+        assert_eq!(c.inner, [8, 7, 6, 5, 4, 3, 2, 1]);
     }
 
     #[test]
     fn inc_qdcount() {
         let mut c = HeaderCounts {
-            inner: [ 0xff,0xfe,0xff,0xff,0xff,0xff,0xff,0xff ]
+            inner: [0xff, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
         };
         assert!(c.inc_qdcount().is_ok());
         assert!(c.inc_qdcount().is_err());
@@ -860,7 +883,7 @@ mod test {
     #[test]
     fn inc_ancount() {
         let mut c = HeaderCounts {
-            inner: [ 0xff,0xff,0xff,0xfe,0xff,0xff,0xff,0xff ]
+            inner: [0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xff, 0xff],
         };
         assert!(c.inc_ancount().is_ok());
         assert!(c.inc_ancount().is_err());
@@ -869,7 +892,7 @@ mod test {
     #[test]
     fn inc_nscount() {
         let mut c = HeaderCounts {
-            inner: [ 0xff,0xff,0xff,0xff,0xff,0xfe,0xff,0xff ]
+            inner: [0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff],
         };
         assert!(c.inc_nscount().is_ok());
         assert!(c.inc_nscount().is_err());
@@ -878,10 +901,9 @@ mod test {
     #[test]
     fn inc_arcount() {
         let mut c = HeaderCounts {
-            inner: [ 0xff, 0xff,0xff,0xff,0xff,0xff,0xff,0xfe ]
+            inner: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe],
         };
         assert!(c.inc_arcount().is_ok());
         assert!(c.inc_arcount().is_err());
     }
 }
-

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -19,7 +19,9 @@
 //! [RFC 1035]: https://tools.ietf.org/html/rfc1035
 
 use super::iana::{Opcode, Rcode};
-use super::octets::{Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf};
+use super::octets::{
+    Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf,
+};
 use core::convert::TryInto;
 use core::mem;
 
@@ -367,7 +369,10 @@ impl HeaderCounts {
     /// This function panics if the octets slice is shorter than 24 octets.
     pub fn for_message_slice(message: &[u8]) -> &Self {
         assert!(message.len() >= mem::size_of::<HeaderSection>());
-        unsafe { &*((message[mem::size_of::<Header>()..].as_ptr()) as *const HeaderCounts) }
+        unsafe {
+            &*((message[mem::size_of::<Header>()..].as_ptr())
+                as *const HeaderCounts)
+        }
     }
 
     /// Creates a mutable counts reference from the octets slice of a message.
@@ -380,7 +385,10 @@ impl HeaderCounts {
     /// This function panics if the octets slice is shorter than 24 octets.
     pub fn for_message_slice_mut(message: &mut [u8]) -> &mut Self {
         assert!(message.len() >= mem::size_of::<HeaderSection>());
-        unsafe { &mut *((message[mem::size_of::<Header>()..].as_ptr()) as *mut HeaderCounts) }
+        unsafe {
+            &mut *((message[mem::size_of::<Header>()..].as_ptr())
+                as *mut HeaderCounts)
+        }
     }
 
     /// Returns a reference to the raw octets slice of the header counts.
@@ -748,7 +756,10 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for HeaderSection {
 }
 
 impl Compose for HeaderSection {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.inner)
     }
 }
@@ -783,7 +794,10 @@ mod test {
             HeaderCounts::for_message_slice_mut(vec.as_mut()).as_slice(),
             b"\x12\x34\x56\x78\x9a\xbc\xde\xf0"
         );
-        assert_eq!(HeaderSection::for_message_slice(header).as_slice(), header);
+        assert_eq!(
+            HeaderSection::for_message_slice(header).as_slice(),
+            header
+        );
         assert_eq!(
             HeaderSection::for_message_slice_mut(vec.as_mut()).as_slice(),
             header

--- a/src/base/iana/class.rs
+++ b/src/base/iana/class.rs
@@ -1,6 +1,5 @@
 //! DNS CLASSes.
 
-
 //------------ Class ---------------------------------------------------------
 
 int_enum! {
@@ -28,34 +27,33 @@ int_enum! {
     Class, u16;
 
     /// Internet (IN).
-    /// 
+    ///
     /// This class is defined in RFC 1035 and really the only one relevant
     /// at all.
     (In => 1, b"IN")
 
     /// Chaosnet (CH).
-    /// 
+    ///
     /// A network protocol developed at MIT in the 1970s. Reused by BIND for
     /// built-in server information zones.",
     (Ch => 3, b"CH")
 
     /// Hesiod (HS).
-    /// 
+    ///
     /// A system information protocol part of MIT's Project Athena.",
     (Hs => 4, b"HS")
 
     /// Query class None.
-    /// 
+    ///
     /// Defined in RFC 2136, this class is used in UPDATE queries to
     /// require that an RRset does not exist prior to the update.",
     (None => 0xFE, b"NONE")
 
     /// Query class * (ANY).
-    /// 
+    ///
     /// This class can be used in a query to indicate that records for the
     /// given name from any class are requested.",
     (Any => 0xFF, b"*")
 }
 
 int_enum_str_with_prefix!(Class, "CLASS", b"CLASS", u16, "unknown class");
-

--- a/src/base/iana/digestalg.rs
+++ b/src/base/iana/digestalg.rs
@@ -1,9 +1,8 @@
 //! Delegation signer digest algorithm numbers.
 
-
 //------------ DigestAlg -----------------------------------------------------
 
-int_enum!{
+int_enum! {
     /// Delegation signer digest algorithm numbers.
     ///
     /// These numbers are used in the DS resource record to specify how the
@@ -44,4 +43,3 @@ int_enum!{
 }
 
 int_enum_str_decimal!(DigestAlg, u8);
-

--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -258,7 +258,8 @@ macro_rules! int_enum_str_decimal {
                 scanner.scan_string_word(|word| {
                     use ::std::str::FromStr;
 
-                    Self::from_str(&word).map_err($crate::master::scan::SyntaxError::content)
+                    Self::from_str(&word)
+                        .map_err($crate::master::scan::SyntaxError::content)
                 })
             }
         }
@@ -335,8 +336,9 @@ macro_rules! int_enum_str_with_decimal {
                 scanner: &mut $crate::master::scan::Scanner<C>,
             ) -> Result<Self, $crate::master::scan::ScanError> {
                 scanner.scan_string_word(|word| {
-                    core::str::FromStr::from_str(&word)
-                        .map_err(|_| $crate::master::scan::SyntaxError::UnknownMnemonic)
+                    core::str::FromStr::from_str(&word).map_err(|_| {
+                        $crate::master::scan::SyntaxError::UnknownMnemonic
+                    })
                 })
             }
         }
@@ -384,7 +386,9 @@ macro_rules! int_enum_str_with_prefix {
                 match $ianatype::from_mnemonic(s.as_bytes()) {
                     Some(res) => Ok(res),
                     None => {
-                        if let Some((n, _)) = s.char_indices().nth($str_prefix.len()) {
+                        if let Some((n, _)) =
+                            s.char_indices().nth($str_prefix.len())
+                        {
                             let (l, r) = s.split_at(n);
                             if l.eq_ignore_ascii_case($str_prefix) {
                                 let value = match u16::from_str_radix(r, 10) {
@@ -429,8 +433,9 @@ macro_rules! int_enum_str_with_prefix {
                 scanner.scan_string_word(|word| {
                     use ::std::str::FromStr;
 
-                    Self::from_str(&word)
-                        .map_err(|_| $crate::master::scan::SyntaxError::UnknownMnemonic)
+                    Self::from_str(&word).map_err(|_| {
+                        $crate::master::scan::SyntaxError::UnknownMnemonic
+                    })
                 })
             }
         }

--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -4,7 +4,7 @@
 ///
 /// This adds impls for `From`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and
 /// `Hash`.
-/// 
+///
 /// For `FromStr` and `Display`, see one of the other macros in this module.
 macro_rules! int_enum {
     ( $(#[$attr:meta])* =>
@@ -15,7 +15,7 @@ macro_rules! int_enum {
         #[derive(Clone, Copy, Debug)]
         pub enum $ianatype {
             $( $(#[$variant_attr])* $variant ),*,
-            
+
             /// A raw value given through its integer.
             Int($inttype)
         }
@@ -232,11 +232,11 @@ macro_rules! int_enum_str_mnemonics_only {
 /// only print the decimal values.
 macro_rules! int_enum_str_decimal {
     ($ianatype:ident, $inttype:ident) => {
-        
         impl $ianatype {
             pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
                 core::str::from_utf8(bytes).ok().and_then(|r| {
-                    $inttype::from_str_radix(r, 10).ok()
+                    $inttype::from_str_radix(r, 10)
+                        .ok()
                         .map($ianatype::from_int)
                 })
             }
@@ -250,30 +250,26 @@ macro_rules! int_enum_str_decimal {
             }
         }
 
-        #[cfg(feature="master")]
+        #[cfg(feature = "master")]
         impl $crate::master::scan::Scan for $ianatype {
             fn scan<C: $crate::master::scan::CharSource>(
-                scanner: &mut $crate::master::scan::Scanner<C>
+                scanner: &mut $crate::master::scan::Scanner<C>,
             ) -> Result<Self, $crate::master::scan::ScanError> {
                 scanner.scan_string_word(|word| {
                     use ::std::str::FromStr;
 
-                    Self::from_str(&word)
-                         .map_err($crate::master::scan::SyntaxError::content)
+                    Self::from_str(&word).map_err($crate::master::scan::SyntaxError::content)
                 })
             }
         }
 
         impl core::fmt::Display for $ianatype {
-            fn fmt(
-                &self, f: &mut core::fmt::Formatter
-            ) -> core::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "{}", self.to_int())
             }
         }
-    }
+    };
 }
-
 
 /// Adds impls for `FromStr` and `Display` to the type given as first argument.
 ///
@@ -288,13 +284,14 @@ macro_rules! int_enum_str_with_decimal {
             pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
                 $ianatype::from_mnemonic(bytes).or_else(|| {
                     core::str::from_utf8(bytes).ok().and_then(|r| {
-                        $inttype::from_str_radix(r, 10).ok()
+                        $inttype::from_str_radix(r, 10)
+                            .ok()
                             .map($ianatype::from_int)
                     })
                 })
             }
         }
-                                        
+
         impl core::str::FromStr for $ianatype {
             type Err = FromStrError;
 
@@ -306,8 +303,7 @@ macro_rules! int_enum_str_with_decimal {
                     None => {
                         if let Ok(res) = $inttype::from_str_radix(s, 10) {
                             Ok($ianatype::Int(res))
-                        }
-                        else {
+                        } else {
                             Err(FromStrError)
                         }
                     }
@@ -316,8 +312,7 @@ macro_rules! int_enum_str_with_decimal {
         }
 
         impl core::fmt::Display for $ianatype {
-            fn fmt(&self, f: &mut core::fmt::Formatter)
-                   -> core::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 use core::fmt::Write;
 
                 match self.to_mnemonic() {
@@ -334,21 +329,20 @@ macro_rules! int_enum_str_with_decimal {
             }
         }
 
-        #[cfg(feature="master")]
+        #[cfg(feature = "master")]
         impl $crate::master::scan::Scan for $ianatype {
             fn scan<C: $crate::master::scan::CharSource>(
-                scanner: &mut $crate::master::scan::Scanner<C>
+                scanner: &mut $crate::master::scan::Scanner<C>,
             ) -> Result<Self, $crate::master::scan::ScanError> {
                 scanner.scan_string_word(|word| {
-                    core::str::FromStr::from_str(&word).map_err(|_| {
-                        $crate::master::scan::SyntaxError::UnknownMnemonic
-                    })
+                    core::str::FromStr::from_str(&word)
+                        .map_err(|_| $crate::master::scan::SyntaxError::UnknownMnemonic)
                 })
             }
         }
 
         from_str_error!($error);
-    }
+    };
 }
 
 /// Adds impls for `FromStr` and `Display` to the type given as first argument.
@@ -366,15 +360,15 @@ macro_rules! int_enum_str_with_prefix {
             pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
                 $ianatype::from_mnemonic(bytes).or_else(|| {
                     if bytes.len() <= $u8_prefix.len() {
-                        return None
+                        return None;
                     }
                     let (l, r) = bytes.split_at($u8_prefix.len());
                     if !l.eq_ignore_ascii_case($u8_prefix) {
-                        return None
+                        return None;
                     }
                     let r = match core::str::from_utf8(r) {
                         Ok(r) => r,
-                        Err(_) => return None
+                        Err(_) => return None,
                     };
                     u16::from_str_radix(r, 10).ok().map($ianatype::from_int)
                 })
@@ -390,21 +384,18 @@ macro_rules! int_enum_str_with_prefix {
                 match $ianatype::from_mnemonic(s.as_bytes()) {
                     Some(res) => Ok(res),
                     None => {
-                        if let Some((n, _)) = s.char_indices()
-                                               .nth($str_prefix.len()) {
+                        if let Some((n, _)) = s.char_indices().nth($str_prefix.len()) {
                             let (l, r) = s.split_at(n);
                             if l.eq_ignore_ascii_case($str_prefix) {
                                 let value = match u16::from_str_radix(r, 10) {
                                     Ok(x) => x,
-                                    Err(..) => return Err(FromStrError)
+                                    Err(..) => return Err(FromStrError),
                                 };
                                 Ok($ianatype::from_int(value))
-                            }
-                            else {
+                            } else {
                                 Err(FromStrError)
                             }
-                        }
-                        else {
+                        } else {
                             Err(FromStrError)
                         }
                     }
@@ -413,8 +404,7 @@ macro_rules! int_enum_str_with_prefix {
         }
 
         impl core::fmt::Display for $ianatype {
-            fn fmt(&self, f: &mut core::fmt::Formatter)
-                   -> core::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 use core::fmt::Write;
 
                 match self.to_mnemonic() {
@@ -431,24 +421,22 @@ macro_rules! int_enum_str_with_prefix {
             }
         }
 
-        #[cfg(feature="master")]
+        #[cfg(feature = "master")]
         impl $crate::master::scan::Scan for $ianatype {
             fn scan<C: $crate::master::scan::CharSource>(
-                scanner: &mut $crate::master::scan::Scanner<C>
+                scanner: &mut $crate::master::scan::Scanner<C>,
             ) -> Result<Self, $crate::master::scan::ScanError> {
                 scanner.scan_string_word(|word| {
                     use ::std::str::FromStr;
 
                     Self::from_str(&word)
-                         .map_err(|_| {
-                             $crate::master::scan::SyntaxError::UnknownMnemonic
-                         })
+                        .map_err(|_| $crate::master::scan::SyntaxError::UnknownMnemonic)
                 })
             }
         }
 
         from_str_error!($error);
-    }
+    };
 }
 
 macro_rules! from_str_error {
@@ -459,16 +447,14 @@ macro_rules! from_str_error {
         #[cfg(feature = "std")]
         impl std::error::Error for FromStrError {
             fn description(&self) -> &str {
-               $description
+                $description
             }
         }
 
         impl core::fmt::Display for FromStrError {
-            fn fmt(
-                &self, f: &mut core::fmt::Formatter
-            ) -> core::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 $description.fmt(f)
             }
         }
-    }
+    };
 }

--- a/src/base/iana/mod.rs
+++ b/src/base/iana/mod.rs
@@ -31,12 +31,12 @@ pub use self::exterr::ExtendedErrorCode;
 pub use self::nsec3::Nsec3HashAlg;
 pub use self::opcode::Opcode;
 pub use self::opt::OptionCode;
-pub use self::rcode::{Rcode, OptRcode, TsigRcode};
+pub use self::rcode::{OptRcode, Rcode, TsigRcode};
 pub use self::rtype::Rtype;
 pub use self::secalg::SecAlg;
 
-
-#[macro_use] mod macros;
+#[macro_use]
+mod macros;
 
 pub mod class;
 pub mod digestalg;
@@ -47,4 +47,3 @@ pub mod opt;
 pub mod rcode;
 pub mod rtype;
 pub mod secalg;
-

--- a/src/base/iana/nsec3.rs
+++ b/src/base/iana/nsec3.rs
@@ -1,9 +1,8 @@
 //! NSEC3 hash algorithms.
 
-
 //------------ Nsec3HashAlg --------------------------------------------------
 
-int_enum!{
+int_enum! {
     /// NSEC3 hash algorithm numbers.
     ///
     /// This type selects the algorithm used to hash domain names for use with
@@ -22,4 +21,3 @@ int_enum!{
 }
 
 int_enum_str_decimal!(Nsec3HashAlg, u8);
-

--- a/src/base/iana/opcode.rs
+++ b/src/base/iana/opcode.rs
@@ -1,9 +1,8 @@
 //! DNS OpCodes.
 
-
 //------------ Opcode --------------------------------------------------------
 
-int_enum!{
+int_enum! {
     /// DNS OpCodes.
     ///
     /// The opcode specifies the kind of query to be performed.
@@ -83,4 +82,3 @@ int_enum!{
 }
 
 int_enum_str_with_decimal!(Opcode, u8, "unknown opcode");
-

--- a/src/base/iana/opt.rs
+++ b/src/base/iana/opt.rs
@@ -171,4 +171,3 @@ int_enum! {
 }
 
 int_enum_str_with_decimal!(OptionCode, u16, "unknown option code");
-

--- a/src/base/iana/rcode.rs
+++ b/src/base/iana/rcode.rs
@@ -19,7 +19,6 @@
 
 use core::{cmp, fmt, hash};
 
-
 //------------ Rcode --------------------------------------------------------
 
 /// DNS Response Codes.
@@ -163,7 +162,7 @@ pub enum Rcode {
     /// A raw, integer rcode value.
     ///
     /// When converting to an `u8`, only the lower four bits are used.
-    Int(u8)
+    Int(u8),
 }
 
 impl Rcode {
@@ -185,7 +184,7 @@ impl Rcode {
             8 => NXRRSet,
             9 => NotAuth,
             10 => NotZone,
-            value => Int(value)
+            value => Int(value),
         }
     }
 
@@ -205,22 +204,24 @@ impl Rcode {
             NXRRSet => 8,
             NotAuth => 9,
             NotZone => 10,
-            Int(value) => value & 0x0F
+            Int(value) => value & 0x0F,
         }
     }
 }
 
-
 //--- From
 
 impl From<u8> for Rcode {
-    fn from(value: u8) -> Rcode { Rcode::from_int(value) }
+    fn from(value: u8) -> Rcode {
+        Rcode::from_int(value)
+    }
 }
 
 impl From<Rcode> for u8 {
-    fn from(value: Rcode) -> u8 { value.to_int() }
+    fn from(value: Rcode) -> u8 {
+        value.to_int()
+    }
 }
-
 
 //--- Display
 
@@ -240,16 +241,13 @@ impl fmt::Display for Rcode {
             NXRRSet => "NXRRSET".fmt(f),
             NotAuth => "NOAUTH".fmt(f),
             NotZone => "NOTZONE".fmt(f),
-            Int(i) => {
-                match Rcode::from_int(i) {
-                    Rcode::Int(i) => i.fmt(f),
-                    value => value.fmt(f)
-                }
-            }
+            Int(i) => match Rcode::from_int(i) {
+                Rcode::Int(i) => i.fmt(f),
+                value => value.fmt(f),
+            },
         }
     }
 }
-
 
 //--- PartialEq and Eq
 
@@ -271,8 +269,7 @@ impl cmp::PartialEq<Rcode> for u8 {
     }
 }
 
-impl cmp::Eq for Rcode { }
-
+impl cmp::Eq for Rcode {}
 
 //--- PartialOrd and Ord
 
@@ -300,7 +297,6 @@ impl cmp::Ord for Rcode {
     }
 }
 
-
 //--- Hash
 
 impl hash::Hash for Rcode {
@@ -308,7 +304,6 @@ impl hash::Hash for Rcode {
         self.to_int().hash(state)
     }
 }
-
 
 //------------ OptRcode -----------------------------------------------------
 
@@ -465,7 +460,6 @@ pub enum OptRcode {
 
     // XXX We will not define the values from the TSIG and TKEY RFCs,
     //     unless are used in OPT records, too?
-
     /// Bad or missing server cookie.
     ///
     /// The request contained a COOKIE option either without a server cookie
@@ -480,9 +474,8 @@ pub enum OptRcode {
     ///
     /// When converting to a 12 bit code, the upper four bits are simply
     /// ignored.
-    Int(u16)
+    Int(u16),
 }
-
 
 impl OptRcode {
     /// Creates an rcode from an integer.
@@ -505,7 +498,7 @@ impl OptRcode {
             10 => NotZone,
             16 => BadVers,
             23 => BadCookie,
-            value => Int(value)
+            value => Int(value),
         }
     }
 
@@ -527,15 +520,13 @@ impl OptRcode {
             NotZone => 10,
             BadVers => 16,
             BadCookie => 23,
-            Int(value) => value & 0x0F
+            Int(value) => value & 0x0F,
         }
     }
 
     /// Creates an extended rcode value from its parts.
     pub fn from_parts(rcode: Rcode, ext: u8) -> OptRcode {
-        OptRcode::from_int(
-            u16::from(ext) << 4 | u16::from(rcode.to_int())
-        )
+        OptRcode::from_int(u16::from(ext) << 4 | u16::from(rcode.to_int()))
     }
 
     /// Returns the two parts of an extended rcode value.
@@ -555,21 +546,25 @@ impl OptRcode {
     }
 }
 
-
 //--- From
 
 impl From<u16> for OptRcode {
-    fn from(value: u16) -> OptRcode { OptRcode::from_int(value) }
+    fn from(value: u16) -> OptRcode {
+        OptRcode::from_int(value)
+    }
 }
 
 impl From<OptRcode> for u16 {
-    fn from(value: OptRcode) -> u16 { value.to_int() }
+    fn from(value: OptRcode) -> u16 {
+        value.to_int()
+    }
 }
 
 impl From<Rcode> for OptRcode {
-    fn from(value: Rcode) -> OptRcode { OptRcode::from_parts(value, 0) }
+    fn from(value: Rcode) -> OptRcode {
+        OptRcode::from_parts(value, 0)
+    }
 }
-
 
 //--- Display
 
@@ -591,21 +586,17 @@ impl fmt::Display for OptRcode {
             NotZone => "NOTZONE".fmt(f),
             BadVers => "BADVER".fmt(f),
             BadCookie => "BADCOOKIE".fmt(f),
-            Int(i) => {
-                match OptRcode::from_int(i) {
-                    Int(i) => i.fmt(f),
-                    value => value.fmt(f)
-                }
-            }
+            Int(i) => match OptRcode::from_int(i) {
+                Int(i) => i.fmt(f),
+                value => value.fmt(f),
+            },
         }
     }
 }
 
-
-
 //------------ TsigRcode ----------------------------------------------------
 
-int_enum!{
+int_enum! {
     /// Response codes for transaction authentication (TSIG).
     ///
     /// TSIG and TKEY resource records contain a 16 bit wide error field whose
@@ -817,7 +808,6 @@ int_enum!{
     /// [RFC 7873]: https://tools.ietf.org/html/rfc7873
     (BadCookie => 23, b"BADCOOKIE")
 }
-
 
 //--- From
 

--- a/src/base/iana/rtype.rs
+++ b/src/base/iana/rtype.rs
@@ -1,9 +1,8 @@
 //! Resource Record (RR) TYPEs
 
-
 //------------ Rtype ---------------------------------------------------------
 
-int_enum!{
+int_enum! {
     /// Resource Record Types.
     ///
     /// Each resource records has a 16 bit type value indicating what kind of
@@ -16,7 +15,7 @@ int_enum!{
     /// This type is complete as of 2019-01-28.
     ///
     /// [IANA registry]: http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
-    /// 
+    ///
     /// In order to avoid confusion over capitalization, the mnemonics are
     /// treated as single acronyms and therefore all variant names are spelled
     /// with an initial capital letter in accordance with the Rust naming
@@ -60,7 +59,7 @@ int_enum!{
     ///
     /// (Experimental.)
     (Mr => 9, b"MR")
-    
+
     /// A null resource record.
     ///
     /// (Experimental.)
@@ -83,7 +82,7 @@ int_enum!{
 
     /// Text strings.
     (Txt => 16, b"TXT")
-    
+
     /// For Responsible Person.
     ///
     /// See RFC 1183
@@ -113,7 +112,7 @@ int_enum!{
     ///
     /// See RFC 1706.
     (Nsap => 22, b"NSAP")
-    
+
     /// For domain name pointer, NSAP style.
     ///
     /// See RFC 1348, RFC 1637, RFC 1706.
@@ -134,7 +133,7 @@ int_enum!{
     ///
     /// See RFC 1712
     (Gpos => 27, b"GPOS")
-    
+
     /// IPv6 address.
     ///
     /// See RFC 3596.
@@ -250,7 +249,7 @@ int_enum!{
     ///
     /// See RFC 5155.
     (Nsec3param => 51, b"NSEC3PARAM")
-    
+
     /// TLSA.
     ///
     /// See RFC 6698.
@@ -284,7 +283,7 @@ int_enum!{
     ///
     /// See RFC 7344.
     (Cdnskey => 60, b"CDNSKEY")
-    
+
     /// OpenPGP key.
     ///
     /// See draft-ietf-dane-openpgpkey.
@@ -309,7 +308,7 @@ int_enum!{
     ///
     /// IANA-Reserved.
     (Uinfo => 100, b"UINFO")
-    
+
     /// UID.
     ///
     /// IANA-Reserved.
@@ -354,12 +353,12 @@ int_enum!{
     ///
     /// See RFC 7043.
     (Eui64 => 109, b"EUI64")
-    
+
     /// Transaction key.
     ///
     /// See RFC 2930.
     (Tkey => 249, b"TKEY")
-    
+
     /// Transaction signature.
     ///
     /// See RFC 2845.
@@ -369,7 +368,7 @@ int_enum!{
     ///
     /// See RFC 1995.
     (Ixfr => 251, b"IXFR")
-    
+
     /// Transfer of entire zone.
     ///
     /// See RFC 1035 and RFC 5936.
@@ -415,7 +414,4 @@ int_enum!{
     (Dlv => 32769, b"DLV")
 }
 
-int_enum_str_with_prefix!(
-    Rtype, "TYPE", b"TYPE", u16, "unknown record type"
-);
-
+int_enum_str_with_prefix!(Rtype, "TYPE", b"TYPE", u16, "unknown record type");

--- a/src/base/iana/secalg.rs
+++ b/src/base/iana/secalg.rs
@@ -1,9 +1,8 @@
 //! DNSSEC Algorithm Numbers
 
-
 //------------ SecAlg -------------------------------------------------------
 
-int_enum!{
+int_enum! {
     /// Security Algorithm Numbers.
     ///
     /// These numbers are used in various security related record types.
@@ -118,4 +117,3 @@ int_enum!{
 }
 
 int_enum_str_with_decimal!(SecAlg, u8, "unknown algorithm");
-

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -10,21 +10,18 @@
 //!
 //! [`Message`]: struct.Message.html
 
-use core::{fmt, mem};
-use core::marker::PhantomData;
 use super::header::{Header, HeaderCounts, HeaderSection};
 use super::iana::{Class, Rcode, Rtype};
 use super::message_builder::{AdditionalBuilder, AnswerBuilder};
 use super::name::ParsedDname;
-use super::octets::{
-    OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf
-};
+use super::octets::{OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf};
 use super::opt::{Opt, OptRecord};
 use super::question::Question;
 use super::rdata::ParseRecordData;
 use super::record::{AsRecord, ParsedRecord, Record};
 use crate::rdata::rfc1035::Cname;
-
+use core::marker::PhantomData;
+use core::{fmt, mem};
 
 //------------ Message -------------------------------------------------------
 
@@ -44,7 +41,7 @@ use crate::rdata::rfc1035::Cname;
 ///
 /// The header section is of a fixed sized and can be accessed at any time
 /// through the methods given under [Header Section]. Most likely, you will
-/// be interested in the first part of the header which is 
+/// be interested in the first part of the header which is
 /// returned by the [`header`] method.  The second part of the header
 /// section contains the number of entries in the following four sections
 /// and is of less interest as there are more sophisticated ways of accessing
@@ -65,11 +62,11 @@ use crate::rdata::rfc1035::Cname;
 ///
 /// You can acquire an iterator over the questions through the [`question`]
 /// method. It returns a [`QuestionSection`] value that is an iterator over
-/// questions. Since a single question is such a common case, there is a 
+/// questions. Since a single question is such a common case, there is a
 /// convenience method [`first_question`] that returns the first question
 /// only.
 ///
-/// The following three section all contain DNS resource records. In 
+/// The following three section all contain DNS resource records. In
 /// queries, they are empty in a request and may or may not contain records
 /// in a response. The *answer* section contains all the records that answer
 /// the given question. The *authority* section contains records declaring
@@ -81,7 +78,7 @@ use crate::rdata::rfc1035::Cname;
 /// may include these right away and free of charge.
 ///
 /// There are functions to access all three sections directly: [`answer`],
-/// [`authority`], and [`additional`]. Each method returns a value of type 
+/// [`authority`], and [`additional`]. Each method returns a value of type
 /// [RecordSection] which acts as an iterator over the records in the
 /// section. Since there are no pointers to where the later sections start,
 /// accessing them directly means iterating over the previous sections. This
@@ -153,7 +150,7 @@ use crate::rdata::rfc1035::Cname;
 /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
 #[derive(Clone, Copy)]
 pub struct Message<Octets> {
-    octets: Octets
+    octets: Octets,
 }
 
 /// # Creation and Conversion
@@ -166,11 +163,12 @@ impl<Octets> Message<Octets> {
     /// function returns ok, the message may still be broken with other
     /// methods returning errors later one.
     pub fn from_octets(octets: Octets) -> Result<Self, ShortBuf>
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         if octets.as_ref().len() < mem::size_of::<HeaderSection>() {
             Err(ShortBuf)
-        }
-        else {
+        } else {
             Ok(unsafe { Self::from_octets_unchecked(octets) })
         }
     }
@@ -195,7 +193,9 @@ impl<Octets> Message<Octets> {
 
     /// Returns a slice to the underlying octets sequence.
     pub fn as_slice(&self) -> &[u8]
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         self.octets.as_ref()
     }
 
@@ -204,17 +204,20 @@ impl<Octets> Message<Octets> {
     /// Because it is possible to utterly break the message using this slice,
     /// the method is private.
     fn as_slice_mut(&mut self) -> &mut [u8]
-    where Octets: AsMut<[u8]> {
+    where
+        Octets: AsMut<[u8]>,
+    {
         self.octets.as_mut()
     }
 
     /// Returns a message for a slice of the octets sequence.
     pub fn for_slice(&self) -> Message<&[u8]>
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         unsafe { Message::from_octets_unchecked(self.octets.as_ref()) }
     }
 }
-
 
 /// # Header Section
 ///
@@ -223,10 +226,12 @@ impl<Octets: AsRef<[u8]>> Message<Octets> {
     pub fn header(&self) -> Header {
         *Header::for_message_slice(self.as_slice())
     }
-    
+
     /// Returns a mutable reference to the message header.
     pub fn header_mut(&mut self) -> &mut Header
-    where Octets: AsMut<[u8]> {
+    where
+        Octets: AsMut<[u8]>,
+    {
         Header::for_message_slice_mut(self.as_slice_mut())
     }
 
@@ -254,7 +259,9 @@ impl<Octets: AsRef<[u8]>> Message<Octets> {
 /// # Access to Sections
 ///
 impl<Octets> Message<Octets>
-where for<'a> &'a Octets: OctetsRef {
+where
+    for<'a> &'a Octets: OctetsRef,
+{
     /// Returns the question section.
     pub fn question(&self) -> QuestionSection<&Octets> {
         QuestionSection::new(&self.octets)
@@ -317,13 +324,15 @@ where for<'a> &'a Octets: OctetsRef {
     /// Returns all four sections in one fell swoop.
     #[allow(clippy::type_complexity)]
     pub fn sections(
-        &self
+        &self,
     ) -> Result<
         (
-            QuestionSection<&Octets>, RecordSection<&Octets>,
-            RecordSection<&Octets>, RecordSection<&Octets>
+            QuestionSection<&Octets>,
+            RecordSection<&Octets>,
+            RecordSection<&Octets>,
+            RecordSection<&Octets>,
         ),
-        ParseError
+        ParseError,
     > {
         let question = self.question();
         let answer = question.clone().next_section()?;
@@ -347,13 +356,12 @@ where for<'a> &'a Octets: OctetsRef {
     }
 }
 
-
 /// # Helpers for Common Tasks
 ///
 impl<Octets> Message<Octets>
 where
     Octets: AsRef<[u8]>,
-    for<'a> &'a Octets: OctetsRef
+    for<'a> &'a Octets: OctetsRef,
 {
     /// Returns whether this is the answer to some other message.
     ///
@@ -363,16 +371,16 @@ where
     pub fn is_answer<Other>(&self, query: &Message<Other>) -> bool
     where
         Other: AsRef<[u8]>,
-        for <'o> &'o Other: OctetsRef
+        for<'o> &'o Other: OctetsRef,
     {
         if !self.header().qr()
             || self.header().id() != query.header().id()
-            || self.header_counts().qdcount()
-                != query.header_counts().qdcount()
+            || self.header_counts().qdcount() != query.header_counts().qdcount()
         {
             false
+        } else {
+            self.question() == query.question()
         }
-        else { self.question() == query.question() }
     }
 
     /// Returns the first question, if there is any.
@@ -382,7 +390,7 @@ where
     pub fn first_question(&self) -> Option<Question<ParsedDname<&Octets>>> {
         match self.question().next() {
             None | Some(Err(..)) => None,
-            Some(Ok(question)) => Some(question)
+            Some(Ok(question)) => Some(question),
         }
     }
 
@@ -392,17 +400,14 @@ where
     /// exactly one question or there is a parse error.
     ///
     /// [`first_question`]: #method.first_question
-    pub fn sole_question(
-        &self
-    ) -> Result<Question<ParsedDname<&Octets>>, ParseError> {
+    pub fn sole_question(&self) -> Result<Question<ParsedDname<&Octets>>, ParseError> {
         match self.header_counts().qdcount() {
             0 => return Err(ParseError::form_error("no question")),
-            1 => { }
+            1 => {}
             _ => return Err(ParseError::form_error("multiple questions")),
         }
         self.question().next().unwrap()
     }
-
 
     /// Returns the query type of the first question, if any.
     pub fn qtype(&self) -> Option<Rtype> {
@@ -411,10 +416,12 @@ where
 
     /// Returns whether the message contains answers of a given type.
     pub fn contains_answer<'s, Data>(&'s self) -> bool
-    where Data: ParseRecordData<&'s Octets> {
+    where
+        Data: ParseRecordData<&'s Octets>,
+    {
         let answer = match self.answer() {
             Ok(answer) => answer,
-            Err(..) => return false
+            Err(..) => return false,
         };
         answer.limit_to::<Data>().next().is_some()
     }
@@ -443,7 +450,7 @@ where
     pub fn canonical_name(&self) -> Option<ParsedDname<&Octets>> {
         let question = match self.first_question() {
             None => return None,
-            Some(question) => question
+            Some(question) => question,
         };
         let mut name = question.into_qname();
         let answer = match self.answer() {
@@ -465,10 +472,10 @@ where
                 }
             }
             if !found {
-                return Some(name)
+                return Some(name);
             }
         }
-        
+
         None
     }
 
@@ -478,7 +485,7 @@ where
             Ok(section) => match section.limit_to::<Opt<_>>().next() {
                 Some(Ok(rr)) => Some(OptRecord::from(rr)),
                 _ => None,
-            }
+            },
             Err(_) => None,
         }
     }
@@ -492,18 +499,18 @@ where
     /// If the last record is of the wrong type or parsing fails, returns
     /// `None`.
     pub fn get_last_additional<'s, Data: ParseRecordData<&'s Octets>>(
-        &'s self
+        &'s self,
     ) -> Option<Record<ParsedDname<&'s Octets>, Data>> {
         let mut section = match self.additional() {
             Ok(section) => section,
-            Err(_) => return None
+            Err(_) => return None,
         };
         loop {
             match section.count {
                 Err(_) => return None,
                 Ok(0) => return None,
                 Ok(1) => break,
-                _ => { }
+                _ => {}
             }
             let _ = section.next();
         }
@@ -513,7 +520,7 @@ where
         };
         let record = match record.into_record() {
             Ok(Some(record)) => record,
-            _ => return None
+            _ => return None,
         };
         Some(record)
     }
@@ -527,10 +534,10 @@ where
     ///
     /// The method panics if the additional section is empty.
     pub fn remove_last_additional(&mut self)
-    where Octets: AsMut<[u8]> {
-        HeaderCounts::for_message_slice_mut(
-            self.octets.as_mut()
-        ).dec_arcount();
+    where
+        Octets: AsMut<[u8]>,
+    {
+        HeaderCounts::for_message_slice_mut(self.octets.as_mut()).dec_arcount();
     }
 
     /// Copy records from a message into the target message builder.
@@ -541,14 +548,14 @@ where
     pub fn copy_records<'s, R, F, T, O>(
         &'s self,
         target: T,
-        mut op: F
+        mut op: F,
     ) -> Result<AdditionalBuilder<O>, CopyRecordsError>
     where
-        for <'a> &'a Octets: OctetsRef,
+        for<'a> &'a Octets: OctetsRef,
         R: AsRecord + 's,
         F: FnMut(ParsedRecord<&'s Octets>) -> Option<R>,
         T: Into<AnswerBuilder<O>>,
-        O: OctetsBuilder
+        O: OctetsBuilder,
     {
         let mut source = self.answer()?;
         let mut target = target.into();
@@ -581,7 +588,6 @@ where
     }
 }
 
-
 //--- AsRef
 
 impl<Octets> AsRef<Octets> for Message<Octets> {
@@ -596,33 +602,33 @@ impl<Octets: AsRef<[u8]>> AsRef<[u8]> for Message<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Message<SrcOctets>> for Message<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Message<SrcOctets>) -> Result<Self, ShortBuf> {
-        Octets::octets_from(source.octets).map(|octets| {
-            unsafe {
-                Self::from_octets_unchecked(octets)
-            }
-        })
+        Octets::octets_from(source.octets)
+            .map(|octets| unsafe { Self::from_octets_unchecked(octets) })
     }
 }
-
 
 //--- IntoIterator
 
 impl<'a, Octets> IntoIterator for &'a Message<Octets>
-where for<'s> &'s Octets: OctetsRef {
+where
+    for<'s> &'s Octets: OctetsRef,
+{
     type Item = Result<(ParsedRecord<&'a Octets>, Section), ParseError>;
     type IntoIter = MessageIter<&'a Octets>;
 
     fn into_iter(self) -> Self::IntoIter {
-        MessageIter { inner: self.answer().ok() }
+        MessageIter {
+            inner: self.answer().ok(),
+        }
     }
 }
-
 
 //------------ QuestionSection ----------------------------------------------
 
@@ -648,7 +654,7 @@ pub struct QuestionSection<Ref> {
     /// The `Result` is here to monitor an error during iteration.
     /// It is used to fuse the iterator after an error and is also returned
     /// by `answer()` should that be called after an error.
-    count: Result<u16, ParseError>
+    count: Result<u16, ParseError>,
 }
 
 impl<Ref: OctetsRef> QuestionSection<Ref> {
@@ -657,9 +663,7 @@ impl<Ref: OctetsRef> QuestionSection<Ref> {
         let mut parser = Parser::from_ref(octets);
         parser.advance(mem::size_of::<HeaderSection>()).unwrap();
         QuestionSection {
-            count: Ok(HeaderCounts::for_message_slice(
-                parser.as_slice()).qdcount()
-            ),
+            count: Ok(HeaderCounts::for_message_slice(parser.as_slice()).qdcount()),
             parser,
         }
     }
@@ -676,7 +680,7 @@ impl<Ref: OctetsRef> QuestionSection<Ref> {
     ///
     /// [`RecordSection`]: struct.RecordSection.html
     pub fn answer(mut self) -> Result<RecordSection<Ref>, ParseError> {
-        while self.next().is_some() { }
+        while self.next().is_some() {}
         let _ = self.count?;
         Ok(RecordSection::new(self.parser, Section::first()))
     }
@@ -689,7 +693,6 @@ impl<Ref: OctetsRef> QuestionSection<Ref> {
     }
 }
 
-
 //--- Iterator
 
 impl<Ref: OctetsRef> Iterator for QuestionSection<Ref> {
@@ -697,28 +700,28 @@ impl<Ref: OctetsRef> Iterator for QuestionSection<Ref> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.count {
-            Ok(count) if count > 0 => {
-                match Question::parse(&mut self.parser) {
-                    Ok(question) => {
-                        self.count = Ok(count - 1);
-                        Some(Ok(question))
-                    }
-                    Err(err) => {
-                        self.count = Err(err);
-                        Some(Err(err))
-                    }
+            Ok(count) if count > 0 => match Question::parse(&mut self.parser) {
+                Ok(question) => {
+                    self.count = Ok(count - 1);
+                    Some(Ok(question))
                 }
-            }
-            _ => None
+                Err(err) => {
+                    self.count = Err(err);
+                    Some(Err(err))
+                }
+            },
+            _ => None,
         }
     }
 }
 
-
 //--- PartialEq
 
 impl<Ref, Other> PartialEq<QuestionSection<Other>> for QuestionSection<Ref>
-where Ref: OctetsRef, Other: OctetsRef {
+where
+    Ref: OctetsRef,
+    Other: OctetsRef,
+{
     fn eq(&self, other: &QuestionSection<Other>) -> bool {
         let mut me = *self;
         let mut other = *other;
@@ -726,16 +729,15 @@ where Ref: OctetsRef, Other: OctetsRef {
             match (me.next(), other.next()) {
                 (Some(Ok(left)), Some(Ok(right))) => {
                     if left != right {
-                        return false
+                        return false;
                     }
                 }
                 (None, None) => return true,
-                _ => return false
+                _ => return false,
             }
         }
     }
 }
-
 
 //------------ Section -------------------------------------------------------
 
@@ -748,20 +750,21 @@ where Ref: OctetsRef, Other: OctetsRef {
 pub enum Section {
     Answer,
     Authority,
-    Additional
+    Additional,
 }
-
 
 impl Section {
     /// Returns the first section.
-    pub fn first() -> Self { Section::Answer }
+    pub fn first() -> Self {
+        Section::Answer
+    }
 
     /// Returns the correct record count for this section.
     fn count(self, counts: HeaderCounts) -> u16 {
         match self {
             Section::Answer => counts.ancount(),
             Section::Authority => counts.nscount(),
-            Section::Additional => counts.arcount()
+            Section::Additional => counts.arcount(),
         }
     }
 
@@ -770,11 +773,10 @@ impl Section {
         match self {
             Section::Answer => Some(Section::Authority),
             Section::Authority => Some(Section::Additional),
-            Section::Additional => None
+            Section::Additional => None,
         }
     }
 }
-
 
 //------------ RecordSection -----------------------------------------------
 
@@ -816,7 +818,7 @@ pub struct RecordSection<Ref> {
     /// The `Result` is here to monitor an error during iteration.
     /// It is used to fuse the iterator after an error and is also returned
     /// by `answer()` should that be called after an error.
-    count: Result<u16, ParseError>
+    count: Result<u16, ParseError>,
 }
 
 impl<Ref: OctetsRef> RecordSection<Ref> {
@@ -825,9 +827,7 @@ impl<Ref: OctetsRef> RecordSection<Ref> {
     /// The parser must be positioned at the beginning of this section.
     fn new(parser: Parser<Ref>, section: Section) -> Self {
         RecordSection {
-            count: Ok(section.count(
-                *HeaderCounts::for_message_slice(parser.as_slice())
-            )),
+            count: Ok(section.count(*HeaderCounts::for_message_slice(parser.as_slice()))),
             section,
             parser,
         }
@@ -853,9 +853,7 @@ impl<Ref: OctetsRef> RecordSection<Ref> {
     /// [`ParseRecordData`]: ../rdata/trait.ParseRecordData.html
     /// [`ParsedDname`]: ../name/struct.ParsedDname.html
     /// [domain::rdata::parsed]: ../../rdata/parsed/index.html
-    pub fn limit_to<Data: ParseRecordData<Ref>>(
-        self
-    ) -> RecordIter<Ref, Data> {
+    pub fn limit_to<Data: ParseRecordData<Ref>>(self) -> RecordIter<Ref, Data> {
         RecordIter::new(self, false)
     }
 
@@ -865,9 +863,7 @@ impl<Ref: OctetsRef> RecordSection<Ref> {
     /// of class IN.
     ///
     /// [`limit_to`]: #method.limit_to
-    pub fn limit_to_in<Data: ParseRecordData<Ref>>(
-        self
-    ) -> RecordIter<Ref, Data> {
+    pub fn limit_to_in<Data: ParseRecordData<Ref>>(self) -> RecordIter<Ref, Data> {
         RecordIter::new(self, true)
     }
 
@@ -878,9 +874,9 @@ impl<Ref: OctetsRef> RecordSection<Ref> {
     pub fn next_section(mut self) -> Result<Option<Self>, ParseError> {
         let section = match self.section.next_section() {
             Some(section) => section,
-            None => return Ok(None)
+            None => return Ok(None),
         };
-        while self.skip_next().is_some() { }
+        while self.skip_next().is_some() {}
         let _ = self.count?;
         Ok(Some(RecordSection::new(self.parser, section)))
     }
@@ -888,23 +884,20 @@ impl<Ref: OctetsRef> RecordSection<Ref> {
     /// Skip the next record.
     fn skip_next(&mut self) -> Option<Result<(), ParseError>> {
         match self.count {
-            Ok(count) if count > 0 => {
-                match ParsedRecord::skip(&mut self.parser) {
-                    Ok(_) => {
-                        self.count = Ok(count - 1);
-                        Some(Ok(()))
-                    }
-                    Err(err) => {
-                        self.count = Err(err);
-                        Some(Err(err))
-                    }
+            Ok(count) if count > 0 => match ParsedRecord::skip(&mut self.parser) {
+                Ok(_) => {
+                    self.count = Ok(count - 1);
+                    Some(Ok(()))
                 }
-            }
-            _ => None
+                Err(err) => {
+                    self.count = Err(err);
+                    Some(Err(err))
+                }
+            },
+            _ => None,
         }
     }
 }
-
 
 //--- Iterator
 
@@ -913,23 +906,20 @@ impl<Ref: OctetsRef> Iterator for RecordSection<Ref> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.count {
-            Ok(count) if count > 0 => {
-                match ParsedRecord::parse(&mut self.parser) {
-                    Ok(record) => {
-                        self.count = Ok(count - 1);
-                        Some(Ok(record))
-                    }
-                    Err(err) => {
-                        self.count = Err(err);
-                        Some(Err(err))
-                    }
+            Ok(count) if count > 0 => match ParsedRecord::parse(&mut self.parser) {
+                Ok(record) => {
+                    self.count = Ok(count - 1);
+                    Some(Ok(record))
                 }
-            }
-            _ => None
+                Err(err) => {
+                    self.count = Err(err);
+                    Some(Err(err))
+                }
+            },
+            _ => None,
         }
     }
 }
-
 
 //------------ MessageIter ---------------------------------------------------
 
@@ -949,7 +939,7 @@ impl<Ref: OctetsRef> Iterator for MessageIter<Ref> {
                 if let Some(item) = item {
                     return Some(item.map(|item| (item, inner.section)));
                 }
-            },
+            }
             None => return None,
         }
 
@@ -960,11 +950,10 @@ impl<Ref: OctetsRef> Iterator for MessageIter<Ref> {
                 self.inner = section;
                 self.next()
             }
-            Err(err) => Some(Err(err))
+            Err(err) => Some(Err(err)),
         }
     }
 }
-
 
 //------------ RecordIter ----------------------------------------------------
 
@@ -987,13 +976,17 @@ impl<Ref: OctetsRef> Iterator for MessageIter<Ref> {
 pub struct RecordIter<Ref, Data> {
     section: RecordSection<Ref>,
     in_only: bool,
-    marker: PhantomData<Data>
+    marker: PhantomData<Data>,
 }
 
 impl<Ref: OctetsRef, Data: ParseRecordData<Ref>> RecordIter<Ref, Data> {
     /// Creates a new record iterator.
     fn new(section: RecordSection<Ref>, in_only: bool) -> Self {
-        RecordIter { section, in_only, marker: PhantomData }
+        RecordIter {
+            section,
+            in_only,
+            marker: PhantomData,
+        }
     }
 
     /// Trades the limited iterator for the full iterator.
@@ -1008,18 +1001,18 @@ impl<Ref: OctetsRef, Data: ParseRecordData<Ref>> RecordIter<Ref, Data> {
     ///
     /// Returns an error if parsing the message has failed. Returns
     /// `Ok(None)` if this iterator was already on the additional section.
-    pub fn next_section(
-        self
-    ) -> Result<Option<RecordSection<Ref>>, ParseError> {
+    pub fn next_section(self) -> Result<Option<RecordSection<Ref>>, ParseError> {
         self.section.next_section()
     }
 }
 
-
 //--- Iterator
 
 impl<Ref, Data> Iterator for RecordIter<Ref, Data>
-where Ref: OctetsRef, Data: ParseRecordData<Ref> {
+where
+    Ref: OctetsRef,
+    Data: ParseRecordData<Ref>,
+{
     type Item = Result<Record<ParsedDname<Ref>, Data>, ParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1030,17 +1023,16 @@ where Ref: OctetsRef, Data: ParseRecordData<Ref> {
                 None => return None,
             };
             if self.in_only && record.class() != Class::In {
-                continue
+                continue;
             }
             match record.into_record() {
                 Ok(Some(record)) => return Some(Ok(record)),
                 Err(err) => return Some(Err(err)),
-                Ok(None) => { }
+                Ok(None) => {}
             }
         }
     }
 }
-
 
 //============ Error Types ===================================================
 
@@ -1056,7 +1048,6 @@ pub enum CopyRecordsError {
     ShortBuf,
 }
 
-
 //--- From
 
 impl From<ParseError> for CopyRecordsError {
@@ -1071,31 +1062,33 @@ impl From<ShortBuf> for CopyRecordsError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for CopyRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CopyRecordsError::Parse(ref err) => err.fmt(f),
-            CopyRecordsError::ShortBuf => ShortBuf.fmt(f)
+            CopyRecordsError::ShortBuf => ShortBuf.fmt(f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for CopyRecordsError { }
-
+impl std::error::Error for CopyRecordsError {}
 
 //============ Testing =======================================================
 
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "std")] use std::vec::Vec;
-    #[cfg(feature = "std")] use crate::rdata::{Ns, AllRecordData};
-    #[cfg(feature = "std")] use crate::base::message_builder::MessageBuilder;
-    #[cfg(feature = "std")] use crate::base::name::Dname;
     use super::*;
+    #[cfg(feature = "std")]
+    use crate::base::message_builder::MessageBuilder;
+    #[cfg(feature = "std")]
+    use crate::base::name::Dname;
+    #[cfg(feature = "std")]
+    use crate::rdata::{AllRecordData, Ns};
+    #[cfg(feature = "std")]
+    use std::vec::Vec;
 
     // Helper for test cases
     #[cfg(feature = "std")]
@@ -1105,14 +1098,16 @@ mod test {
         msg.push((
             Dname::vec_from_str("foo.example.com.").unwrap(),
             86000,
-            Cname::new(Dname::vec_from_str("baz.example.com.").unwrap())
-        )).unwrap();
+            Cname::new(Dname::vec_from_str("baz.example.com.").unwrap()),
+        ))
+        .unwrap();
         let mut msg = msg.authority();
         msg.push((
             Dname::vec_from_str("bar.example.com.").unwrap(),
             86000,
-            Ns::new(Dname::vec_from_str("baz.example.com.").unwrap())
-        )).unwrap();
+            Ns::new(Dname::vec_from_str("baz.example.com.").unwrap()),
+        ))
+        .unwrap();
         msg.into_message()
     }
 
@@ -1129,9 +1124,8 @@ mod test {
 
         // Message without CNAMEs.
         let mut msg = MessageBuilder::new_vec().question();
-        msg.push(
-            (Dname::vec_from_str("example.com.").unwrap(), Rtype::A)
-        ).unwrap();
+        msg.push((Dname::vec_from_str("example.com.").unwrap(), Rtype::A))
+            .unwrap();
         let msg_ref = msg.as_message();
         assert_eq!(
             Dname::vec_from_str("example.com.").unwrap(),
@@ -1143,18 +1137,21 @@ mod test {
         msg.push((
             Dname::vec_from_str("bar.example.com.").unwrap(),
             86000,
-            Cname::new(Dname::vec_from_str("baz.example.com.").unwrap())
-        )).unwrap();
+            Cname::new(Dname::vec_from_str("baz.example.com.").unwrap()),
+        ))
+        .unwrap();
         msg.push((
             Dname::vec_from_str("example.com.").unwrap(),
             86000,
-            Cname::new(Dname::vec_from_str("foo.example.com.").unwrap())
-        )).unwrap();
+            Cname::new(Dname::vec_from_str("foo.example.com.").unwrap()),
+        ))
+        .unwrap();
         msg.push((
             Dname::vec_from_str("foo.example.com.").unwrap(),
             86000,
-            Cname::new(Dname::vec_from_str("bar.example.com.").unwrap())
-        )).unwrap();
+            Cname::new(Dname::vec_from_str("bar.example.com.").unwrap()),
+        ))
+        .unwrap();
         let msg_ref = msg.as_message();
         assert_eq!(
             Dname::vec_from_str("baz.example.com.").unwrap(),
@@ -1165,14 +1162,16 @@ mod test {
         msg.push((
             Dname::vec_from_str("baz.example.com").unwrap(),
             86000,
-            Cname::new(Dname::vec_from_str("foo.example.com").unwrap())
-        )).unwrap();
+            Cname::new(Dname::vec_from_str("foo.example.com").unwrap()),
+        ))
+        .unwrap();
         assert!(msg.as_message().canonical_name().is_none());
         msg.push((
             Dname::vec_from_str("baz.example.com").unwrap(),
             86000,
-            A::from_octets(127,0,0,1)
-        )).unwrap();
+            A::from_octets(127, 0, 0, 1),
+        ))
+        .unwrap();
         assert!(msg.as_message().canonical_name().is_none());
     }
 
@@ -1198,8 +1197,7 @@ mod test {
         let msg = msg.for_slice();
         let target = MessageBuilder::new_vec().question();
         let res = msg.copy_records(target.answer(), |rr| {
-            if let Ok(Some(rr)) =
-                    rr.into_record::<AllRecordData<_, ParsedDname<_>>>() {
+            if let Ok(Some(rr)) = rr.into_record::<AllRecordData<_, ParsedDname<_>>>() {
                 if rr.rtype() == Rtype::Cname {
                     return Some(rr);
                 }
@@ -1215,4 +1213,3 @@ mod test {
         }
     }
 }
-

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -22,7 +22,7 @@
 //! of these types, tuples of the components also work, such as a pair of a
 //! domain name and a record type for a question or a triple of the owner
 //! name, TTL, and record data for a record. If you already have a question
-//! or record, you can use the `push_ref` method to add 
+//! or record, you can use the `push_ref` method to add
 //!
 //!
 //! The `push` method of the record
@@ -128,22 +128,26 @@
 //! [`Record`]: ../question/struct.Record.html
 //! [octets builder]: ../octets/trait.OctetsBuilder.html
 
-use core::mem;
-#[cfg(feature = "std")] use core::convert::TryInto;
-use core::ops::{Deref, DerefMut};
-#[cfg(feature = "std")] use std::collections::HashMap;
-#[cfg(feature = "std")] use std::vec::Vec;
-#[cfg(feature = "bytes")] use bytes::BytesMut;
 use super::header::{Header, HeaderCounts, HeaderSection};
-use super::iana::{OptionCode, OptRcode, Rcode, Rtype};
+use super::iana::{OptRcode, OptionCode, Rcode, Rtype};
 use super::message::Message;
-use super::name::{ToDname, Label};
+use super::name::{Label, ToDname};
+#[cfg(feature = "std")]
+use super::octets::Octets64;
 use super::octets::{Compose, OctetsBuilder, OctetsRef, ShortBuf};
-#[cfg(feature = "std")] use super::octets::Octets64;
-use super::opt::{OptHeader, OptData};
+use super::opt::{OptData, OptHeader};
 use super::question::AsQuestion;
 use super::record::AsRecord;
-
+#[cfg(feature = "bytes")]
+use bytes::BytesMut;
+#[cfg(feature = "std")]
+use core::convert::TryInto;
+use core::mem;
+use core::ops::{Deref, DerefMut};
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 //------------ MessageBuilder ------------------------------------------------
 
@@ -176,9 +180,7 @@ impl<Target: OctetsBuilder> MessageBuilder<Target> {
     pub fn from_target(mut target: Target) -> Result<Self, ShortBuf> {
         target.truncate(0);
         target.append_slice(HeaderSection::new().as_slice())?;
-        Ok(MessageBuilder {
-            target,
-        })
+        Ok(MessageBuilder { target })
     }
 }
 
@@ -194,27 +196,23 @@ impl MessageBuilder<Vec<u8>> {
 impl MessageBuilder<StreamTarget<Vec<u8>>> {
     /// Creates a new builder for a streamable message atop a `Vec<u8>`.
     pub fn new_stream_vec() -> Self {
-        Self::from_target(
-            StreamTarget::new(Vec::new()).unwrap()
-        ).unwrap()
+        Self::from_target(StreamTarget::new(Vec::new()).unwrap()).unwrap()
     }
 }
 
-#[cfg(feature="bytes")]
+#[cfg(feature = "bytes")]
 impl MessageBuilder<BytesMut> {
-    /// Creates a new message builder atop a bytes value. 
+    /// Creates a new message builder atop a bytes value.
     pub fn new_bytes() -> Self {
         Self::from_target(BytesMut::new()).unwrap()
     }
 }
 
-#[cfg(feature="bytes")]
+#[cfg(feature = "bytes")]
 impl MessageBuilder<StreamTarget<BytesMut>> {
-    /// Creates a new streamable message builder atop a bytes value. 
+    /// Creates a new streamable message builder atop a bytes value.
     pub fn new_stream_bytes() -> Self {
-        Self::from_target(
-            StreamTarget::new(BytesMut::new()).unwrap()
-        ).unwrap()
+        Self::from_target(StreamTarget::new(BytesMut::new()).unwrap()).unwrap()
     }
 }
 
@@ -232,7 +230,10 @@ impl<Target: OctetsBuilder> MessageBuilder<Target> {
         msg: &Message<Octets>,
         rcode: Rcode,
     ) -> Result<AnswerBuilder<Target>, ShortBuf>
-    where Octets: AsRef<[u8]>, for<'a> &'a Octets: OctetsRef {
+    where
+        Octets: AsRef<[u8]>,
+        for<'a> &'a Octets: OctetsRef,
+    {
         {
             let header = self.header_mut();
             header.set_id(msg.header().id());
@@ -254,17 +255,13 @@ impl<Target: OctetsBuilder> MessageBuilder<Target> {
     ///
     /// Sets a random ID, pushes the domain and the AXFR record type into
     /// the question section, and converts the builder into an answer builder.
-    pub fn request_axfr<N: ToDname>(
-        mut self,
-        apex: N
-    ) -> Result<AnswerBuilder<Target>, ShortBuf> {
+    pub fn request_axfr<N: ToDname>(mut self, apex: N) -> Result<AnswerBuilder<Target>, ShortBuf> {
         self.header_mut().set_random_id();
         let mut builder = self.question();
         builder.push((apex, Rtype::Axfr))?;
         Ok(builder.answer())
     }
 }
-
 
 /// # Access to the Message Header
 ///
@@ -358,7 +355,9 @@ impl<Target> MessageBuilder<Target> {
 
     /// Returns an octets slice of the octets assembled so far.
     pub fn as_slice(&self) -> &[u8]
-    where Target: AsRef<[u8]> {
+    where
+        Target: AsRef<[u8]>,
+    {
         self.as_target().as_ref()
     }
 
@@ -367,42 +366,50 @@ impl<Target> MessageBuilder<Target> {
     /// This message is atop the octets slices derived from the builder, so
     /// it can be created cheaply.
     pub fn as_message(&self) -> Message<&[u8]>
-    where Target: AsRef<[u8]> {
+    where
+        Target: AsRef<[u8]>,
+    {
         unsafe { Message::from_octets_unchecked(self.target.as_ref()) }
     }
 }
 
-
 //--- From
 
 impl<Target> From<QuestionBuilder<Target>> for MessageBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: QuestionBuilder<Target>) -> Self {
         src.builder()
     }
 }
 
 impl<Target> From<AnswerBuilder<Target>> for MessageBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AnswerBuilder<Target>) -> Self {
         src.builder()
     }
 }
 
 impl<Target> From<AuthorityBuilder<Target>> for MessageBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AuthorityBuilder<Target>) -> Self {
         src.builder()
     }
 }
 
 impl<Target> From<AdditionalBuilder<Target>> for MessageBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AdditionalBuilder<Target>) -> Self {
         src.builder()
     }
 }
-
 
 //--- AsRef
 //
@@ -419,7 +426,6 @@ impl<Target: AsRef<[u8]>> AsRef<[u8]> for MessageBuilder<Target> {
         self.as_slice()
     }
 }
-
 
 //------------ QuestionBuilder -----------------------------------------------
 
@@ -477,10 +483,7 @@ impl<Target: OctetsBuilder> QuestionBuilder<Target> {
     ///
     /// [`AsQuestion`]: ../question/trait.AsQuestion.html
     /// [`Question`]: ../question/trait.Question.html
-    pub fn push(
-        &mut self,
-        question: impl AsQuestion
-    ) -> Result<(), ShortBuf> {
+    pub fn push(&mut self, question: impl AsQuestion) -> Result<(), ShortBuf> {
         let pos = self.as_target().len();
         question.compose_question(self.as_target_mut())?;
         self.counts_mut().inc_qdcount().map_err(|err| {
@@ -498,7 +501,8 @@ impl<Target: OctetsBuilder> QuestionBuilder<Target> {
     ///
     /// All previously added questions will be lost.
     pub fn rewind(&mut self) {
-        self.as_target_mut().truncate(mem::size_of::<HeaderSection>());
+        self.as_target_mut()
+            .truncate(mem::size_of::<HeaderSection>());
         self.counts_mut().set_qdcount(0);
     }
 
@@ -564,37 +568,43 @@ impl<Target> QuestionBuilder<Target> {
     }
 }
 
-
 //--- From
 
 impl<Target> From<MessageBuilder<Target>> for QuestionBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: MessageBuilder<Target>) -> Self {
         src.question()
     }
 }
 
 impl<Target> From<AnswerBuilder<Target>> for QuestionBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AnswerBuilder<Target>) -> Self {
         src.question()
     }
 }
 
 impl<Target> From<AuthorityBuilder<Target>> for QuestionBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AuthorityBuilder<Target>) -> Self {
         src.question()
     }
 }
 
 impl<Target> From<AdditionalBuilder<Target>> for QuestionBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AdditionalBuilder<Target>) -> Self {
         src.question()
     }
 }
-
 
 //--- Deref, DerefMut, AsRef, and AsMut
 
@@ -636,7 +646,6 @@ impl<Target: AsRef<[u8]>> AsRef<[u8]> for QuestionBuilder<Target> {
     }
 }
 
-
 //------------ AnswerBuilder -------------------------------------------------
 
 /// Builds the answer section of a DNS message.
@@ -676,7 +685,7 @@ impl<Target: OctetsBuilder> AnswerBuilder<Target> {
     fn new(builder: MessageBuilder<Target>) -> Self {
         AnswerBuilder {
             start: builder.target.as_ref().len(),
-            builder
+            builder,
         }
     }
 
@@ -794,37 +803,43 @@ impl<Target> AnswerBuilder<Target> {
     }
 }
 
-
 //--- From
 
 impl<Target> From<MessageBuilder<Target>> for AnswerBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: MessageBuilder<Target>) -> Self {
         src.answer()
     }
 }
 
 impl<Target> From<QuestionBuilder<Target>> for AnswerBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: QuestionBuilder<Target>) -> Self {
         src.answer()
     }
 }
 
 impl<Target> From<AuthorityBuilder<Target>> for AnswerBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AuthorityBuilder<Target>) -> Self {
         src.answer()
     }
 }
 
 impl<Target> From<AdditionalBuilder<Target>> for AnswerBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AdditionalBuilder<Target>) -> Self {
         src.answer()
     }
 }
-
 
 //--- Deref, DerefMut, AsRef, and AsMut
 
@@ -866,7 +881,6 @@ impl<Target: AsRef<[u8]>> AsRef<[u8]> for AnswerBuilder<Target> {
     }
 }
 
-
 //------------ AuthorityBuilder ----------------------------------------------
 
 /// Builds the authority section of a DNS message.
@@ -896,7 +910,7 @@ pub struct AuthorityBuilder<Target> {
     answer: AnswerBuilder<Target>,
 
     /// The index in the octets builder where the authority section starts.
-    start: usize
+    start: usize,
 }
 
 impl<Target: OctetsBuilder> AuthorityBuilder<Target> {
@@ -906,7 +920,7 @@ impl<Target: OctetsBuilder> AuthorityBuilder<Target> {
     fn new(answer: AnswerBuilder<Target>) -> Self {
         AuthorityBuilder {
             start: answer.as_target().as_ref().len(),
-            answer
+            answer,
         }
     }
 
@@ -1025,37 +1039,43 @@ impl<Target> AuthorityBuilder<Target> {
     }
 }
 
-
 //--- From
 
 impl<Target> From<MessageBuilder<Target>> for AuthorityBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: MessageBuilder<Target>) -> Self {
         src.authority()
     }
 }
 
 impl<Target> From<QuestionBuilder<Target>> for AuthorityBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: QuestionBuilder<Target>) -> Self {
         src.authority()
     }
 }
 
 impl<Target> From<AnswerBuilder<Target>> for AuthorityBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AnswerBuilder<Target>) -> Self {
         src.authority()
     }
 }
 
 impl<Target> From<AdditionalBuilder<Target>> for AuthorityBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AdditionalBuilder<Target>) -> Self {
         src.authority()
     }
 }
-
 
 //--- Deref, DerefMut, AsRef, and AsMut
 
@@ -1096,7 +1116,6 @@ impl<Target: AsRef<[u8]>> AsRef<[u8]> for AuthorityBuilder<Target> {
         self.as_slice()
     }
 }
-
 
 //------------ AdditionalBuilder ---------------------------------------------
 
@@ -1142,7 +1161,7 @@ impl<Target: OctetsBuilder> AdditionalBuilder<Target> {
     fn new(authority: AuthorityBuilder<Target>) -> Self {
         AdditionalBuilder {
             start: authority.as_target().as_ref().len(),
-            authority
+            authority,
         }
     }
 
@@ -1193,7 +1212,9 @@ impl<Target: OctetsBuilder> AdditionalBuilder<Target> {
     ///
     /// [`OptBuilder`]: struct.OptBuilder.html
     pub fn opt<F, R>(&mut self, build: F) -> Result<R, ShortBuf>
-    where F: FnOnce(&mut OptBuilder<Target>) -> Result<R, ShortBuf> {
+    where
+        F: FnOnce(&mut OptBuilder<Target>) -> Result<R, ShortBuf>,
+    {
         build(&mut OptBuilder::new(self)?)
     }
 }
@@ -1277,37 +1298,43 @@ impl<Target> AdditionalBuilder<Target> {
     }
 }
 
-
 //--- From
 
 impl<Target> From<MessageBuilder<Target>> for AdditionalBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: MessageBuilder<Target>) -> Self {
         src.additional()
     }
 }
 
 impl<Target> From<QuestionBuilder<Target>> for AdditionalBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: QuestionBuilder<Target>) -> Self {
         src.additional()
     }
 }
 
 impl<Target> From<AnswerBuilder<Target>> for AdditionalBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AnswerBuilder<Target>) -> Self {
         src.additional()
     }
 }
 
 impl<Target> From<AuthorityBuilder<Target>> for AdditionalBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn from(src: AuthorityBuilder<Target>) -> Self {
         src.additional()
     }
 }
-
 
 //--- Deref, DerefMut, AsRef, and AsMut
 
@@ -1349,7 +1376,6 @@ impl<Target: AsRef<[u8]>> AsRef<[u8]> for AdditionalBuilder<Target> {
     }
 }
 
-
 //------------ RecordSectionBuilder ------------------------------------------
 
 /// A section that can have records pushed to it.
@@ -1371,7 +1397,9 @@ pub trait RecordSectionBuilder {
 }
 
 impl<Target> RecordSectionBuilder for AnswerBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn push(&mut self, record: impl AsRecord) -> Result<(), ShortBuf> {
         Self::push(self, record)
     }
@@ -1384,12 +1412,13 @@ impl<Target: OctetsBuilder> RecordSectionBuilder for AuthorityBuilder<Target> {
 }
 
 impl<Target> RecordSectionBuilder for AdditionalBuilder<Target>
-where Target: OctetsBuilder {
+where
+    Target: OctetsBuilder,
+{
     fn push(&mut self, record: impl AsRecord) -> Result<(), ShortBuf> {
         Self::push(self, record)
     }
 }
-
 
 //------------ OptBuilder ----------------------------------------------------
 
@@ -1414,44 +1443,45 @@ pub struct OptBuilder<'a, Target> {
 
 impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
     /// Creates a new opt builder atop an additional builder.
-    fn new(
-        additional: &'a mut AdditionalBuilder<Target>
-    ) -> Result<Self, ShortBuf> {
+    fn new(additional: &'a mut AdditionalBuilder<Target>) -> Result<Self, ShortBuf> {
         let start = additional.as_target().as_ref().len();
         let arcount = additional.counts().arcount();
 
-        let err = additional.as_target_mut().append_all(|target| {
-            OptHeader::default().compose(target)?;
-            0u16.compose(target)
-        }).is_err();
+        let err = additional
+            .as_target_mut()
+            .append_all(|target| {
+                OptHeader::default().compose(target)?;
+                0u16.compose(target)
+            })
+            .is_err();
         if err {
-            return Err(ShortBuf)
+            return Err(ShortBuf);
         }
         if additional.counts_mut().inc_arcount().is_err() {
             additional.as_target_mut().truncate(start);
-            return Err(ShortBuf)
+            return Err(ShortBuf);
         }
 
         Ok(OptBuilder {
-            additional, start, arcount
+            additional,
+            start,
+            arcount,
         })
     }
 
     /// Appends an option to the OPT record.
     pub fn push<Opt: OptData>(&mut self, opt: &Opt) -> Result<(), ShortBuf> {
-        self.push_raw_option(opt.code(), |target| {
-            opt.compose(target)
-        })
+        self.push_raw_option(opt.code(), |target| opt.compose(target))
     }
 
     /// Appends a raw option to the OPT record.
     ///
     /// The method will append an option with the given option code. The data
     /// of the option will be written via the closure `op`.
-    pub fn push_raw_option<F>(
-        &mut self, code: OptionCode, op: F
-    ) -> Result<(), ShortBuf>
-    where F: FnOnce(&mut Target) -> Result<(), ShortBuf> {
+    pub fn push_raw_option<F>(&mut self, code: OptionCode, op: F) -> Result<(), ShortBuf>
+    where
+        F: FnOnce(&mut Target) -> Result<(), ShortBuf>,
+    {
         // Add the option.
         let pos = self.as_target().as_ref().len();
         self.as_target_mut().append_all(|target| {
@@ -1461,12 +1491,10 @@ impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
 
         // Update the length. If the option is too long, truncate and return
         // an error.
-        let len = self.as_target().as_ref().len()
-                - self.start
-                - (mem::size_of::<OptHeader>() + 2);
+        let len = self.as_target().as_ref().len() - self.start - (mem::size_of::<OptHeader>() + 2);
         if len > usize::from(u16::max_value()) {
             self.as_target_mut().truncate(pos);
-            return Err(ShortBuf)
+            return Err(ShortBuf);
         }
         let start = self.start + mem::size_of::<OptHeader>();
         self.as_target_mut().as_mut()[start..start + 2]
@@ -1541,9 +1569,7 @@ impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
     /// Returns a mutual reference the full OPT header.
     fn opt_header_mut(&mut self) -> &mut OptHeader {
         let start = self.start;
-        OptHeader::for_record_slice_mut(
-            &mut self.as_target_mut().as_mut()[start..]
-        )
+        OptHeader::for_record_slice_mut(&mut self.as_target_mut().as_mut()[start..])
     }
 
     /// Returns a reference to the underlying octets builder.
@@ -1556,7 +1582,6 @@ impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
         self.additional.as_target_mut()
     }
 }
-
 
 //------------ StreamTarget --------------------------------------------------
 
@@ -1575,7 +1600,7 @@ impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
 #[derive(Clone, Debug)]
 pub struct StreamTarget<Target> {
     /// The underlying octets builder.
-    target: Target
+    target: Target,
 }
 
 impl<Target: OctetsBuilder> StreamTarget<Target> {
@@ -1604,7 +1629,7 @@ impl<Target: OctetsBuilder> StreamTarget<Target> {
     pub fn as_target(&self) -> &Target {
         &self.target
     }
-    
+
     /// Converts the stream target into the underlying octets builder.
     ///
     /// The returned builder will contain the 16 bit length value with the
@@ -1637,7 +1662,6 @@ impl<Target: OctetsBuilder> StreamTarget<Target> {
     }
 }
 
-
 //--- AsRef, AsMut
 
 impl<Target: AsRef<[u8]>> AsRef<[u8]> for StreamTarget<Target> {
@@ -1652,7 +1676,6 @@ impl<Target: AsMut<[u8]>> AsMut<[u8]> for StreamTarget<Target> {
     }
 }
 
-
 //--- OctetsBuilder
 
 impl<Target: OctetsBuilder> OctetsBuilder for StreamTarget<Target> {
@@ -1664,7 +1687,7 @@ impl<Target: OctetsBuilder> OctetsBuilder for StreamTarget<Target> {
                 self.update_shim();
                 Ok(())
             }
-            Err(ShortBuf) => Err(ShortBuf)
+            Err(ShortBuf) => Err(ShortBuf),
         }
     }
 
@@ -1677,7 +1700,6 @@ impl<Target: OctetsBuilder> OctetsBuilder for StreamTarget<Target> {
         self.target.freeze()
     }
 }
-
 
 //------------ StaticCompressor ----------------------------------------------
 
@@ -1714,7 +1736,7 @@ impl<Target> StaticCompressor<Target> {
         StaticCompressor {
             target,
             entries: Default::default(),
-            len: 0
+            len: 0,
         }
     }
 
@@ -1730,29 +1752,32 @@ impl<Target> StaticCompressor<Target> {
 
     /// Returns a reference to the octets slice of the content.
     pub fn as_slice(&self) -> &[u8]
-    where Target: AsRef<[u8]> {
+    where
+        Target: AsRef<[u8]>,
+    {
         self.target.as_ref()
     }
 
     /// Returns a reference to the octets slice of the content.
     pub fn as_slice_mut(&mut self) -> &mut [u8]
-    where Target: AsMut<[u8]> {
+    where
+        Target: AsMut<[u8]>,
+    {
         self.target.as_mut()
     }
 
     /// Returns a known position of a domain name if there is one.
-    fn get<'a, N: Iterator<Item = &'a Label> + Clone>(
-        &self,
-        name: N,
-    ) -> Option<u16>
-    where Target: AsRef<[u8]> {
+    fn get<'a, N: Iterator<Item = &'a Label> + Clone>(&self, name: N) -> Option<u16>
+    where
+        Target: AsRef<[u8]>,
+    {
         self.entries[..self.len].iter().find_map(|&pos| {
-            if name.clone().eq(
-                Label::iter_slice(self.target.as_ref(), pos as usize)
-            ) {
+            if name
+                .clone()
+                .eq(Label::iter_slice(self.target.as_ref(), pos as usize))
+            {
                 Some(pos)
-            }
-            else {
+            } else {
                 None
             }
         })
@@ -1764,13 +1789,11 @@ impl<Target> StaticCompressor<Target> {
             self.entries[self.len] = pos as u16;
             self.len += 1;
             true
-        }
-        else {
+        } else {
             false
         }
     }
 }
-
 
 //--- AsRef and AsMut
 
@@ -1785,7 +1808,6 @@ impl<Target: AsMut<[u8]>> AsMut<[u8]> for StaticCompressor<Target> {
         self.as_slice_mut()
     }
 }
-
 
 //--- OctetsBuilder
 
@@ -1803,16 +1825,13 @@ impl<Target: OctetsBuilder> OctetsBuilder for StaticCompressor<Target> {
             for i in 0..self.len {
                 if self.entries[i] >= len {
                     self.len = i;
-                    break
+                    break;
                 }
             }
         }
     }
 
-    fn append_compressed_dname<N: ToDname>(
-        &mut self,
-        name: &N
-    ) -> Result<(), ShortBuf> {
+    fn append_compressed_dname<N: ToDname>(&mut self, name: &N) -> Result<(), ShortBuf> {
         let mut name = name.iter_labels().peekable();
 
         loop {
@@ -1821,13 +1840,13 @@ impl<Target: OctetsBuilder> OctetsBuilder for StaticCompressor<Target> {
             if let Some(label) = name.peek() {
                 if label.is_root() {
                     label.compose(self)?;
-                    return Ok(())
+                    return Ok(());
                 }
             }
 
             // If we already know this name, append it as a compressed label.
             if let Some(pos) = self.get(name.clone()) {
-                return (pos | 0xC000).compose(self)
+                return (pos | 0xC000).compose(self);
             }
 
             // So we don’t know the name. Try inserting it into the
@@ -1837,7 +1856,7 @@ impl<Target: OctetsBuilder> OctetsBuilder for StaticCompressor<Target> {
                 while let Some(label) = name.next() {
                     label.compose(self)?;
                 }
-                return Ok(())
+                return Ok(());
             }
 
             // Advance to the parent.
@@ -1850,7 +1869,6 @@ impl<Target: OctetsBuilder> OctetsBuilder for StaticCompressor<Target> {
         self.target.freeze()
     }
 }
-
 
 //------------ TreeCompressor ------------------------------------------------
 
@@ -1900,9 +1918,11 @@ impl Node {
     fn drop_above(&mut self, len: u16) {
         self.value = match self.value {
             Some(value) if value < len => Some(value),
-            _ => None
+            _ => None,
         };
-        self.parents.values_mut().for_each(|node| node.drop_above(len))
+        self.parents
+            .values_mut()
+            .for_each(|node| node.drop_above(len))
     }
 }
 
@@ -1912,7 +1932,7 @@ impl<Target> TreeCompressor<Target> {
     pub fn new(target: Target) -> Self {
         TreeCompressor {
             target,
-            start: Default::default()
+            start: Default::default(),
         }
     }
 
@@ -1928,20 +1948,21 @@ impl<Target> TreeCompressor<Target> {
 
     /// Returns an octets slice of the data.
     pub fn as_slice(&self) -> &[u8]
-    where Target: AsRef<[u8]> {
+    where
+        Target: AsRef<[u8]>,
+    {
         self.target.as_ref()
     }
 
     /// Returns an mutable octets slice of the data.
     pub fn as_slice_mut(&mut self) -> &mut [u8]
-    where Target: AsMut<[u8]> {
+    where
+        Target: AsMut<[u8]>,
+    {
         self.target.as_mut()
     }
 
-    fn get<'a, N: Iterator<Item = &'a Label> + Clone>(
-        &self,
-        name: N
-    ) -> Option<u16> {
+    fn get<'a, N: Iterator<Item = &'a Label> + Clone>(&self, name: N) -> Option<u16> {
         let mut node = &self.start;
         for label in name {
             if label.is_root() {
@@ -1952,29 +1973,25 @@ impl<Target> TreeCompressor<Target> {
         None
     }
 
-    fn insert<'a, N: Iterator<Item = &'a Label> + Clone>(
-        &mut self,
-        name: N,
-        pos: usize
-    ) -> bool {
+    fn insert<'a, N: Iterator<Item = &'a Label> + Clone>(&mut self, name: N, pos: usize) -> bool {
         if pos >= 0xC000 {
-            return false
+            return false;
         }
         let pos = pos as u16;
         let mut node = &mut self.start;
         for label in name {
             if label.is_root() {
                 node.value = Some(pos);
-                break
+                break;
             }
-            node = node.parents.entry(
-                label.as_ref().try_into().unwrap()
-            ).or_default();
+            node = node
+                .parents
+                .entry(label.as_ref().try_into().unwrap())
+                .or_default();
         }
         true
     }
 }
-
 
 //--- AsRef, AsMut, and OctetsBuilder
 
@@ -2007,10 +2024,7 @@ impl<Target: OctetsBuilder> OctetsBuilder for TreeCompressor<Target> {
         }
     }
 
-    fn append_compressed_dname<N: ToDname>(
-        &mut self,
-        name: &N
-    ) -> Result<(), ShortBuf> {
+    fn append_compressed_dname<N: ToDname>(&mut self, name: &N) -> Result<(), ShortBuf> {
         let mut name = name.iter_labels().peekable();
 
         loop {
@@ -2019,13 +2033,13 @@ impl<Target: OctetsBuilder> OctetsBuilder for TreeCompressor<Target> {
             if let Some(label) = name.peek() {
                 if label.is_root() {
                     label.compose(self)?;
-                    return Ok(())
+                    return Ok(());
                 }
             }
 
             // If we already know this name, append it as a compressed label.
             if let Some(pos) = self.get(name.clone()) {
-                return (pos | 0xC000).compose(self)
+                return (pos | 0xC000).compose(self);
             }
 
             // So we don’t know the name. Try inserting it into the
@@ -2035,7 +2049,7 @@ impl<Target: OctetsBuilder> OctetsBuilder for TreeCompressor<Target> {
                 while let Some(label) = name.next() {
                     label.compose(self)?;
                 }
-                return Ok(())
+                return Ok(());
             }
 
             // Advance to the parent. If the parent is root, just write that
@@ -2056,12 +2070,12 @@ impl<Target: OctetsBuilder> OctetsBuilder for TreeCompressor<Target> {
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod test {
-    use std::vec::Vec;
-    use crate::base::{iana::Rtype, Dname, opt};
-    use crate::rdata::{A, Ns, Soa};
-    use crate::base::Serial;
-    use core::str::FromStr;
     use super::*;
+    use crate::base::Serial;
+    use crate::base::{iana::Rtype, opt, Dname};
+    use crate::rdata::{Ns, Soa, A};
+    use core::str::FromStr;
+    use std::vec::Vec;
 
     #[test]
     fn message_builder() {
@@ -2070,11 +2084,8 @@ mod test {
 
         // Create a message builder wrapping a compressor wrapping a stream
         // target.
-        let mut msg = MessageBuilder::from_target(
-            StaticCompressor::new(
-                StreamTarget::new_vec()
-            )
-        ).unwrap();
+        let mut msg =
+            MessageBuilder::from_target(StaticCompressor::new(StreamTarget::new_vec())).unwrap();
 
         // Set the RD bit in the header and proceed to the question section.
         msg.header_mut().set_rd(true);
@@ -2085,8 +2096,10 @@ mod test {
         let mut msg = msg.answer();
 
         // Add two answer and proceed to the additional sections
-        msg.push((&name, 86400, A::from_octets(192, 0, 2, 1))).unwrap();
-        msg.push((&name, 86400, A::from_octets(192, 0, 2, 2))).unwrap();
+        msg.push((&name, 86400, A::from_octets(192, 0, 2, 1)))
+            .unwrap();
+        msg.push((&name, 86400, A::from_octets(192, 0, 2, 2)))
+            .unwrap();
 
         // Add an authority
         let mut msg = msg.authority();
@@ -2094,8 +2107,9 @@ mod test {
 
         // Add additional
         let mut msg = msg.additional();
-        msg.push((&name, 86400, A::from_octets(192, 0, 2, 1))).unwrap();
-        
+        msg.push((&name, 86400, A::from_octets(192, 0, 2, 1)))
+            .unwrap();
+
         // Convert the builder into the actual message.
         let target = msg.finish().into_target();
 
@@ -2107,8 +2121,14 @@ mod test {
 
         let section = msg.answer().unwrap();
         let mut records = section.limit_to::<A>();
-        assert_eq!(records.next().unwrap().unwrap().data(), &A::from_octets(192, 0, 2, 1));
-        assert_eq!(records.next().unwrap().unwrap().data(), &A::from_octets(192, 0, 2, 2));
+        assert_eq!(
+            records.next().unwrap().unwrap().data(),
+            &A::from_octets(192, 0, 2, 1)
+        );
+        assert_eq!(
+            records.next().unwrap().unwrap().data(),
+            &A::from_octets(192, 0, 2, 2)
+        );
 
         let section = msg.authority().unwrap();
         let mut records = section.limit_to::<Ns<_>>();
@@ -2133,7 +2153,8 @@ mod test {
             o.set_udp_payload_size(4096);
             o.push(&nsid)?;
             Ok(())
-        }).unwrap();
+        })
+        .unwrap();
 
         let msg = Message::from_octets(msg.finish()).unwrap();
         let opt = msg.opt().unwrap();
@@ -2151,25 +2172,34 @@ mod test {
         msg.header_mut().set_ra(true);
         msg.header_mut().set_qr(true);
 
-        msg.push((&"example".parse::<Dname<Vec<u8>>>().unwrap(), Rtype::Ns)).unwrap();
+        msg.push((&"example".parse::<Dname<Vec<u8>>>().unwrap(), Rtype::Ns))
+            .unwrap();
         let mut msg = msg.authority();
 
         let mname: Dname<Vec<u8>> = "a.root-servers.net".parse().unwrap();
         let rname = "nstld.verisign-grs.com".parse().unwrap();
-        msg.push((Dname::root_slice(), 86390, Soa::new(mname, rname, Serial(2020081701), 1800, 900, 604800, 86400))).unwrap();
+        msg.push((
+            Dname::root_slice(),
+            86390,
+            Soa::new(mname, rname, Serial(2020081701), 1800, 900, 604800, 86400),
+        ))
+        .unwrap();
         msg.finish()
     }
 
     #[test]
     fn compressor() {
         // An example negative response to `example. NS` with an SOA to test various compressed name situations.
-        let expect = &[0x00,0x00,0x81,0x83,0x00,0x01,0x00,0x00,0x00,0x01,0x00,0x00,0x07,0x65,0x78,0x61,
-        0x6d,0x70,0x6c,0x65,0x00,0x00,0x02,0x00,0x01,0x00,0x00,0x06,0x00,0x01,0x00,0x01,
-        0x51,0x76,0x00,0x40,0x01,0x61,0x0c,0x72,0x6f,0x6f,0x74,0x2d,0x73,0x65,0x72,0x76,
-        0x65,0x72,0x73,0x03,0x6e,0x65,0x74,0x00,0x05,0x6e,0x73,0x74,0x6c,0x64,0x0c,0x76,
-        0x65,0x72,0x69,0x73,0x69,0x67,0x6e,0x2d,0x67,0x72,0x73,0x03,0x63,0x6f,0x6d,0x00,
-        0x78,0x68,0x00,0x25,0x00,0x00,0x07,0x08,0x00,0x00,0x03,0x84,0x00,0x09,0x3a,0x80,
-        0x00,0x01,0x51,0x80];
+        let expect = &[
+            0x00, 0x00, 0x81, 0x83, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x07, 0x65,
+            0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x06,
+            0x00, 0x01, 0x00, 0x01, 0x51, 0x76, 0x00, 0x40, 0x01, 0x61, 0x0c, 0x72, 0x6f, 0x6f,
+            0x74, 0x2d, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x73, 0x03, 0x6e, 0x65, 0x74, 0x00,
+            0x05, 0x6e, 0x73, 0x74, 0x6c, 0x64, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x73, 0x69, 0x67,
+            0x6e, 0x2d, 0x67, 0x72, 0x73, 0x03, 0x63, 0x6f, 0x6d, 0x00, 0x78, 0x68, 0x00, 0x25,
+            0x00, 0x00, 0x07, 0x08, 0x00, 0x00, 0x03, 0x84, 0x00, 0x09, 0x3a, 0x80, 0x00, 0x01,
+            0x51, 0x80,
+        ];
 
         let msg = create_compressed(StaticCompressor::new(Vec::new()));
         assert_eq!(&expect[..], msg.as_ref());

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -212,7 +212,8 @@ impl MessageBuilder<BytesMut> {
 impl MessageBuilder<StreamTarget<BytesMut>> {
     /// Creates a new streamable message builder atop a bytes value.
     pub fn new_stream_bytes() -> Self {
-        Self::from_target(StreamTarget::new(BytesMut::new()).unwrap()).unwrap()
+        Self::from_target(StreamTarget::new(BytesMut::new()).unwrap())
+            .unwrap()
     }
 }
 
@@ -255,7 +256,10 @@ impl<Target: OctetsBuilder> MessageBuilder<Target> {
     ///
     /// Sets a random ID, pushes the domain and the AXFR record type into
     /// the question section, and converts the builder into an answer builder.
-    pub fn request_axfr<N: ToDname>(mut self, apex: N) -> Result<AnswerBuilder<Target>, ShortBuf> {
+    pub fn request_axfr<N: ToDname>(
+        mut self,
+        apex: N,
+    ) -> Result<AnswerBuilder<Target>, ShortBuf> {
         self.header_mut().set_random_id();
         let mut builder = self.question();
         builder.push((apex, Rtype::Axfr))?;
@@ -483,7 +487,10 @@ impl<Target: OctetsBuilder> QuestionBuilder<Target> {
     ///
     /// [`AsQuestion`]: ../question/trait.AsQuestion.html
     /// [`Question`]: ../question/trait.Question.html
-    pub fn push(&mut self, question: impl AsQuestion) -> Result<(), ShortBuf> {
+    pub fn push(
+        &mut self,
+        question: impl AsQuestion,
+    ) -> Result<(), ShortBuf> {
         let pos = self.as_target().len();
         question.compose_question(self.as_target_mut())?;
         self.counts_mut().inc_qdcount().map_err(|err| {
@@ -1405,7 +1412,9 @@ where
     }
 }
 
-impl<Target: OctetsBuilder> RecordSectionBuilder for AuthorityBuilder<Target> {
+impl<Target: OctetsBuilder> RecordSectionBuilder
+    for AuthorityBuilder<Target>
+{
     fn push(&mut self, record: impl AsRecord) -> Result<(), ShortBuf> {
         Self::push(self, record)
     }
@@ -1443,7 +1452,9 @@ pub struct OptBuilder<'a, Target> {
 
 impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
     /// Creates a new opt builder atop an additional builder.
-    fn new(additional: &'a mut AdditionalBuilder<Target>) -> Result<Self, ShortBuf> {
+    fn new(
+        additional: &'a mut AdditionalBuilder<Target>,
+    ) -> Result<Self, ShortBuf> {
         let start = additional.as_target().as_ref().len();
         let arcount = additional.counts().arcount();
 
@@ -1478,7 +1489,11 @@ impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
     ///
     /// The method will append an option with the given option code. The data
     /// of the option will be written via the closure `op`.
-    pub fn push_raw_option<F>(&mut self, code: OptionCode, op: F) -> Result<(), ShortBuf>
+    pub fn push_raw_option<F>(
+        &mut self,
+        code: OptionCode,
+        op: F,
+    ) -> Result<(), ShortBuf>
     where
         F: FnOnce(&mut Target) -> Result<(), ShortBuf>,
     {
@@ -1491,7 +1506,9 @@ impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
 
         // Update the length. If the option is too long, truncate and return
         // an error.
-        let len = self.as_target().as_ref().len() - self.start - (mem::size_of::<OptHeader>() + 2);
+        let len = self.as_target().as_ref().len()
+            - self.start
+            - (mem::size_of::<OptHeader>() + 2);
         if len > usize::from(u16::max_value()) {
             self.as_target_mut().truncate(pos);
             return Err(ShortBuf);
@@ -1569,7 +1586,9 @@ impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
     /// Returns a mutual reference the full OPT header.
     fn opt_header_mut(&mut self) -> &mut OptHeader {
         let start = self.start;
-        OptHeader::for_record_slice_mut(&mut self.as_target_mut().as_mut()[start..])
+        OptHeader::for_record_slice_mut(
+            &mut self.as_target_mut().as_mut()[start..],
+        )
     }
 
     /// Returns a reference to the underlying octets builder.
@@ -1767,7 +1786,10 @@ impl<Target> StaticCompressor<Target> {
     }
 
     /// Returns a known position of a domain name if there is one.
-    fn get<'a, N: Iterator<Item = &'a Label> + Clone>(&self, name: N) -> Option<u16>
+    fn get<'a, N: Iterator<Item = &'a Label> + Clone>(
+        &self,
+        name: N,
+    ) -> Option<u16>
     where
         Target: AsRef<[u8]>,
     {
@@ -1831,7 +1853,10 @@ impl<Target: OctetsBuilder> OctetsBuilder for StaticCompressor<Target> {
         }
     }
 
-    fn append_compressed_dname<N: ToDname>(&mut self, name: &N) -> Result<(), ShortBuf> {
+    fn append_compressed_dname<N: ToDname>(
+        &mut self,
+        name: &N,
+    ) -> Result<(), ShortBuf> {
         let mut name = name.iter_labels().peekable();
 
         loop {
@@ -1962,7 +1987,10 @@ impl<Target> TreeCompressor<Target> {
         self.target.as_mut()
     }
 
-    fn get<'a, N: Iterator<Item = &'a Label> + Clone>(&self, name: N) -> Option<u16> {
+    fn get<'a, N: Iterator<Item = &'a Label> + Clone>(
+        &self,
+        name: N,
+    ) -> Option<u16> {
         let mut node = &self.start;
         for label in name {
             if label.is_root() {
@@ -1973,7 +2001,11 @@ impl<Target> TreeCompressor<Target> {
         None
     }
 
-    fn insert<'a, N: Iterator<Item = &'a Label> + Clone>(&mut self, name: N, pos: usize) -> bool {
+    fn insert<'a, N: Iterator<Item = &'a Label> + Clone>(
+        &mut self,
+        name: N,
+        pos: usize,
+    ) -> bool {
         if pos >= 0xC000 {
             return false;
         }
@@ -2024,7 +2056,10 @@ impl<Target: OctetsBuilder> OctetsBuilder for TreeCompressor<Target> {
         }
     }
 
-    fn append_compressed_dname<N: ToDname>(&mut self, name: &N) -> Result<(), ShortBuf> {
+    fn append_compressed_dname<N: ToDname>(
+        &mut self,
+        name: &N,
+    ) -> Result<(), ShortBuf> {
         let mut name = name.iter_labels().peekable();
 
         loop {
@@ -2084,8 +2119,10 @@ mod test {
 
         // Create a message builder wrapping a compressor wrapping a stream
         // target.
-        let mut msg =
-            MessageBuilder::from_target(StaticCompressor::new(StreamTarget::new_vec())).unwrap();
+        let mut msg = MessageBuilder::from_target(StaticCompressor::new(
+            StreamTarget::new_vec(),
+        ))
+        .unwrap();
 
         // Set the RD bit in the header and proceed to the question section.
         msg.header_mut().set_rd(true);
@@ -2181,7 +2218,15 @@ mod test {
         msg.push((
             Dname::root_slice(),
             86390,
-            Soa::new(mname, rname, Serial(2020081701), 1800, 900, 604800, 86400),
+            Soa::new(
+                mname,
+                rname,
+                Serial(2020081701),
+                1800,
+                900,
+                604800,
+                86400,
+            ),
         ))
         .unwrap();
         msg.finish()
@@ -2191,14 +2236,16 @@ mod test {
     fn compressor() {
         // An example negative response to `example. NS` with an SOA to test various compressed name situations.
         let expect = &[
-            0x00, 0x00, 0x81, 0x83, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x07, 0x65,
-            0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x06,
-            0x00, 0x01, 0x00, 0x01, 0x51, 0x76, 0x00, 0x40, 0x01, 0x61, 0x0c, 0x72, 0x6f, 0x6f,
-            0x74, 0x2d, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x73, 0x03, 0x6e, 0x65, 0x74, 0x00,
-            0x05, 0x6e, 0x73, 0x74, 0x6c, 0x64, 0x0c, 0x76, 0x65, 0x72, 0x69, 0x73, 0x69, 0x67,
-            0x6e, 0x2d, 0x67, 0x72, 0x73, 0x03, 0x63, 0x6f, 0x6d, 0x00, 0x78, 0x68, 0x00, 0x25,
-            0x00, 0x00, 0x07, 0x08, 0x00, 0x00, 0x03, 0x84, 0x00, 0x09, 0x3a, 0x80, 0x00, 0x01,
-            0x51, 0x80,
+            0x00, 0x00, 0x81, 0x83, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x00, 0x00,
+            0x02, 0x00, 0x01, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x51,
+            0x76, 0x00, 0x40, 0x01, 0x61, 0x0c, 0x72, 0x6f, 0x6f, 0x74, 0x2d,
+            0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x73, 0x03, 0x6e, 0x65, 0x74,
+            0x00, 0x05, 0x6e, 0x73, 0x74, 0x6c, 0x64, 0x0c, 0x76, 0x65, 0x72,
+            0x69, 0x73, 0x69, 0x67, 0x6e, 0x2d, 0x67, 0x72, 0x73, 0x03, 0x63,
+            0x6f, 0x6d, 0x00, 0x78, 0x68, 0x00, 0x25, 0x00, 0x00, 0x07, 0x08,
+            0x00, 0x00, 0x03, 0x84, 0x00, 0x09, 0x3a, 0x80, 0x00, 0x01, 0x51,
+            0x80,
         ];
 
         let msg = create_compressed(StaticCompressor::new(Vec::new()));

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -102,7 +102,9 @@ pub use self::message_builder::TreeCompressor;
 pub use self::message_builder::{
     MessageBuilder, RecordSectionBuilder, StaticCompressor, StreamTarget,
 };
-pub use self::name::{Dname, DnameBuilder, ParsedDname, RelativeDname, ToDname, ToRelativeDname};
+pub use self::name::{
+    Dname, DnameBuilder, ParsedDname, RelativeDname, ToDname, ToRelativeDname,
+};
 #[cfg(feature = "smallvec")]
 pub use self::octets::OctetsVec;
 pub use self::octets::{Compose, Parser, ShortBuf};

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -28,10 +28,10 @@
 //! wire-format messages other forms of representation conversion such as
 //! reading from a master file, we use the term *parsing* for extracting data
 //! from a wire-format representation and *composing* for producing such a
-//! representation. 
+//! representation.
 //!
 //! Both parsing and composing happen on buffers holding a complete DNS
-//! message. This seems to be a reasonable choice given the limited 
+//! message. This seems to be a reasonable choice given the limited
 //! size of DNS messages and the complexities introduced by compressing
 //! domain names in message by referencing other parts of the message.
 //! The fundamental types for parsing and composing are also part of the
@@ -97,18 +97,18 @@ pub use self::cmp::CanonicalOrd;
 pub use self::header::{Header, HeaderCounts, HeaderSection};
 pub use self::iana::Rtype;
 pub use self::message::{Message, QuestionSection, RecordSection};
+#[cfg(feature = "std")]
+pub use self::message_builder::TreeCompressor;
 pub use self::message_builder::{
-    MessageBuilder, RecordSectionBuilder, StaticCompressor, StreamTarget
+    MessageBuilder, RecordSectionBuilder, StaticCompressor, StreamTarget,
 };
-#[cfg(feature = "std")] pub use self::message_builder::TreeCompressor;
-pub use self::name::{
-    Dname, DnameBuilder, ParsedDname, RelativeDname, ToDname, ToRelativeDname
-};
-pub use self::octets::{Compose, Parser, ShortBuf}; 
-#[cfg(feature = "smallvec")] pub use self::octets::OctetsVec;
+pub use self::name::{Dname, DnameBuilder, ParsedDname, RelativeDname, ToDname, ToRelativeDname};
+#[cfg(feature = "smallvec")]
+pub use self::octets::OctetsVec;
+pub use self::octets::{Compose, Parser, ShortBuf};
 pub use self::question::Question;
 pub use self::rdata::{ParseRecordData, RecordData, UnknownRecordData};
-pub use self::record::{Record, RecordHeader, ParsedRecord};
+pub use self::record::{ParsedRecord, Record, RecordHeader};
 pub use self::serial::Serial;
 
 //--- Modules
@@ -123,9 +123,8 @@ pub mod name;
 pub mod net;
 pub mod octets;
 pub mod opt;
+pub mod question;
 pub mod rdata;
 pub mod record;
-pub mod question;
 pub mod serial;
 pub mod str;
-

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -57,7 +57,11 @@ impl<Builder> DnameBuilder<Builder> {
     where
         Builder: EmptyBuilder,
     {
-        unsafe { DnameBuilder::from_builder_unchecked(Builder::with_capacity(capacity)) }
+        unsafe {
+            DnameBuilder::from_builder_unchecked(Builder::with_capacity(
+                capacity,
+            ))
+        }
     }
 
     /// Creates a new domain name builder atop an existing octets builder.
@@ -204,7 +208,10 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
     /// bytes.
     //
     //  XXX NEEDS TESTS
-    pub fn append_name<N: ToRelativeDname>(&mut self, name: &N) -> Result<(), PushNameError> {
+    pub fn append_name<N: ToRelativeDname>(
+        &mut self,
+        name: &N,
+    ) -> Result<(), PushNameError> {
         let head = self.head.take();
         self.end_label();
         if self.len() + name.len() > 254 {
@@ -342,15 +349,12 @@ where
     let ch = chars.next().ok_or(FromStrError::UnexpectedEnd)?;
     if ('0'..='9').contains(&ch) {
         let v = ch.to_digit(10).unwrap() * 100
-            + chars
-                .next()
-                .ok_or(FromStrError::UnexpectedEnd)
-                .and_then(|c| c.to_digit(10).ok_or(FromStrError::IllegalEscape))?
-                * 10
-            + chars
-                .next()
-                .ok_or(FromStrError::UnexpectedEnd)
-                .and_then(|c| c.to_digit(10).ok_or(FromStrError::IllegalEscape))?;
+            + chars.next().ok_or(FromStrError::UnexpectedEnd).and_then(
+                |c| c.to_digit(10).ok_or(FromStrError::IllegalEscape),
+            )? * 10
+            + chars.next().ok_or(FromStrError::UnexpectedEnd).and_then(
+                |c| c.to_digit(10).ok_or(FromStrError::IllegalEscape),
+            )?;
         if v > 255 {
             return Err(FromStrError::IllegalEscape);
         }
@@ -506,12 +510,24 @@ impl From<PushNameError> for FromStrError {
 impl fmt::Display for FromStrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            FromStrError::UnexpectedEnd => f.write_str("unexpected end of input"),
-            FromStrError::EmptyLabel => f.write_str("an empty label was encountered"),
-            FromStrError::BinaryLabel => f.write_str("a binary label was encountered"),
-            FromStrError::LongLabel => f.write_str("label length limit exceeded"),
-            FromStrError::IllegalEscape => f.write_str("illegal escape sequence"),
-            FromStrError::IllegalCharacter(char) => write!(f, "illegal character '{}'", char),
+            FromStrError::UnexpectedEnd => {
+                f.write_str("unexpected end of input")
+            }
+            FromStrError::EmptyLabel => {
+                f.write_str("an empty label was encountered")
+            }
+            FromStrError::BinaryLabel => {
+                f.write_str("a binary label was encountered")
+            }
+            FromStrError::LongLabel => {
+                f.write_str("label length limit exceeded")
+            }
+            FromStrError::IllegalEscape => {
+                f.write_str("illegal escape sequence")
+            }
+            FromStrError::IllegalCharacter(char) => {
+                write!(f, "illegal character '{}'", char)
+            }
             FromStrError::LongName => f.write_str("long domain name"),
             FromStrError::ShortBuf => ShortBuf.fmt(f),
         }

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -3,19 +3,20 @@
 //! This is a private module for tidiness. `DnameBuilder` and `PushError`
 //! are re-exported by the parent module.
 
-use core::{fmt, ops};
-#[cfg(feature = "std")] use std::vec::Vec;
-#[cfg(feature = "bytes")] use bytes::BytesMut;
 use super::super::octets::{EmptyBuilder, OctetsBuilder, ShortBuf};
 use super::dname::Dname;
 use super::relative::{RelativeDname, RelativeDnameError};
 use super::traits::{ToDname, ToRelativeDname};
-
+#[cfg(feature = "bytes")]
+use bytes::BytesMut;
+use core::{fmt, ops};
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 //------------ DnameBuilder --------------------------------------------------
 
 /// Builds a domain name step by step by appending data.
-/// 
+///
 /// The domain name builder is the most fundamental way to construct a new
 /// domain name. It wraps an octets builder and allows adding single octets,
 /// octet slices, or entire labels.
@@ -37,23 +38,26 @@ impl<Builder> DnameBuilder<Builder> {
     /// domain name. Since that may not be the case, this function is
     /// unsafe.
     pub(super) unsafe fn from_builder_unchecked(builder: Builder) -> Self {
-        DnameBuilder { builder, head: None }
+        DnameBuilder {
+            builder,
+            head: None,
+        }
     }
 
     /// Creates a new, empty name builder.
     pub fn new() -> Self
-    where Builder: EmptyBuilder {
+    where
+        Builder: EmptyBuilder,
+    {
         unsafe { DnameBuilder::from_builder_unchecked(Builder::empty()) }
     }
 
     /// Creates a new, empty builder with a given capacity.
     pub fn with_capacity(capacity: usize) -> Self
-    where Builder: EmptyBuilder {
-        unsafe {
-            DnameBuilder::from_builder_unchecked(
-                Builder::with_capacity(capacity)
-            )
-        }
+    where
+        Builder: EmptyBuilder,
+    {
+        unsafe { DnameBuilder::from_builder_unchecked(Builder::with_capacity(capacity)) }
     }
 
     /// Creates a new domain name builder atop an existing octets builder.
@@ -61,7 +65,9 @@ impl<Builder> DnameBuilder<Builder> {
     /// The function checks that whatever is in the builder already
     /// consititutes a correctly encoded relative domain name.
     pub fn from_builder(builder: Builder) -> Result<Self, RelativeDnameError>
-    where Builder: OctetsBuilder {
+    where
+        Builder: OctetsBuilder,
+    {
         RelativeDname::check_slice(builder.as_ref())?;
         Ok(unsafe { DnameBuilder::from_builder_unchecked(builder) })
     }
@@ -83,7 +89,7 @@ impl DnameBuilder<Vec<u8>> {
     }
 }
 
-#[cfg(feature="bytes")] 
+#[cfg(feature = "bytes")]
 impl DnameBuilder<BytesMut> {
     /// Creates an empty domain name bulider atop a bytes value.
     pub fn new_bytes() -> Self {
@@ -121,11 +127,10 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
         }
         if let Some(head) = self.head {
             if len - head > 63 {
-                return Err(PushError::LongLabel)
+                return Err(PushError::LongLabel);
             }
             self.builder.append_slice(&[ch])?;
-        }
-        else {
+        } else {
             self.head = Some(len);
             self.builder.append_slice(&[0, ch])?;
         }
@@ -140,19 +145,18 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
     /// If `slice` is empty, does absolutely nothing.
     pub fn append_slice(&mut self, slice: &[u8]) -> Result<(), PushError> {
         if slice.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         if let Some(head) = self.head {
             if slice.len() > 63 - (self.len() - head) {
-                return Err(PushError::LongLabel)
+                return Err(PushError::LongLabel);
             }
-        }
-        else {
+        } else {
             if slice.len() > 63 {
-                return Err(PushError::LongLabel)
+                return Err(PushError::LongLabel);
             }
             if self.len() + slice.len() > 254 {
-                return Err(PushError::LongName)
+                return Err(PushError::LongName);
             }
             self.head = Some(self.len());
             self.builder.append_slice(&[0])?;
@@ -185,7 +189,7 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
         self.end_label();
         if let Err(err) = self.append_slice(label) {
             self.head = head;
-            return Err(err)
+            return Err(err);
         }
         self.end_label();
         Ok(())
@@ -200,14 +204,12 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
     /// bytes.
     //
     //  XXX NEEDS TESTS
-    pub fn append_name<N: ToRelativeDname>(
-        &mut self, name: &N
-    ) -> Result<(), PushNameError> {
+    pub fn append_name<N: ToRelativeDname>(&mut self, name: &N) -> Result<(), PushNameError> {
         let head = self.head.take();
         self.end_label();
         if self.len() + name.len() > 254 {
             self.head = head;
-            return Err(PushNameError::LongName)
+            return Err(PushNameError::LongName);
         }
         for label in name.iter_labels() {
             label.build(&mut self.builder)?
@@ -233,14 +235,14 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
     /// [`in_label`] #method.in_label
     pub fn append_chars<C: IntoIterator<Item = char>>(
         &mut self,
-        chars: C
+        chars: C,
     ) -> Result<(), FromStrError> {
         let mut chars = chars.into_iter();
         while let Some(ch) = chars.next() {
             match ch {
                 '.' => {
                     if !self.in_label() {
-                        return Err(FromStrError::EmptyLabel)
+                        return Err(FromStrError::EmptyLabel);
                     }
                     self.end_label();
                 }
@@ -248,17 +250,15 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
                     let in_label = self.in_label();
                     self.push(parse_escape(&mut chars, in_label)?)?;
                 }
-                ' ' ..= '-' | '/' ..= '[' | ']' ..= '~' => {
-                    self.push(ch as u8)?
-                }
-                _ => return Err(FromStrError::IllegalCharacter(ch))
+                ' '..='-' | '/'..='[' | ']'..='~' => self.push(ch as u8)?,
+                _ => return Err(FromStrError::IllegalCharacter(ch)),
             }
         }
         Ok(())
     }
 
     /// Finishes building the name and returns the resulting relative name.
-    /// 
+    ///
     /// If there currently is a label being built, ends the label first
     /// before returning the name. I.e., you don’t have to call [`end_label`]
     /// explicitely.
@@ -269,13 +269,9 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
     ///
     /// [`end_label`]: #method.end_label
     /// [`into_dname`]: #method.into_dname
-    pub fn finish(
-        mut self
-    ) -> RelativeDname<Builder::Octets> {
+    pub fn finish(mut self) -> RelativeDname<Builder::Octets> {
         self.end_label();
-        unsafe {
-            RelativeDname::from_octets_unchecked(self.builder.freeze())
-        }
+        unsafe { RelativeDname::from_octets_unchecked(self.builder.freeze()) }
     }
 
     /// Appends the root label to the name and returns it as a `Dname`.
@@ -283,38 +279,32 @@ impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
     /// If there currently is a label under construction, ends the label.
     /// Then adds the empty root label and transforms the name into a
     /// `Dname`.
-    pub fn into_dname(
-        mut self
-    ) -> Result<Dname<Builder::Octets>, PushError> {
+    pub fn into_dname(mut self) -> Result<Dname<Builder::Octets>, PushError> {
         self.end_label();
         self.builder.append_slice(&[0])?;
-        Ok(unsafe {
-            Dname::from_octets_unchecked(self.builder.freeze())
-        })
+        Ok(unsafe { Dname::from_octets_unchecked(self.builder.freeze()) })
     }
 
     /// Appends an origin and returns the resulting `Dname`.
     /// If there currently is a label under construction, ends the label.
     /// Then adds the `origin` and transforms the name into a
-    /// `Dname`. 
+    /// `Dname`.
     //
     //  XXX NEEDS TESTS
     pub fn append_origin<N: ToDname>(
-        mut self, origin: &N
+        mut self,
+        origin: &N,
     ) -> Result<Dname<Builder::Octets>, PushNameError> {
         self.end_label();
         if self.len() + origin.len() > 255 {
-            return Err(PushNameError::LongName)
+            return Err(PushNameError::LongName);
         }
         for label in origin.iter_labels() {
             label.build(&mut self.builder)?
         }
-        Ok(unsafe {
-            Dname::from_octets_unchecked(self.builder.freeze())
-        })
+        Ok(unsafe { Dname::from_octets_unchecked(self.builder.freeze()) })
     }
 }
-
 
 //--- Default
 
@@ -323,7 +313,6 @@ impl<Builder: EmptyBuilder> Default for DnameBuilder<Builder> {
         Self::new()
     }
 }
-
 
 //--- Deref and AsRef
 
@@ -341,42 +330,43 @@ impl<Builder: OctetsBuilder> AsRef<[u8]> for DnameBuilder<Builder> {
     }
 }
 
-
 //------------ Santa’s Little Helpers ----------------------------------------
 
 /// Parses the contents of an escape sequence from `chars`.
 ///
 /// The backslash should already have been taken out of `chars`.
 fn parse_escape<C>(chars: &mut C, in_label: bool) -> Result<u8, FromStrError>
-                where C: Iterator<Item=char> {
+where
+    C: Iterator<Item = char>,
+{
     let ch = chars.next().ok_or(FromStrError::UnexpectedEnd)?;
     if ('0'..='9').contains(&ch) {
         let v = ch.to_digit(10).unwrap() * 100
-              + chars.next().ok_or(FromStrError::UnexpectedEnd)
-                     .and_then(|c| c.to_digit(10)
-                                    .ok_or(FromStrError::IllegalEscape))?
-                     * 10
-              + chars.next().ok_or(FromStrError::UnexpectedEnd)
-                     .and_then(|c| c.to_digit(10)
-                                    .ok_or(FromStrError::IllegalEscape))?;
+            + chars
+                .next()
+                .ok_or(FromStrError::UnexpectedEnd)
+                .and_then(|c| c.to_digit(10).ok_or(FromStrError::IllegalEscape))?
+                * 10
+            + chars
+                .next()
+                .ok_or(FromStrError::UnexpectedEnd)
+                .and_then(|c| c.to_digit(10).ok_or(FromStrError::IllegalEscape))?;
         if v > 255 {
-            return Err(FromStrError::IllegalEscape)
+            return Err(FromStrError::IllegalEscape);
         }
         Ok(v as u8)
-    }
-    else if ch == '[' {
+    } else if ch == '[' {
         // `\[` at the start of a label marks a binary label which we don’t
         // support. Within a label, the sequence is fine.
         if in_label {
             Ok(b'[')
-        }
-        else {
+        } else {
             Err(FromStrError::BinaryLabel)
         }
+    } else {
+        Ok(ch as u8)
     }
-    else { Ok(ch as u8) }
 }
-
 
 //============ Error Types ===================================================
 
@@ -395,7 +385,6 @@ pub enum PushError {
     ShortBuf,
 }
 
-
 //--- From
 
 impl From<ShortBuf> for PushError {
@@ -404,25 +393,20 @@ impl From<ShortBuf> for PushError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for PushError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            PushError::LongLabel
-                => f.write_str("long label"),
-            PushError::LongName
-                => f.write_str("long domain name"),
-            PushError::ShortBuf
-                => ShortBuf.fmt(f)
+            PushError::LongLabel => f.write_str("long label"),
+            PushError::LongName => f.write_str("long domain name"),
+            PushError::ShortBuf => ShortBuf.fmt(f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for PushError { }
-
+impl std::error::Error for PushError {}
 
 //------------ PushNameError -------------------------------------------------
 
@@ -444,23 +428,19 @@ impl From<ShortBuf> for PushNameError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for PushNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            PushNameError::LongName
-                => f.write_str("long domain name"),
-            PushNameError::ShortBuf
-                => ShortBuf.fmt(f)
+            PushNameError::LongName => f.write_str("long domain name"),
+            PushNameError::ShortBuf => ShortBuf.fmt(f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for PushNameError { }
-
+impl std::error::Error for PushNameError {}
 
 //------------ FromStrError --------------------------------------------------
 
@@ -500,7 +480,6 @@ pub enum FromStrError {
     ShortBuf,
 }
 
-
 //--- From
 
 impl From<PushError> for FromStrError {
@@ -522,35 +501,25 @@ impl From<PushNameError> for FromStrError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for FromStrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            FromStrError::UnexpectedEnd
-                => f.write_str("unexpected end of input"),
-            FromStrError::EmptyLabel
-                => f.write_str("an empty label was encountered"),
-            FromStrError::BinaryLabel
-                => f.write_str("a binary label was encountered"),
-            FromStrError::LongLabel
-                => f.write_str("label length limit exceeded"),
-            FromStrError::IllegalEscape
-                => f.write_str("illegal escape sequence"),
-            FromStrError::IllegalCharacter(char)
-                => write!(f, "illegal character '{}'", char),
-            FromStrError::LongName
-                => f.write_str("long domain name"),
-            FromStrError::ShortBuf
-                => ShortBuf.fmt(f)
+            FromStrError::UnexpectedEnd => f.write_str("unexpected end of input"),
+            FromStrError::EmptyLabel => f.write_str("an empty label was encountered"),
+            FromStrError::BinaryLabel => f.write_str("a binary label was encountered"),
+            FromStrError::LongLabel => f.write_str("label length limit exceeded"),
+            FromStrError::IllegalEscape => f.write_str("illegal escape sequence"),
+            FromStrError::IllegalCharacter(char) => write!(f, "illegal character '{}'", char),
+            FromStrError::LongName => f.write_str("long domain name"),
+            FromStrError::ShortBuf => ShortBuf.fmt(f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for FromStrError { }
-
+impl std::error::Error for FromStrError {}
 
 //============ Testing =======================================================
 
@@ -571,8 +540,7 @@ mod test {
         builder.append_slice(b"le").unwrap();
         builder.end_label();
         builder.append_slice(b"com").unwrap();
-        assert_eq!(builder.finish().as_slice(),
-                   b"\x03www\x07example\x03com");
+        assert_eq!(builder.finish().as_slice(), b"\x03www\x07example\x03com");
     }
 
     #[test]
@@ -581,8 +549,7 @@ mod test {
         builder.append_label(b"www").unwrap();
         builder.append_label(b"example").unwrap();
         builder.append_label(b"com").unwrap();
-        assert_eq!(builder.finish().as_slice(),
-                   b"\x03www\x07example\x03com");
+        assert_eq!(builder.finish().as_slice(), b"\x03www\x07example\x03com");
     }
 
     #[test]
@@ -592,15 +559,14 @@ mod test {
         builder.append_slice(b"ww").unwrap();
         builder.append_label(b"example").unwrap();
         builder.append_slice(b"com").unwrap();
-        assert_eq!(builder.finish().as_slice(),
-                   b"\x03www\x07example\x03com");
+        assert_eq!(builder.finish().as_slice(), b"\x03www\x07example\x03com");
     }
 
     #[test]
     fn name_limit() {
         let mut builder = DnameBuilder::new_vec();
         for _ in 0..25 {
-            // 9 bytes label is 10 bytes in total 
+            // 9 bytes label is 10 bytes in total
             builder.append_label(b"123456789").unwrap();
         }
 
@@ -619,10 +585,14 @@ mod test {
     fn label_limit() {
         let mut builder = DnameBuilder::new_vec();
         builder.append_label(&[0u8; 63][..]).unwrap();
-        assert_eq!(builder.append_label(&[0u8; 64][..]),
-                   Err(PushError::LongLabel));
-        assert_eq!(builder.append_label(&[0u8; 164][..]),
-                   Err(PushError::LongLabel));
+        assert_eq!(
+            builder.append_label(&[0u8; 64][..]),
+            Err(PushError::LongLabel)
+        );
+        assert_eq!(
+            builder.append_label(&[0u8; 164][..]),
+            Err(PushError::LongLabel)
+        );
 
         builder.append_slice(&[0u8; 60][..]).unwrap();
         let _ = builder.clone().append_label(b"123").unwrap();
@@ -638,8 +608,7 @@ mod test {
         builder.append_label(b"www").unwrap();
         builder.append_label(b"example").unwrap();
         builder.append_slice(b"com").unwrap();
-        assert_eq!(builder.finish().as_slice(),
-                   b"\x03www\x07example\x03com");
+        assert_eq!(builder.finish().as_slice(), b"\x03www\x07example\x03com");
     }
 
     #[test]

--- a/src/base/name/chain.rs
+++ b/src/base/name/chain.rs
@@ -3,13 +3,12 @@
 //! This is a private module. Its public types are re-exported by the parent
 //! crate.
 
-use core::{fmt, iter};
-use super::label::Label;
 use super::super::octets::{Compose, OctetsBuilder, ShortBuf};
+use super::label::Label;
 use super::relative::DnameIter;
 use super::traits::{ToDname, ToEitherDname, ToLabelIter, ToRelativeDname};
 use super::uncertain::UncertainDname;
-
+use core::{fmt, iter};
 
 //------------ Chain ---------------------------------------------------------
 
@@ -44,8 +43,7 @@ impl<L: ToEitherDname, R: ToEitherDname> Chain<L, R> {
     pub(super) fn new(left: L, right: R) -> Result<Self, LongChainError> {
         if left.len() + right.len() > 255 {
             Err(LongChainError)
-        }
-        else {
+        } else {
             Ok(Chain { left, right })
         }
     }
@@ -53,15 +51,16 @@ impl<L: ToEitherDname, R: ToEitherDname> Chain<L, R> {
 
 impl<Octets: AsRef<[u8]>, R: ToEitherDname> Chain<UncertainDname<Octets>, R> {
     /// Creates a chain from an uncertain name.
-    /// 
+    ///
     /// This function is separate because the ultimate size depends on the
     /// variant of the left name.
     pub(super) fn new_uncertain(
-        left: UncertainDname<Octets>, right: R
+        left: UncertainDname<Octets>,
+        right: R,
     ) -> Result<Self, LongChainError> {
         if let UncertainDname::Relative(ref name) = left {
             if name.len() + right.len() > 255 {
-                return Err(LongChainError)
+                return Err(LongChainError);
             }
         }
         Ok(Chain { left, right })
@@ -82,10 +81,7 @@ impl<L: ToRelativeDname, R: ToEitherDname> Chain<L, R> {
     /// [`Compose`]: ../compose/trait.Compose.html
     /// [`ToDname`]: trait.ToDname.html
     /// [`ToRelativeDname`]: trait.ToRelativeDname.html
-    pub fn chain<N: ToEitherDname>(
-        self,
-        other: N
-    ) -> Result<Chain<Self, N>, LongChainError> {
+    pub fn chain<N: ToEitherDname>(self, other: N) -> Result<Chain<Self, N>, LongChainError> {
         Chain::new(self, other)
     }
 }
@@ -97,24 +93,17 @@ impl<L, R> Chain<L, R> {
     }
 }
 
-
 //--- Compose
 
 impl<L: ToRelativeDname, R: ToEitherDname> Compose for Chain<L, R> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.left.compose(target)?;
             self.right.compose(target)
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.left.compose_canonical(target)?;
             self.right.compose_canonical(target)
@@ -123,45 +112,34 @@ impl<L: ToRelativeDname, R: ToEitherDname> Compose for Chain<L, R> {
 }
 
 impl<Octets, R: ToDname> Compose for Chain<UncertainDname<Octets>, R>
-where Octets: AsRef<[u8]>, R: ToDname {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+where
+    Octets: AsRef<[u8]>,
+    R: ToDname,
+{
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         match self.left {
             UncertainDname::Absolute(ref name) => name.compose(target),
-            UncertainDname::Relative(ref name) => {
-                target.append_all(|target| {
-                    name.compose(target)?;
-                    self.right.compose(target)
-                })
-            }
+            UncertainDname::Relative(ref name) => target.append_all(|target| {
+                name.compose(target)?;
+                self.right.compose(target)
+            }),
         }
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         match self.left {
-            UncertainDname::Absolute(ref name) => {
-                name.compose_canonical(target)
-            }
-            UncertainDname::Relative(ref name) => {
-                target.append_all(|target| {
-                    name.compose_canonical(target)?;
-                    self.right.compose_canonical(target)
-                })
-            }
+            UncertainDname::Absolute(ref name) => name.compose_canonical(target),
+            UncertainDname::Relative(ref name) => target.append_all(|target| {
+                name.compose_canonical(target)?;
+                self.right.compose_canonical(target)
+            }),
         }
     }
 }
 
-
 //--- ToLabelIter, ToRelativeDname, ToDname
 
-impl<'a, L: ToRelativeDname, R: ToEitherDname> ToLabelIter<'a>
-            for Chain<L, R> {
+impl<'a, L: ToRelativeDname, R: ToEitherDname> ToLabelIter<'a> for Chain<L, R> {
     type LabelIter = ChainIter<'a, L, R>;
 
     fn iter_labels(&'a self) -> Self::LabelIter {
@@ -170,34 +148,32 @@ impl<'a, L: ToRelativeDname, R: ToEitherDname> ToLabelIter<'a>
 }
 
 impl<'a, Octets, R> ToLabelIter<'a> for Chain<UncertainDname<Octets>, R>
-where Octets: AsRef<[u8]>, R: ToDname {
+where
+    Octets: AsRef<[u8]>,
+    R: ToDname,
+{
     type LabelIter = UncertainChainIter<'a, Octets, R>;
 
     fn iter_labels(&'a self) -> Self::LabelIter {
         match self.left {
-            UncertainDname::Absolute(ref name) => {
-                UncertainChainIter::Absolute(name.iter_labels())
-            }
-            UncertainDname::Relative(ref name) => {
-                UncertainChainIter::Relative(
-                    ChainIter(name.iter_labels()
-                                  .chain(self.right.iter_labels()))
-                )
-            }
+            UncertainDname::Absolute(ref name) => UncertainChainIter::Absolute(name.iter_labels()),
+            UncertainDname::Relative(ref name) => UncertainChainIter::Relative(ChainIter(
+                name.iter_labels().chain(self.right.iter_labels()),
+            )),
         }
     }
 }
 
-impl<L: ToRelativeDname, R: ToRelativeDname> ToRelativeDname for Chain<L, R> {
-}
+impl<L: ToRelativeDname, R: ToRelativeDname> ToRelativeDname for Chain<L, R> {}
 
-impl<L: ToRelativeDname, R: ToDname> ToDname for Chain<L, R> {
-}
+impl<L: ToRelativeDname, R: ToDname> ToDname for Chain<L, R> {}
 
 impl<Octets, R> ToDname for Chain<UncertainDname<Octets>, R>
-where Octets: AsRef<[u8]>, R: ToDname
-{ }
-
+where
+    Octets: AsRef<[u8]>,
+    R: ToDname,
+{
+}
 
 //--- Display
 
@@ -207,24 +183,29 @@ impl<L: fmt::Display, R: fmt::Display> fmt::Display for Chain<L, R> {
     }
 }
 
-
 //------------ ChainIter -----------------------------------------------------
 
 /// The label iterator for chained domain names.
 #[derive(Debug)]
 pub struct ChainIter<'a, L: ToLabelIter<'a>, R: ToLabelIter<'a>>(
-    iter::Chain<L::LabelIter, R::LabelIter>
+    iter::Chain<L::LabelIter, R::LabelIter>,
 );
 
 impl<'a, L, R> Clone for ChainIter<'a, L, R>
-where L: ToLabelIter<'a>, R: ToLabelIter<'a> {
+where
+    L: ToLabelIter<'a>,
+    R: ToLabelIter<'a>,
+{
     fn clone(&self) -> Self {
         ChainIter(self.0.clone())
     }
 }
 
 impl<'a, L, R> Iterator for ChainIter<'a, L, R>
-        where L: ToLabelIter<'a>, R: ToLabelIter<'a> {
+where
+    L: ToLabelIter<'a>,
+    R: ToLabelIter<'a>,
+{
     type Item = &'a Label;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -233,12 +214,14 @@ impl<'a, L, R> Iterator for ChainIter<'a, L, R>
 }
 
 impl<'a, L, R> DoubleEndedIterator for ChainIter<'a, L, R>
-        where L: ToLabelIter<'a>, R: ToLabelIter<'a> {
+where
+    L: ToLabelIter<'a>,
+    R: ToLabelIter<'a>,
+{
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
     }
 }
-
 
 //------------ UncertainChainIter --------------------------------------------
 
@@ -249,41 +232,47 @@ pub enum UncertainChainIter<'a, Octets: AsRef<[u8]>, R: ToLabelIter<'a>> {
 }
 
 impl<'a, Octets, R> Clone for UncertainChainIter<'a, Octets, R>
-where Octets: AsRef<[u8]>, R: ToLabelIter<'a> {
+where
+    Octets: AsRef<[u8]>,
+    R: ToLabelIter<'a>,
+{
     fn clone(&self) -> Self {
         use UncertainChainIter::*;
 
         match *self {
             Absolute(ref inner) => Absolute(inner.clone()),
-            Relative(ref inner) => Relative(inner.clone())
+            Relative(ref inner) => Relative(inner.clone()),
         }
     }
 }
 
 impl<'a, Octets, R> Iterator for UncertainChainIter<'a, Octets, R>
-where Octets: AsRef<[u8]>, R: ToLabelIter<'a>
+where
+    Octets: AsRef<[u8]>,
+    R: ToLabelIter<'a>,
 {
     type Item = &'a Label;
 
     fn next(&mut self) -> Option<Self::Item> {
         match *self {
             UncertainChainIter::Absolute(ref mut inner) => inner.next(),
-            UncertainChainIter::Relative(ref mut inner) => inner.next()
+            UncertainChainIter::Relative(ref mut inner) => inner.next(),
         }
     }
 }
 
 impl<'a, Octets, R> DoubleEndedIterator for UncertainChainIter<'a, Octets, R>
-where Octets: AsRef<[u8]>, R: ToLabelIter<'a>
+where
+    Octets: AsRef<[u8]>,
+    R: ToLabelIter<'a>,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         match *self {
             UncertainChainIter::Absolute(ref mut inner) => inner.next_back(),
-            UncertainChainIter::Relative(ref mut inner) => inner.next_back()
+            UncertainChainIter::Relative(ref mut inner) => inner.next_back(),
         }
     }
 }
-
 
 //============ Error Types ===================================================
 
@@ -292,7 +281,6 @@ where Octets: AsRef<[u8]>, R: ToLabelIter<'a>
 /// Chaining domain names would exceed the size limit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LongChainError;
-
 
 //--- Display and Error
 
@@ -303,44 +291,42 @@ impl fmt::Display for LongChainError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for LongChainError { }
-
+impl std::error::Error for LongChainError {}
 
 //============ Testing =======================================================
 
 #[cfg(test)]
 mod test {
-    use crate::base::name::{Dname, RelativeDname, ToLabelIter};
     use super::*;
+    use crate::base::name::{Dname, RelativeDname, ToLabelIter};
 
     /// Tests that `ToDname` and `ToRelativeDname` are implemented for the
     /// right types.
     #[test]
     #[cfg(feature = "std")]
     fn impls() {
-        fn assert_to_dname<T: ToDname>(_: &T) { }
-        fn assert_to_relative_dname<T: ToRelativeDname>(_: &T) { }
+        fn assert_to_dname<T: ToDname>(_: &T) {}
+        fn assert_to_relative_dname<T: ToRelativeDname>(_: &T) {}
 
         let rel = RelativeDname::empty_ref()
-                                  .chain(RelativeDname::empty_ref()).unwrap();
+            .chain(RelativeDname::empty_ref())
+            .unwrap();
         assert_to_relative_dname(&rel);
+        assert_to_dname(&RelativeDname::empty_ref().chain(Dname::root_ref()).unwrap());
         assert_to_dname(
-            &RelativeDname::empty_ref().chain(Dname::root_ref()).unwrap()
-        );
-        assert_to_dname(
-            &RelativeDname::empty_ref().chain(
-                RelativeDname::empty_ref()
-            ).unwrap().chain(Dname::root_ref()).unwrap()
+            &RelativeDname::empty_ref()
+                .chain(RelativeDname::empty_ref())
+                .unwrap()
+                .chain(Dname::root_ref())
+                .unwrap(),
         );
         assert_to_dname(&rel.clone().chain(Dname::root_ref()).unwrap());
-        assert_to_relative_dname(
-            &rel.chain(RelativeDname::empty_ref()).unwrap()
-        );
+        assert_to_relative_dname(&rel.chain(RelativeDname::empty_ref()).unwrap());
+        assert_to_dname(&UncertainDname::root_vec().chain(Dname::root_vec()).unwrap());
         assert_to_dname(
-            &UncertainDname::root_vec().chain(Dname::root_vec()).unwrap()
-        );
-        assert_to_dname(
-            &UncertainDname::empty_vec().chain(Dname::root_vec()).unwrap()
+            &UncertainDname::empty_vec()
+                .chain(Dname::root_vec())
+                .unwrap(),
         );
     }
 
@@ -352,7 +338,7 @@ mod test {
 
         let mut builder = DnameBuilder::new_vec();
         for _ in 0..25 {
-            // 9 bytes label is 10 bytes in total 
+            // 9 bytes label is 10 bytes in total
             builder.append_label(b"123456789").unwrap();
         }
         let left = builder.finish();
@@ -371,88 +357,75 @@ mod test {
         let six_rel = builder.finish();
         assert_eq!(six_rel.len(), 6);
 
-        assert_eq!(
-            left.clone().chain(five_abs.clone()).unwrap().len(),
-            255
-        );
-        assert_eq!(
-            left.clone().chain(five_rel.clone()).unwrap().len(),
-            255
-        );
+        assert_eq!(left.clone().chain(five_abs.clone()).unwrap().len(), 255);
+        assert_eq!(left.clone().chain(five_rel.clone()).unwrap().len(), 255);
         assert!(left.clone().chain(six_abs.clone()).is_err());
         assert!(left.clone().chain(six_rel.clone()).is_err());
-        assert!(
-            left.clone().chain(
-                five_rel.clone()
-            ).unwrap().chain(five_abs.clone()).is_err()
-        );
-        assert!(
-            left.clone().chain(
-                five_rel.clone()
-            ).unwrap().chain(five_rel.clone()).is_err()
-        );
+        assert!(left
+            .clone()
+            .chain(five_rel.clone())
+            .unwrap()
+            .chain(five_abs.clone())
+            .is_err());
+        assert!(left
+            .clone()
+            .chain(five_rel.clone())
+            .unwrap()
+            .chain(five_rel.clone())
+            .is_err());
 
         let left = UncertainDname::from(left);
-        assert_eq!(
-            left.clone().chain(five_abs.clone()).unwrap().len(),
-            255
-        );
+        assert_eq!(left.clone().chain(five_abs.clone()).unwrap().len(), 255);
         assert!(left.clone().chain(six_abs.clone()).is_err());
 
         let left = UncertainDname::from(left.into_absolute().unwrap());
-        assert_eq!(
-            left.clone().chain(six_abs.clone()).unwrap().len(),
-            251
-        );
+        assert_eq!(left.clone().chain(six_abs.clone()).unwrap().len(), 251);
     }
 
     /// Tests that the label iterators all work as expected.
     #[test]
     fn iter_labels() {
-        fn cmp_iter<'a, I: Iterator<Item=&'a Label>>(
-            iter: I, labels: &[&[u8]]
-        ) {
+        fn cmp_iter<'a, I: Iterator<Item = &'a Label>>(iter: I, labels: &[&[u8]]) {
             let labels = labels.iter().map(|s| Label::from_slice(s).unwrap());
             assert!(iter.eq(labels))
         }
 
         let w = RelativeDname::from_octets(b"\x03www".as_ref()).unwrap();
-        let ec = RelativeDname::from_octets(
-            b"\x07example\x03com".as_ref()
-        ).unwrap();
-        let ecr = Dname::from_octets(
-            b"\x07example\x03com\x00".as_ref()
-        ).unwrap();
-        let fbr = Dname::from_octets(
-            b"\x03foo\x03bar\x00".as_ref()
-        ).unwrap();
+        let ec = RelativeDname::from_octets(b"\x07example\x03com".as_ref()).unwrap();
+        let ecr = Dname::from_octets(b"\x07example\x03com\x00".as_ref()).unwrap();
+        let fbr = Dname::from_octets(b"\x03foo\x03bar\x00".as_ref()).unwrap();
 
         cmp_iter(
-            w.clone().chain(ec.clone()).unwrap().iter_labels(), 
-            &[b"www", b"example", b"com"]
+            w.clone().chain(ec.clone()).unwrap().iter_labels(),
+            &[b"www", b"example", b"com"],
         );
         cmp_iter(
             w.clone().chain(ecr.clone()).unwrap().iter_labels(),
-            &[b"www", b"example", b"com", b""]
+            &[b"www", b"example", b"com", b""],
         );
         cmp_iter(
-            w.clone().chain(ec.clone()).unwrap().chain(
-                Dname::root_ref()
-            ).unwrap().iter_labels(),
-            &[b"www", b"example", b"com", b""]
+            w.clone()
+                .chain(ec.clone())
+                .unwrap()
+                .chain(Dname::root_ref())
+                .unwrap()
+                .iter_labels(),
+            &[b"www", b"example", b"com", b""],
         );
-        
+
         cmp_iter(
-            UncertainDname::from(w.clone()).chain(
-                ecr.clone()
-            ).unwrap().iter_labels(),
-            &[b"www", b"example", b"com", b""]
+            UncertainDname::from(w.clone())
+                .chain(ecr.clone())
+                .unwrap()
+                .iter_labels(),
+            &[b"www", b"example", b"com", b""],
         );
         cmp_iter(
-            UncertainDname::from(ecr.clone()).chain(
-                fbr.clone()
-            ).unwrap().iter_labels(),
-            &[b"example", b"com", b""]
+            UncertainDname::from(ecr.clone())
+                .chain(fbr.clone())
+                .unwrap()
+                .iter_labels(),
+            &[b"example", b"com", b""],
         );
     }
 
@@ -463,39 +436,50 @@ mod test {
         use std::vec::Vec;
 
         let w = RelativeDname::from_octets(b"\x03www".as_ref()).unwrap();
-        let ec = RelativeDname::from_octets(
-            b"\x07example\x03com".as_ref()
-        ).unwrap();
-        let ecr = Dname::from_octets(
-            b"\x07example\x03com\x00".as_ref()
-        ).unwrap();
+        let ec = RelativeDname::from_octets(b"\x07example\x03com".as_ref()).unwrap();
+        let ecr = Dname::from_octets(b"\x07example\x03com\x00".as_ref()).unwrap();
         let fbr = Dname::from_octets(b"\x03foo\x03bar\x00".as_ref()).unwrap();
 
         let mut buf = Vec::new();
-        w.clone().chain(ec.clone()).unwrap().compose(&mut buf).unwrap();
+        w.clone()
+            .chain(ec.clone())
+            .unwrap()
+            .compose(&mut buf)
+            .unwrap();
         assert_eq!(buf, b"\x03www\x07example\x03com".as_ref());
 
         let mut buf = Vec::new();
-        w.clone().chain(ecr.clone()).unwrap().compose(&mut buf).unwrap();
+        w.clone()
+            .chain(ecr.clone())
+            .unwrap()
+            .compose(&mut buf)
+            .unwrap();
         assert_eq!(buf, b"\x03www\x07example\x03com\x00");
 
         let mut buf = Vec::new();
-        w.clone().chain(ec.clone()).unwrap().chain(
-            Dname::root_ref()
-        ).unwrap().compose(&mut buf).unwrap();
+        w.clone()
+            .chain(ec.clone())
+            .unwrap()
+            .chain(Dname::root_ref())
+            .unwrap()
+            .compose(&mut buf)
+            .unwrap();
         assert_eq!(buf, b"\x03www\x07example\x03com\x00");
 
         let mut buf = Vec::new();
-        UncertainDname::from(w.clone()).chain(
-            ecr.clone()
-        ).unwrap().compose(&mut buf).unwrap();
+        UncertainDname::from(w.clone())
+            .chain(ecr.clone())
+            .unwrap()
+            .compose(&mut buf)
+            .unwrap();
         assert_eq!(buf, b"\x03www\x07example\x03com\x00");
 
         let mut buf = Vec::new();
-        UncertainDname::from(ecr.clone()).chain(
-            fbr.clone()
-        ).unwrap().compose(&mut buf).unwrap();
+        UncertainDname::from(ecr.clone())
+            .chain(fbr.clone())
+            .unwrap()
+            .compose(&mut buf)
+            .unwrap();
         assert_eq!(buf, b"\x07example\x03com\x00");
     }
 }
-

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -1,7 +1,7 @@
 use super::super::cmp::CanonicalOrd;
 use super::super::octets::{
-    Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsExt, OctetsFrom, OctetsRef,
-    Parse, ParseError, Parser, ShortBuf,
+    Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsExt,
+    OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 use super::builder::{DnameBuilder, FromStrError};
 use super::label::{Label, LabelTypeError, SplitLabelError};
@@ -10,7 +10,9 @@ use super::traits::{ToDname, ToLabelIter};
 #[cfg(feature = "master")]
 use super::uncertain::UncertainDname;
 #[cfg(feature = "master")]
-use crate::master::scan::{CharSource, Scan, ScanError, Scanner, SyntaxError};
+use crate::master::scan::{
+    CharSource, Scan, ScanError, Scanner, SyntaxError,
+};
 #[cfg(feature = "bytes")]
 use bytes::Bytes;
 use core::str::FromStr;
@@ -292,12 +294,18 @@ impl<Octets: AsRef<[u8]> + ?Sized> Dname<Octets> {
     }
 
     /// Determines whether `base` is a prefix of `self`.
-    pub fn starts_with<'a, N: ToLabelIter<'a> + ?Sized>(&'a self, base: &'a N) -> bool {
+    pub fn starts_with<'a, N: ToLabelIter<'a> + ?Sized>(
+        &'a self,
+        base: &'a N,
+    ) -> bool {
         <Self as ToLabelIter>::starts_with(self, base)
     }
 
     /// Determines whether `base` is a suffix of `self`.
-    pub fn ends_with<'a, N: ToLabelIter<'a> + ?Sized>(&'a self, base: &'a N) -> bool {
+    pub fn ends_with<'a, N: ToLabelIter<'a> + ?Sized>(
+        &'a self,
+        base: &'a N,
+    ) -> bool {
         <Self as ToLabelIter>::ends_with(self, base)
     }
 
@@ -354,7 +362,9 @@ impl<Octets: AsRef<[u8]> + ?Sized> Dname<Octets> {
     pub fn slice(&self, begin: usize, end: usize) -> &RelativeDname<[u8]> {
         self.check_index(begin);
         self.check_index(end);
-        unsafe { RelativeDname::from_slice_unchecked(&self.0.as_ref()[begin..end]) }
+        unsafe {
+            RelativeDname::from_slice_unchecked(&self.0.as_ref()[begin..end])
+        }
     }
 
     /// Returns the part of the name starting at the given position.
@@ -399,7 +409,9 @@ impl<Octets: AsRef<[u8]> + ?Sized> Dname<Octets> {
     /// [`range_to`]: #method.range_to
     pub fn slice_to(&self, end: usize) -> &RelativeDname<[u8]> {
         self.check_index(end);
-        unsafe { RelativeDname::from_slice_unchecked(&self.0.as_ref()[..end]) }
+        unsafe {
+            RelativeDname::from_slice_unchecked(&self.0.as_ref()[..end])
+        }
     }
 
     /// Returns the part of the name indicated by start and end positions.
@@ -429,7 +441,9 @@ impl<Octets: AsRef<[u8]> + ?Sized> Dname<Octets> {
     {
         self.check_index(begin);
         self.check_index(end);
-        unsafe { RelativeDname::from_octets_unchecked(self.0.range(begin, end)) }
+        unsafe {
+            RelativeDname::from_octets_unchecked(self.0.range(begin, end))
+        }
     }
 
     /// Returns the part of the name starting at the given position.
@@ -443,7 +457,10 @@ impl<Octets: AsRef<[u8]> + ?Sized> Dname<Octets> {
     ///
     /// The method panics if `begin` isn’t the index of the beginning of a
     /// label or is out of bounds.
-    pub fn range_from<'a>(&'a self, begin: usize) -> Dname<<&'a Octets as OctetsRef>::Range>
+    pub fn range_from<'a>(
+        &'a self,
+        begin: usize,
+    ) -> Dname<<&'a Octets as OctetsRef>::Range>
     where
         &'a Octets: OctetsRef,
     {
@@ -463,7 +480,10 @@ impl<Octets: AsRef<[u8]> + ?Sized> Dname<Octets> {
     /// The method panics if `end` is not the beginning of a label or is out
     /// of bounds. Because the returned domain name is relative, the method
     /// will also panic if the end is equal to the length of the name.
-    pub fn range_to<'a>(&'a self, end: usize) -> RelativeDname<<&'a Octets as OctetsRef>::Range>
+    pub fn range_to<'a>(
+        &'a self,
+        end: usize,
+    ) -> RelativeDname<<&'a Octets as OctetsRef>::Range>
     where
         &'a Octets: OctetsRef,
     {
@@ -558,7 +578,10 @@ impl<Octets: AsRef<[u8]>> Dname<Octets> {
     /// If `base` is indeed a suffix, returns a relative domain name with the
     /// remainder of the name. Otherwise, returns an error with an unmodified
     /// `self`.
-    pub fn strip_suffix<N: ToDname + ?Sized>(self, base: &N) -> Result<RelativeDname<Octets>, Self>
+    pub fn strip_suffix<N: ToDname + ?Sized>(
+        self,
+        base: &N,
+    ) -> Result<RelativeDname<Octets>, Self>
     where
         Octets: OctetsExt,
     {
@@ -594,7 +617,8 @@ where
     Octets: OctetsFrom<SrcOctets>,
 {
     fn octets_from(source: Dname<SrcOctets>) -> Result<Self, ShortBuf> {
-        Octets::octets_from(source.0).map(|octets| unsafe { Self::from_octets_unchecked(octets) })
+        Octets::octets_from(source.0)
+            .map(|octets| unsafe { Self::from_octets_unchecked(octets) })
     }
 }
 
@@ -734,7 +758,9 @@ impl<Ref: OctetsRef> Parse<Ref> for Dname<Ref::Range> {
     }
 }
 
-fn name_len<Source: AsRef<[u8]>>(parser: &mut Parser<Source>) -> Result<usize, ParseError> {
+fn name_len<Source: AsRef<[u8]>>(
+    parser: &mut Parser<Source>,
+) -> Result<usize, ParseError> {
     let len = {
         let mut tmp = parser.peek_all();
         loop {
@@ -757,11 +783,17 @@ fn name_len<Source: AsRef<[u8]>>(parser: &mut Parser<Source>) -> Result<usize, P
 }
 
 impl<Octets: AsRef<[u8]> + ?Sized> Compose for Dname<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(self.0.as_ref())
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             for label in self.iter_labels() {
                 label.compose_canonical(target)?;
@@ -775,7 +807,9 @@ impl<Octets: AsRef<[u8]> + ?Sized> Compose for Dname<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Dname<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         let pos = scanner.pos();
         let name = match UncertainDname::scan(scanner)? {
             UncertainDname::Relative(name) => name,
@@ -926,7 +960,9 @@ impl fmt::Display for DnameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             DnameError::BadLabel(ref err) => err.fmt(f),
-            DnameError::CompressedName => f.write_str("compressed domain name"),
+            DnameError::CompressedName => {
+                f.write_str("compressed domain name")
+            }
             DnameError::LongName => f.write_str("long domain name"),
             DnameError::RelativeName => f.write_str("relative name"),
             DnameError::TrailingData => f.write_str("trailing data"),
@@ -965,7 +1001,9 @@ pub(crate) mod test {
 
         #[cfg(feature = "std")]
         {
-            assert_to_dname(&Dname::from_octets(Vec::from(b"\0".as_ref())).unwrap());
+            assert_to_dname(
+                &Dname::from_octets(Vec::from(b"\0".as_ref())).unwrap(),
+            );
         }
     }
 
@@ -974,7 +1012,9 @@ pub(crate) mod test {
     fn impls_bytes() {
         fn assert_to_dname<T: ToDname + ?Sized>(_: &T) {}
 
-        assert_to_dname(&Dname::from_octets(Bytes::from(b"\0".as_ref())).unwrap());
+        assert_to_dname(
+            &Dname::from_octets(Bytes::from(b"\0".as_ref())).unwrap(),
+        );
     }
 
     #[test]
@@ -1087,7 +1127,9 @@ pub(crate) mod test {
         let mut labels = labels.iter();
         loop {
             match (iter.next(), labels.next()) {
-                (Some(left), Some(right)) => assert_eq!(left.as_ref(), *right),
+                (Some(left), Some(right)) => {
+                    assert_eq!(left.as_ref(), *right)
+                }
                 (None, None) => break,
                 (_, None) => panic!("extra items in iterator"),
                 (None, _) => panic!("missing items in iterator"),
@@ -1114,7 +1156,9 @@ pub(crate) mod test {
         let mut labels = labels.iter();
         loop {
             match (iter.next_back(), labels.next()) {
-                (Some(left), Some(right)) => assert_eq!(left.as_ref(), *right),
+                (Some(left), Some(right)) => {
+                    assert_eq!(left.as_ref(), *right)
+                }
                 (None, None) => break,
                 (_, None) => panic!("extra items in iterator"),
                 (None, _) => panic!("missing items in iterator"),
@@ -1187,7 +1231,9 @@ pub(crate) mod test {
     #[test]
     fn starts_with() {
         let root = Dname::root_ref();
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         assert!(root.starts_with(&root));
         assert!(wecr.starts_with(&wecr));
@@ -1203,7 +1249,8 @@ pub(crate) mod test {
         assert!(!root.starts_with(&test));
         assert!(wecr.starts_with(&test));
 
-        let test = RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
+        let test =
+            RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
         assert!(!root.starts_with(&test));
         assert!(wecr.starts_with(&test));
 
@@ -1213,7 +1260,9 @@ pub(crate) mod test {
 
         let test = RelativeDname::from_octets(b"\x03www".as_ref())
             .unwrap()
-            .chain(RelativeDname::from_octets(b"\x07example".as_ref()).unwrap())
+            .chain(
+                RelativeDname::from_octets(b"\x07example".as_ref()).unwrap(),
+            )
             .unwrap();
         assert!(!root.starts_with(&test));
         assert!(wecr.starts_with(&test));
@@ -1228,7 +1277,9 @@ pub(crate) mod test {
     #[test]
     fn ends_with() {
         let root = Dname::root_ref();
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         for name in wecr.iter_suffixes() {
             if name.is_root() {
@@ -1309,7 +1360,10 @@ pub(crate) mod test {
         assert_eq!(wecr.slice_to(0).as_slice(), b"");
         assert_eq!(wecr.slice_to(4).as_slice(), b"\x03www");
         assert_eq!(wecr.slice_to(12).as_slice(), b"\x03www\x07example");
-        assert_eq!(wecr.slice_to(16).as_slice(), b"\x03www\x07example\x03com");
+        assert_eq!(
+            wecr.slice_to(16).as_slice(),
+            b"\x03www\x07example\x03com"
+        );
 
         assert_panic!(wecr.slice_to(17));
         assert_panic!(wecr.slice_to(18));
@@ -1318,7 +1372,9 @@ pub(crate) mod test {
     #[test]
     #[cfg(feature = "std")]
     fn range() {
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         assert_eq!(wecr.range(0, 4).as_slice(), b"\x03www");
         assert_eq!(wecr.range(0, 12).as_slice(), b"\x03www\x07example");
@@ -1337,7 +1393,9 @@ pub(crate) mod test {
     #[test]
     #[cfg(feature = "std")]
     fn range_from() {
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         assert_eq!(
             wecr.range_from(0).as_slice(),
@@ -1354,12 +1412,17 @@ pub(crate) mod test {
     #[test]
     #[cfg(feature = "std")]
     fn range_to() {
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         assert_eq!(wecr.range_to(0).as_slice(), b"");
         assert_eq!(wecr.range_to(4).as_slice(), b"\x03www");
         assert_eq!(wecr.range_to(12).as_slice(), b"\x03www\x07example");
-        assert_eq!(wecr.range_to(16).as_slice(), b"\x03www\x07example\x03com");
+        assert_eq!(
+            wecr.range_to(16).as_slice(),
+            b"\x03www\x07example\x03com"
+        );
 
         assert_panic!(wecr.range_to(17));
         assert_panic!(wecr.range_to(18));
@@ -1368,7 +1431,9 @@ pub(crate) mod test {
     #[test]
     #[cfg(feature = "std")]
     fn split_at() {
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         let (left, right) = wecr.clone().split_at(0);
         assert_eq!(left.as_slice(), b"");
@@ -1395,7 +1460,9 @@ pub(crate) mod test {
     #[test]
     #[cfg(feature = "std")]
     fn split_to() {
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         let mut tmp = wecr.clone();
         assert_eq!(tmp.split_to(0).as_slice(), b"");
@@ -1422,11 +1489,16 @@ pub(crate) mod test {
     #[test]
     #[cfg(feature = "std")]
     fn truncate() {
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         assert_eq!(wecr.clone().truncate(0).as_slice(), b"");
         assert_eq!(wecr.clone().truncate(4).as_slice(), b"\x03www");
-        assert_eq!(wecr.clone().truncate(12).as_slice(), b"\x03www\x07example");
+        assert_eq!(
+            wecr.clone().truncate(12).as_slice(),
+            b"\x03www\x07example"
+        );
         assert_eq!(
             wecr.clone().truncate(16).as_slice(),
             b"\x03www\x07example\x03com"
@@ -1440,7 +1512,9 @@ pub(crate) mod test {
 
     #[test]
     fn split_first() {
-        let mut wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let mut wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         assert_eq!(wecr.split_first().unwrap().as_slice(), b"\x03www");
         assert_eq!(wecr.as_slice(), b"\x07example\x03com\0");
@@ -1456,7 +1530,9 @@ pub(crate) mod test {
 
     #[test]
     fn parent() {
-        let mut wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
+        let mut wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
 
         assert!(wecr.parent());
         assert_eq!(wecr.as_slice(), b"\x07example\x03com\0");
@@ -1472,11 +1548,17 @@ pub(crate) mod test {
 
     #[test]
     fn strip_suffix() {
-        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
-        let ecr = Dname::from_octets(b"\x07example\x03com\0".as_ref()).unwrap();
+        let wecr =
+            Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref())
+                .unwrap();
+        let ecr =
+            Dname::from_octets(b"\x07example\x03com\0".as_ref()).unwrap();
         let cr = Dname::from_octets(b"\x03com\0".as_ref()).unwrap();
-        let wenr = Dname::from_octets(b"\x03www\x07example\x03net\0".as_ref()).unwrap();
-        let enr = Dname::from_octets(b"\x07example\x03net\0".as_ref()).unwrap();
+        let wenr =
+            Dname::from_octets(b"\x03www\x07example\x03net\0".as_ref())
+                .unwrap();
+        let enr =
+            Dname::from_octets(b"\x07example\x03net\0".as_ref()).unwrap();
         let nr = Dname::from_octets(b"\x03net\0".as_ref()).unwrap();
 
         assert_eq!(wecr.clone().strip_suffix(&wecr).unwrap().as_slice(), b"");
@@ -1532,7 +1614,10 @@ pub(crate) mod test {
         // Compressed name.
         let mut p = Parser::from_static(b"\x03com\x03www\x07example\xc0\0");
         p.advance(4).unwrap();
-        assert_eq!(Dname::parse(&mut p), Err(DnameError::CompressedName.into()));
+        assert_eq!(
+            Dname::parse(&mut p),
+            Err(DnameError::CompressedName.into())
+        );
 
         // Bad label header.
         let mut p = Parser::from_static(b"\x03www\x07example\xbffoo");
@@ -1612,7 +1697,12 @@ pub(crate) mod test {
             Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
             &RelativeDname::from_octets(b"\x03www".as_ref())
                 .unwrap()
-                .chain(RelativeDname::from_octets(b"\x07example\x03com".as_ref()).unwrap())
+                .chain(
+                    RelativeDname::from_octets(
+                        b"\x07example\x03com".as_ref()
+                    )
+                    .unwrap()
+                )
                 .unwrap()
                 .chain(Dname::root_ref())
                 .unwrap()
@@ -1621,7 +1711,12 @@ pub(crate) mod test {
             Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
             &RelativeDname::from_octets(b"\x03wWw".as_ref())
                 .unwrap()
-                .chain(RelativeDname::from_octets(b"\x07eXAMple\x03coM".as_ref()).unwrap())
+                .chain(
+                    RelativeDname::from_octets(
+                        b"\x07eXAMple\x03coM".as_ref()
+                    )
+                    .unwrap()
+                )
                 .unwrap()
                 .chain(Dname::root_ref())
                 .unwrap()
@@ -1634,7 +1729,12 @@ pub(crate) mod test {
             Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap(),
             &RelativeDname::from_octets(b"\x03www".as_ref())
                 .unwrap()
-                .chain(RelativeDname::from_octets(b"\x073xample\x03com".as_ref()).unwrap())
+                .chain(
+                    RelativeDname::from_octets(
+                        b"\x073xample\x03com".as_ref()
+                    )
+                    .unwrap()
+                )
                 .unwrap()
                 .chain(Dname::root_ref())
                 .unwrap()

--- a/src/base/name/mod.rs
+++ b/src/base/name/mod.rs
@@ -57,15 +57,22 @@
 //! [`ToRelativeDname`]: trait.ToRelativeDname.html
 //! [`UncertainDname`]: enum.UncertainDname.html
 
-pub use self::builder::{DnameBuilder, FromStrError, PushError, PushNameError};
+pub use self::builder::{
+    DnameBuilder, FromStrError, PushError, PushNameError,
+};
 pub use self::chain::{Chain, ChainIter, LongChainError, UncertainChainIter};
 pub use self::dname::{Dname, DnameError};
 pub use self::label::{
-    Label, LabelTypeError, LongLabelError, OwnedLabel, SliceLabelsIter, SplitLabelError,
+    Label, LabelTypeError, LongLabelError, OwnedLabel, SliceLabelsIter,
+    SplitLabelError,
 };
 pub use self::parsed::{ParsedDname, ParsedDnameIter, ParsedSuffixIter};
-pub use self::relative::{DnameIter, RelativeDname, RelativeDnameError, StripSuffixError};
-pub use self::traits::{ToDname, ToEitherDname, ToLabelIter, ToRelativeDname};
+pub use self::relative::{
+    DnameIter, RelativeDname, RelativeDnameError, StripSuffixError,
+};
+pub use self::traits::{
+    ToDname, ToEitherDname, ToLabelIter, ToRelativeDname,
+};
 pub use self::uncertain::UncertainDname;
 
 mod builder;

--- a/src/base/name/mod.rs
+++ b/src/base/name/mod.rs
@@ -5,7 +5,7 @@
 //! Main types: [`Dname`], [`RelativeDname`], [`ParsedDname`],
 //! [`UncertainDname`], [`DnameBuilder`].<br/>
 //! Main traits: [`ToDname`], [`ToRelativeDname`].
-//! 
+//!
 //! Domain names are a sequence of *labels* which are in turn a sequence of
 //! up to 63 octets. While they are limited to a subset of ASCII by
 //! convention, all octet values are allowed. In their wire-format
@@ -61,13 +61,10 @@ pub use self::builder::{DnameBuilder, FromStrError, PushError, PushNameError};
 pub use self::chain::{Chain, ChainIter, LongChainError, UncertainChainIter};
 pub use self::dname::{Dname, DnameError};
 pub use self::label::{
-    Label, LabelTypeError, LongLabelError, OwnedLabel, SliceLabelsIter,
-    SplitLabelError
+    Label, LabelTypeError, LongLabelError, OwnedLabel, SliceLabelsIter, SplitLabelError,
 };
 pub use self::parsed::{ParsedDname, ParsedDnameIter, ParsedSuffixIter};
-pub use self::relative::{
-    RelativeDname, DnameIter, RelativeDnameError, StripSuffixError
-};
+pub use self::relative::{DnameIter, RelativeDname, RelativeDnameError, StripSuffixError};
 pub use self::traits::{ToDname, ToEitherDname, ToLabelIter, ToRelativeDname};
 pub use self::uncertain::UncertainDname;
 
@@ -79,4 +76,3 @@ mod parsed;
 mod relative;
 mod traits;
 mod uncertain;
-

--- a/src/base/name/parsed.rs
+++ b/src/base/name/parsed.rs
@@ -3,17 +3,15 @@
 //! This is a private module. Its public types are re-exported by the parent
 //! module.
 
-use core::{cmp, fmt, hash};
 use super::super::cmp::CanonicalOrd;
 use super::super::octets::{
-    Compose, FormError, OctetsBuilder, OctetsRef, Parse, Parser, ParseError,
-    ShortBuf
+    Compose, FormError, OctetsBuilder, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 use super::dname::Dname;
 use super::label::{Label, LabelTypeError};
 use super::relative::RelativeDname;
-use super::traits::{ToLabelIter, ToDname};
-
+use super::traits::{ToDname, ToLabelIter};
+use core::{cmp, fmt, hash};
 
 //------------ ParsedDname ---------------------------------------------------
 
@@ -65,7 +63,6 @@ pub struct ParsedDname<Ref> {
     compressed: bool,
 }
 
-
 /// # Properties
 ///
 impl<Ref> ParsedDname<Ref> {
@@ -94,7 +91,9 @@ impl<Ref: AsRef<[u8]>> ParsedDname<Ref> {
     /// additional step returns a name with the left-most label stripped off
     /// until it reaches the root label.
     pub fn iter_suffixes(&self) -> ParsedSuffixIter<Ref>
-    where Ref: Clone {
+    where
+        Ref: Clone,
+    {
         ParsedSuffixIter::new(self.clone())
     }
 
@@ -133,18 +132,18 @@ impl<Ref: AsRef<[u8]>> ParsedDname<Ref> {
     /// label as a relative name and removes it from the name itself. If the
     /// name is only the root label, returns `None` and does nothing.
     pub fn split_first(&mut self) -> Option<RelativeDname<Ref::Range>>
-    where Ref: OctetsRef {
+    where
+        Ref: OctetsRef,
+    {
         if self.len == 1 {
-            return None
+            return None;
         }
         let len = loop {
             match LabelType::peek(&mut self.parser).unwrap() {
                 LabelType::Normal(0) => {
                     unreachable!()
                 }
-                LabelType::Normal(label_len) => {
-                    break label_len + 1
-                }
+                LabelType::Normal(label_len) => break label_len + 1,
                 LabelType::Compressed(pos) => {
                     self.parser.seek(pos).unwrap();
                 }
@@ -152,9 +151,7 @@ impl<Ref: AsRef<[u8]>> ParsedDname<Ref> {
         };
         self.len -= len;
         Some(unsafe {
-            RelativeDname::from_octets_unchecked(
-                self.parser.parse_octets(len).unwrap()
-            )
+            RelativeDname::from_octets_unchecked(self.parser.parse_octets(len).unwrap())
         })
     }
     /// Reduces the name to the parent of the current name.
@@ -163,16 +160,14 @@ impl<Ref: AsRef<[u8]>> ParsedDname<Ref> {
     /// nothing. Otherwise, drops the first label and returns `true`.
     pub fn parent(&mut self) -> bool {
         if self.len == 1 {
-            return false
+            return false;
         }
         let len = loop {
             match LabelType::peek(&mut self.parser).unwrap() {
                 LabelType::Normal(0) => {
                     unreachable!()
                 }
-                LabelType::Normal(label_len) => {
-                    break label_len + 1
-                }
+                LabelType::Normal(label_len) => break label_len + 1,
                 LabelType::Compressed(pos) => {
                     self.parser.seek(pos).unwrap();
                 }
@@ -184,7 +179,6 @@ impl<Ref: AsRef<[u8]>> ParsedDname<Ref> {
     }
 }
 
-
 //--- From
 
 impl<Ref: AsRef<[u8]>> From<Dname<Ref>> for ParsedDname<Ref> {
@@ -193,33 +187,31 @@ impl<Ref: AsRef<[u8]>> From<Dname<Ref>> for ParsedDname<Ref> {
         ParsedDname {
             len: parser.as_slice().len(),
             parser,
-            compressed: false
+            compressed: false,
         }
     }
 }
-
 
 //--- PartialEq and Eq
 
 impl<Ref, N> PartialEq<N> for ParsedDname<Ref>
 where
     Ref: AsRef<[u8]>,
-    N: ToDname + ?Sized
+    N: ToDname + ?Sized,
 {
     fn eq(&self, other: &N) -> bool {
         self.name_eq(other)
     }
 }
 
-impl<Ref: AsRef<[u8]>> Eq for ParsedDname<Ref> { }
-
+impl<Ref: AsRef<[u8]>> Eq for ParsedDname<Ref> {}
 
 //--- PartialOrd, Ord, and CanonicalOrd
 
 impl<Ref, N> PartialOrd<N> for ParsedDname<Ref>
 where
     Ref: AsRef<[u8]>,
-    N: ToDname + ?Sized
+    N: ToDname + ?Sized,
 {
     fn partial_cmp(&self, other: &N) -> Option<cmp::Ordering> {
         Some(self.name_cmp(other))
@@ -235,13 +227,12 @@ impl<Ref: AsRef<[u8]>> Ord for ParsedDname<Ref> {
 impl<Ref, N> CanonicalOrd<N> for ParsedDname<Ref>
 where
     Ref: AsRef<[u8]>,
-    N: ToDname + ?Sized
+    N: ToDname + ?Sized,
 {
     fn canonical_cmp(&self, other: &N) -> cmp::Ordering {
         self.name_cmp(other)
     }
 }
-
 
 //--- Hash
 
@@ -252,7 +243,6 @@ impl<Ref: AsRef<[u8]>> hash::Hash for ParsedDname<Ref> {
         }
     }
 }
-
 
 //--- ToLabelIter and ToDname
 
@@ -272,13 +262,11 @@ impl<Ref: AsRef<[u8]>> ToDname for ParsedDname<Ref> {
     fn as_flat_slice(&self) -> Option<&[u8]> {
         if self.compressed {
             None
-        }
-        else {
+        } else {
             Some(self.parser.peek(self.len).unwrap())
         }
     }
 }
-
 
 //--- IntoIterator
 
@@ -291,11 +279,12 @@ impl<'a, Ref: AsRef<[u8]>> IntoIterator for &'a ParsedDname<Ref> {
     }
 }
 
-
 //--- Parse and Compose
 
 impl<Ref> Parse<Ref> for ParsedDname<Ref>
-where Ref: AsRef<[u8]> + Clone {
+where
+    Ref: AsRef<[u8]> + Clone,
+{
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         // We will walk over the entire name to ensure it is valid. Because
         // we need to clone the original parser for the result, anyway, it is
@@ -326,7 +315,7 @@ where Ref: AsRef<[u8]> + Clone {
                 LabelType::Normal(0) => {
                     len += 1;
                     if len > 255 {
-                        return Err(ParsedDnameError::LongName.into())
+                        return Err(ParsedDnameError::LongName.into());
                     }
                     if ptrs == 0 {
                         parser.seek(tmp.pos()).unwrap();
@@ -337,14 +326,12 @@ where Ref: AsRef<[u8]> + Clone {
                     len += label_len + 1;
                     tmp.advance(label_len)?;
                     if len > 255 {
-                        return Err(ParsedDnameError::LongName.into())
+                        return Err(ParsedDnameError::LongName.into());
                     }
                 }
                 LabelType::Compressed(pos) => {
                     if ptrs >= 127 {
-                        return Err(
-                            ParsedDnameError::ExcessiveCompression.into()
-                        )
+                        return Err(ParsedDnameError::ExcessiveCompression.into());
                     }
                     if ptrs == 0 {
                         parser.seek(tmp.pos()).unwrap();
@@ -355,8 +342,7 @@ where Ref: AsRef<[u8]> + Clone {
                         // position and pretend we don’t have a compressed
                         // name.
                         res.seek(pos)?;
-                    }
-                    else {
+                    } else {
                         compressed = true;
                     }
                     ptrs += 1;
@@ -364,7 +350,11 @@ where Ref: AsRef<[u8]> + Clone {
                 }
             }
         }
-        Ok(ParsedDname { parser: res, len, compressed })
+        Ok(ParsedDname {
+            parser: res,
+            len,
+            compressed,
+        })
     }
 
     /// Skip over a domain name.
@@ -382,34 +372,26 @@ where Ref: AsRef<[u8]> + Clone {
                 Ok(LabelType::Normal(0)) => {
                     len += 1;
                     if len > 255 {
-                        return Err(ParsedDnameError::LongName.into())
+                        return Err(ParsedDnameError::LongName.into());
                     }
-                    return Ok(())
+                    return Ok(());
                 }
                 Ok(LabelType::Normal(label_len)) => {
                     parser.advance(label_len)?;
                     len += label_len + 1;
                     if len > 255 {
-                        return Err(ParsedDnameError::LongName.into())
+                        return Err(ParsedDnameError::LongName.into());
                     }
                 }
-                Ok(LabelType::Compressed(_)) => {
-                    return Ok(())
-                }
-                Err(err) => {
-                    return Err(err)
-                }
+                Ok(LabelType::Compressed(_)) => return Ok(()),
+                Err(err) => return Err(err),
             }
         }
     }
 }
-               
 
 impl<Ref: AsRef<[u8]>> Compose for ParsedDname<Ref> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         if self.compressed {
             target.append_all(|target| {
                 for label in self.iter() {
@@ -417,16 +399,12 @@ impl<Ref: AsRef<[u8]>> Compose for ParsedDname<Ref> {
                 }
                 Ok(())
             })
-        }
-        else {
+        } else {
             target.append_slice(self.parser.peek(self.len).unwrap())
         }
     }
-    
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             for label in self.iter_labels() {
                 label.compose_canonical(target)?;
@@ -435,7 +413,6 @@ impl<Ref: AsRef<[u8]>> Compose for ParsedDname<Ref> {
         })
     }
 }
-
 
 //--- Display and Debug
 
@@ -462,7 +439,6 @@ impl<Ref: AsRef<[u8]>> fmt::Debug for ParsedDname<Ref> {
     }
 }
 
-
 //------------ ParsedDnameIter -----------------------------------------------
 
 /// An iterator over the labels in a parsed domain name.
@@ -478,8 +454,14 @@ impl<'a> ParsedDnameIter<'a> {
     ///
     /// The parser must be positioned at the beginning of the name.
     pub(crate) fn new<Ref>(parser: &'a Parser<Ref>, len: usize) -> Self
-    where Ref: AsRef<[u8]> {
-        ParsedDnameIter { slice: parser.as_slice(), pos: parser.pos(), len }
+    where
+        Ref: AsRef<[u8]>,
+    {
+        ParsedDnameIter {
+            slice: parser.as_slice(),
+            pos: parser.pos(),
+            len,
+        }
     }
 
     /// Returns the next label.
@@ -493,17 +475,14 @@ impl<'a> ParsedDnameIter<'a> {
             let ltype = self.slice[self.pos];
             self.pos += 1;
             match ltype {
-                0 ..= 0x3F => break self.pos + (ltype as usize),
-                0xC0 ..= 0xFF => {
-                    self.pos = (self.slice[self.pos] as usize)
-                             | (((ltype as usize) & 0x3F) << 8);
+                0..=0x3F => break self.pos + (ltype as usize),
+                0xC0..=0xFF => {
+                    self.pos = (self.slice[self.pos] as usize) | (((ltype as usize) & 0x3F) << 8);
                 }
-                _ => panic!("bad label")
+                _ => panic!("bad label"),
             }
         };
-        let res = unsafe {
-            Label::from_slice_unchecked(&self.slice[self.pos..end])
-        };
+        let res = unsafe { Label::from_slice_unchecked(&self.slice[self.pos..end]) };
         self.pos = end;
         self.len -= res.len() + 1;
         res
@@ -515,7 +494,7 @@ impl<'a> Iterator for ParsedDnameIter<'a> {
 
     fn next(&mut self) -> Option<&'a Label> {
         if self.len == 0 {
-            return None
+            return None;
         }
         Some(self.get_label())
     }
@@ -524,20 +503,19 @@ impl<'a> Iterator for ParsedDnameIter<'a> {
 impl<'a> DoubleEndedIterator for ParsedDnameIter<'a> {
     fn next_back(&mut self) -> Option<&'a Label> {
         if self.len == 0 {
-            return None
+            return None;
         }
         let mut tmp = self.clone();
         let label = loop {
             let label = tmp.get_label();
             if tmp.len == 0 {
-                break label
+                break label;
             }
         };
         self.len -= label.len() + 1;
         Some(label)
     }
 }
-
 
 //------------ ParsedSuffixIter ----------------------------------------------
 
@@ -560,7 +538,7 @@ impl<Ref: AsRef<[u8]> + Clone> Iterator for ParsedSuffixIter<Ref> {
     fn next(&mut self) -> Option<Self::Item> {
         let name = match self.name {
             Some(ref mut name) => name,
-            None => return None
+            None => return None,
         };
         let res = name.clone();
         if !name.parent() {
@@ -569,7 +547,6 @@ impl<Ref: AsRef<[u8]> + Clone> Iterator for ParsedSuffixIter<Ref> {
         Some(res)
     }
 }
-
 
 //------------ LabelType -----------------------------------------------------
 
@@ -585,38 +562,33 @@ enum LabelType {
 
 impl LabelType {
     /// Attempts to take a label type from the beginning of `parser`.
-    pub fn parse<Ref: AsRef<[u8]>>(
-        parser: &mut Parser<Ref>
-    ) -> Result<Self, ParseError> {
+    pub fn parse<Ref: AsRef<[u8]>>(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let ltype = parser.parse_u8()?;
         match ltype {
-            0 ..= 0x3F => Ok(LabelType::Normal(ltype as usize)),
-            0xC0 ..= 0xFF => {
+            0..=0x3F => Ok(LabelType::Normal(ltype as usize)),
+            0xC0..=0xFF => {
                 let res = parser.parse_u8()? as usize;
                 let res = res | (((ltype as usize) & 0x3F) << 8);
                 Ok(LabelType::Compressed(res))
             }
-            _ => Err(ParseError::Form(FormError::new("invalid label type")))
+            _ => Err(ParseError::Form(FormError::new("invalid label type"))),
         }
     }
 
     /// Returns the label type at the beginning of `parser` without advancing.
-    pub fn peek<Ref: AsRef<[u8]>>(
-        parser: &mut Parser<Ref>
-    ) -> Result<Self, ParseError> {
+    pub fn peek<Ref: AsRef<[u8]>>(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let ltype = parser.peek(1)?[0];
         match ltype {
-            0 ..= 0x3F => Ok(LabelType::Normal(ltype as usize)),
-            0xC0 ..= 0xFF => {
+            0..=0x3F => Ok(LabelType::Normal(ltype as usize)),
+            0xC0..=0xFF => {
                 let res = (parser.peek(2)?[1]) as usize;
                 let res = res | (((ltype as usize) & 0x3F) << 8);
                 Ok(LabelType::Compressed(res))
             }
-            _ => Err(ParseError::Form(FormError::new("invalid label type")))
+            _ => Err(ParseError::Form(FormError::new("invalid label type"))),
         }
     }
 }
-
 
 //------------ ParsedDnameError ----------------------------------------------
 
@@ -640,7 +612,7 @@ impl fmt::Display for ParsedDnameError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ParsedDnameError { }
+impl std::error::Error for ParsedDnameError {}
 
 impl From<LabelTypeError> for ParsedDnameError {
     fn from(err: LabelTypeError) -> Self {
@@ -651,9 +623,7 @@ impl From<LabelTypeError> for ParsedDnameError {
 impl From<ParsedDnameError> for FormError {
     fn from(err: ParsedDnameError) -> FormError {
         match err {
-            ParsedDnameError::BadLabel(_) => {
-                FormError::new("invalid label type")
-            }
+            ParsedDnameError::BadLabel(_) => FormError::new("invalid label type"),
             ParsedDnameError::LongName => FormError::new("long domain name"),
             ParsedDnameError::ExcessiveCompression => {
                 FormError::new("too many compression pointers")
@@ -668,13 +638,12 @@ impl From<ParsedDnameError> for ParseError {
     }
 }
 
-
 //============ Testing =======================================================
 
 #[cfg(test)]
 mod test {
-    use crate::base::name::{Dname, RelativeDname};
     use super::*;
+    use crate::base::name::{Dname, RelativeDname};
 
     macro_rules! name {
         (root) => {
@@ -693,13 +662,15 @@ mod test {
             name!(b"\x03com\0\x07example\xc0\0\x03www\xc0\x05", 15, 17, true)
         };
 
-        ($bytes:expr, $start:expr, $len:expr, $compressed:expr) => {
-            {
-                let mut parser = Parser::from_ref($bytes.as_ref());
-                parser.advance($start).unwrap();
-                ParsedDname { parser, len: $len, compressed: $compressed }
+        ($bytes:expr, $start:expr, $len:expr, $compressed:expr) => {{
+            let mut parser = Parser::from_ref($bytes.as_ref());
+            parser.advance($start).unwrap();
+            ParsedDname {
+                parser,
+                len: $len,
+                compressed: $compressed,
             }
-        }
+        }};
     }
 
     static WECR: &[u8] = b"\x03www\x07example\x03com\0";
@@ -751,7 +722,9 @@ mod test {
     }
 
     fn cmp_iter_suffixes<I>(iter: I, labels: &[&[u8]])
-    where I: Iterator<Item=ParsedDname<&'static [u8]>> {
+    where
+        I: Iterator<Item = ParsedDname<&'static [u8]>>,
+    {
         for (name, labels) in iter.zip(labels) {
             let mut iter = name.iter();
             let labels = Dname::from_slice(labels).unwrap();
@@ -769,9 +742,12 @@ mod test {
 
     #[test]
     fn iter_suffixes() {
-        let suffixes: &[&[u8]] = &[b"\x03www\x07example\x03com\0",
-                                   b"\x07example\x03com\0", b"\x03com\0",
-                                   b"\0"];
+        let suffixes: &[&[u8]] = &[
+            b"\x03www\x07example\x03com\0",
+            b"\x07example\x03com\0",
+            b"\x03com\0",
+            b"\0",
+        ];
         cmp_iter_suffixes(name!(root).iter_suffixes(), &[b"\0"]);
         cmp_iter_suffixes(name!(flat).iter_suffixes(), suffixes);
         cmp_iter_suffixes(name!(once).iter_suffixes(), suffixes);
@@ -802,7 +778,7 @@ mod test {
         let twice_wec = name!(twice);
 
         let test = Dname::root_ref();
-        assert!( root.starts_with(&test));
+        assert!(root.starts_with(&test));
         assert!(!flat_wec.starts_with(&test));
         assert!(!once_wec.starts_with(&test));
         assert!(!twice_wec.starts_with(&test));
@@ -815,29 +791,27 @@ mod test {
 
         let test = RelativeDname::from_slice(b"\x03www").unwrap();
         assert!(!root.starts_with(&test));
-        assert!( flat_wec.starts_with(&test));
-        assert!( once_wec.starts_with(&test));
-        assert!( twice_wec.starts_with(&test));
-        
+        assert!(flat_wec.starts_with(&test));
+        assert!(once_wec.starts_with(&test));
+        assert!(twice_wec.starts_with(&test));
+
         let test = RelativeDname::from_slice(b"\x03www\x07example").unwrap();
         assert!(!root.starts_with(&test));
-        assert!( flat_wec.starts_with(&test));
-        assert!( once_wec.starts_with(&test));
-        assert!( twice_wec.starts_with(&test));
+        assert!(flat_wec.starts_with(&test));
+        assert!(once_wec.starts_with(&test));
+        assert!(twice_wec.starts_with(&test));
 
-        let test = RelativeDname::from_slice(
-            b"\x03www\x07example\x03com"
-        ).unwrap();
+        let test = RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
         assert!(!root.starts_with(&test));
-        assert!( flat_wec.starts_with(&test));
-        assert!( once_wec.starts_with(&test));
-        assert!( twice_wec.starts_with(&test));
+        assert!(flat_wec.starts_with(&test));
+        assert!(once_wec.starts_with(&test));
+        assert!(twice_wec.starts_with(&test));
 
         let test = Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap();
         assert!(!root.starts_with(&test));
-        assert!( flat_wec.starts_with(&test));
-        assert!( once_wec.starts_with(&test));
-        assert!( twice_wec.starts_with(&test));
+        assert!(flat_wec.starts_with(&test));
+        assert!(once_wec.starts_with(&test));
+        assert!(twice_wec.starts_with(&test));
 
         let test = RelativeDname::from_slice(b"\x07example\x03com").unwrap();
         assert!(!root.starts_with(&test));
@@ -845,25 +819,22 @@ mod test {
         assert!(!once_wec.starts_with(&test));
         assert!(!twice_wec.starts_with(&test));
 
-        let test = RelativeDname::from_octets(
-            b"\x03www".as_ref()
-        ).unwrap().chain(
-            RelativeDname::from_octets(
-                b"\x07example".as_ref()
-            ).unwrap()
-        ).unwrap();
+        let test = RelativeDname::from_octets(b"\x03www".as_ref())
+            .unwrap()
+            .chain(RelativeDname::from_octets(b"\x07example".as_ref()).unwrap())
+            .unwrap();
         assert!(!root.starts_with(&test));
-        assert!( flat_wec.starts_with(&test));
-        assert!( once_wec.starts_with(&test));
-        assert!( twice_wec.starts_with(&test));
+        assert!(flat_wec.starts_with(&test));
+        assert!(once_wec.starts_with(&test));
+        assert!(twice_wec.starts_with(&test));
 
-        let test = test.chain(
-            RelativeDname::from_octets(b"\x03com".as_ref()).unwrap()
-        ).unwrap();
+        let test = test
+            .chain(RelativeDname::from_octets(b"\x03com".as_ref()).unwrap())
+            .unwrap();
         assert!(!root.starts_with(&test));
-        assert!( flat_wec.starts_with(&test));
-        assert!( once_wec.starts_with(&test));
-        assert!( twice_wec.starts_with(&test));
+        assert!(flat_wec.starts_with(&test));
+        assert!(once_wec.starts_with(&test));
+        assert!(twice_wec.starts_with(&test));
     }
 
     #[test]
@@ -872,15 +843,12 @@ mod test {
         let flat_wec = name!(flat);
         let once_wec = name!(once);
         let twice_wec = name!(twice);
-        let wecr = Dname::from_octets(
-            b"\x03www\x07example\x03com\0".as_ref()
-        ).unwrap();
+        let wecr = Dname::from_octets(b"\x03www\x07example\x03com\0".as_ref()).unwrap();
 
         for name in wecr.iter_suffixes() {
             if name.is_root() {
                 assert!(root.ends_with(&name))
-            }
-            else {
+            } else {
                 assert!(!root.ends_with(&name))
             }
             assert!(flat_wec.ends_with(&name));
@@ -889,39 +857,20 @@ mod test {
         }
     }
 
-
     #[test]
     #[cfg(feature = "std")]
     fn split_first() {
         fn split_first_wec(mut name: ParsedDname<&'static [u8]>) {
-            assert_eq!(
-                name.to_vec().as_slice(),
-                b"\x03www\x07example\x03com\0"
-            );
-            assert_eq!(
-                name.split_first().unwrap().as_slice(),
-                b"\x03www".as_ref()
-            );
-            assert_eq!(
-                name.to_vec().as_slice(),
-                b"\x07example\x03com\0"
-            );
+            assert_eq!(name.to_vec().as_slice(), b"\x03www\x07example\x03com\0");
+            assert_eq!(name.split_first().unwrap().as_slice(), b"\x03www".as_ref());
+            assert_eq!(name.to_vec().as_slice(), b"\x07example\x03com\0");
             assert_eq!(
                 name.split_first().unwrap().as_slice(),
                 b"\x07example".as_ref()
             );
-            assert_eq!(
-                name.to_vec().as_slice(),
-                b"\x03com\0"
-            );
-            assert_eq!(
-                name.split_first().unwrap().as_slice(),
-                b"\x03com".as_ref()
-            );
-            assert_eq!(
-                name.to_vec().as_slice(),
-                b"\0"
-            );
+            assert_eq!(name.to_vec().as_slice(), b"\x03com\0");
+            assert_eq!(name.split_first().unwrap().as_slice(), b"\x03com".as_ref());
+            assert_eq!(name.to_vec().as_slice(), b"\0");
             assert_eq!(name.split_first(), None);
             assert_eq!(name.split_first(), None);
         }
@@ -935,28 +884,16 @@ mod test {
     #[cfg(feature = "std")]
     fn parent() {
         fn parent_wec(mut name: ParsedDname<&'static [u8]>) {
-            assert_eq!(
-                name.to_vec().as_slice(),
-                b"\x03www\x07example\x03com\0"
-            );
+            assert_eq!(name.to_vec().as_slice(), b"\x03www\x07example\x03com\0");
             assert_eq!(name.parent(), true);
-            assert_eq!(
-                name.to_vec().as_slice(),
-                b"\x07example\x03com\0"
-            );
+            assert_eq!(name.to_vec().as_slice(), b"\x07example\x03com\0");
             assert_eq!(name.parent(), true);
-            assert_eq!(
-                name.to_vec().as_slice(),
-                b"\x03com\0"
-            );
+            assert_eq!(name.to_vec().as_slice(), b"\x03com\0");
             assert_eq!(name.parent(), true);
-            assert_eq!(
-                name.to_vec().as_slice(),
-                b"\0"
-            );
+            assert_eq!(name.to_vec().as_slice(), b"\0");
             assert_eq!(name.parent(), false);
             assert_eq!(name.parent(), false);
-        } 
+        }
 
         parent_wec(name!(flat));
         parent_wec(name!(once));
@@ -975,11 +912,7 @@ mod test {
             assert_eq!(parsed.compressed, name.compressed);
         }
 
-        fn parse(
-            mut parser: Parser<&[u8]>,
-            equals: ParsedDname<&[u8]>,
-            compose_len: usize
-        ) {
+        fn parse(mut parser: Parser<&[u8]>, equals: ParsedDname<&[u8]>, compose_len: usize) {
             let end = parser.pos() + compose_len;
             name_eq(ParsedDname::parse(&mut parser).unwrap(), equals);
             assert_eq!(parser.pos(), end);
@@ -1011,22 +944,26 @@ mod test {
 
         // Short buffer in the middle of a label.
         let mut parser = p(b"\x03www\x07exam", 0);
-        assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ParseError::ShortInput));
-        assert_eq!(ParsedDname::skip(&mut parser),
-                   Err(ParseError::ShortInput));
+        assert_eq!(
+            ParsedDname::parse(&mut parser.clone()),
+            Err(ParseError::ShortInput)
+        );
+        assert_eq!(ParsedDname::skip(&mut parser), Err(ParseError::ShortInput));
 
         // Short buffer at end of label.
         let mut parser = p(b"\x03www\x07example", 0);
-        assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ParseError::ShortInput));
-        assert_eq!(ParsedDname::skip(&mut parser),
-                   Err(ParseError::ShortInput));
+        assert_eq!(
+            ParsedDname::parse(&mut parser.clone()),
+            Err(ParseError::ShortInput)
+        );
+        assert_eq!(ParsedDname::skip(&mut parser), Err(ParseError::ShortInput));
 
         // Compression pointer beyond the end of buffer.
         let mut parser = p(b"\x03www\xc0\xee12", 0);
-        assert_eq!(ParsedDname::parse(&mut parser.clone()),
-                   Err(ParseError::ShortInput));
+        assert_eq!(
+            ParsedDname::parse(&mut parser.clone()),
+            Err(ParseError::ShortInput)
+        );
         assert_eq!(ParsedDname::skip(&mut parser), Ok(()));
         assert_eq!(parser.remaining(), 2);
 
@@ -1127,16 +1064,15 @@ mod test {
         step(Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap());
         step(Dname::from_slice(b"\x03wWw\x07EXAMPLE\x03com\0").unwrap());
         step(
-            RelativeDname::from_octets(
-                b"\x03www\x07example\x03com"
-            ).unwrap().chain_root()
+            RelativeDname::from_octets(b"\x03www\x07example\x03com")
+                .unwrap()
+                .chain_root(),
         );
         step(
-            RelativeDname::from_octets(
-                b"\x03www\x07example"
-            ).unwrap().chain(
-                Dname::from_octets(b"\x03com\0").unwrap()
-            ).unwrap()
+            RelativeDname::from_octets(b"\x03www\x07example")
+                .unwrap()
+                .chain(Dname::from_octets(b"\x03com\0").unwrap())
+                .unwrap(),
         );
 
         ne_step(Dname::from_slice(b"\x03ww4\x07EXAMPLE\x03com\0").unwrap());
@@ -1144,4 +1080,3 @@ mod test {
 
     // XXX TODO Test for cmp and hash.
 }
-

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -1,5 +1,6 @@
 use super::super::octets::{
-    Compose, IntoBuilder, OctetsBuilder, OctetsExt, OctetsFrom, OctetsRef, ParseError, ShortBuf,
+    Compose, IntoBuilder, OctetsBuilder, OctetsExt, OctetsFrom, OctetsRef,
+    ParseError, ShortBuf,
 };
 use super::builder::{DnameBuilder, PushError};
 use super::chain::{Chain, LongChainError};
@@ -83,7 +84,9 @@ impl<Octets> RelativeDname<Octets> {
     where
         Octets: From<&'static [u8]>,
     {
-        unsafe { RelativeDname::from_octets_unchecked(b"\x01*".as_ref().into()) }
+        unsafe {
+            RelativeDname::from_octets_unchecked(b"\x01*".as_ref().into())
+        }
     }
 }
 
@@ -113,7 +116,9 @@ impl RelativeDname<[u8]> {
     }
 
     /// Checks whether an octet slice contains a correctly encoded name.
-    pub(super) fn check_slice(mut slice: &[u8]) -> Result<(), RelativeDnameError> {
+    pub(super) fn check_slice(
+        mut slice: &[u8],
+    ) -> Result<(), RelativeDnameError> {
         if slice.len() > 254 {
             return Err(RelativeDnameError::LongName);
         }
@@ -209,7 +214,9 @@ impl<Octets> RelativeDname<Octets> {
     ///
     /// This method is only available for octets sequences that have an
     /// associated octets builder such as `Vec<u8>` or `Bytes`.
-    pub fn into_builder(self) -> DnameBuilder<<Octets as IntoBuilder>::Builder>
+    pub fn into_builder(
+        self,
+    ) -> DnameBuilder<<Octets as IntoBuilder>::Builder>
     where
         Octets: IntoBuilder,
     {
@@ -225,7 +232,10 @@ impl<Octets> RelativeDname<Octets> {
     /// [`chain_root`]: #method.chain_root
     pub fn into_absolute(
         self,
-    ) -> Result<Dname<<<Octets as IntoBuilder>::Builder as OctetsBuilder>::Octets>, PushError>
+    ) -> Result<
+        Dname<<<Octets as IntoBuilder>::Builder as OctetsBuilder>::Octets>,
+        PushError,
+    >
     where
         Octets: IntoBuilder,
     {
@@ -241,7 +251,10 @@ impl<Octets> RelativeDname<Octets> {
     /// greater than the size limit of 255. Note that in this case you will
     /// loose both `self` and `other`, so it might be worthwhile to check
     /// first.
-    pub fn chain<N: ToEitherDname>(self, other: N) -> Result<Chain<Self, N>, LongChainError>
+    pub fn chain<N: ToEitherDname>(
+        self,
+        other: N,
+    ) -> Result<Chain<Self, N>, LongChainError>
     where
         Octets: AsRef<[u8]>,
     {
@@ -293,7 +306,10 @@ impl<Octets: AsRef<[u8]> + ?Sized> RelativeDname<Octets> {
     }
 
     /// Determines whether `base` is a prefix of `self`.
-    pub fn starts_with<'a, N: ToLabelIter<'a>>(&'a self, base: &'a N) -> bool {
+    pub fn starts_with<'a, N: ToLabelIter<'a>>(
+        &'a self,
+        base: &'a N,
+    ) -> bool {
         <Self as ToLabelIter>::starts_with(self, base)
     }
 
@@ -370,7 +386,9 @@ impl<Octets: AsRef<[u8]> + ?Sized> RelativeDname<Octets> {
     /// [`range_from`]: #method.range_from
     pub fn slice_from(&self, begin: usize) -> &RelativeDname<[u8]> {
         self.check_index(begin);
-        unsafe { RelativeDname::from_slice_unchecked(&self.0.as_ref()[begin..]) }
+        unsafe {
+            RelativeDname::from_slice_unchecked(&self.0.as_ref()[begin..])
+        }
     }
 
     /// Returns the part of the name ending before the given position.
@@ -392,7 +410,9 @@ impl<Octets: AsRef<[u8]> + ?Sized> RelativeDname<Octets> {
     /// [`range_to`]: #method.range_to
     pub fn slice_to(&self, end: usize) -> &RelativeDname<[u8]> {
         self.check_index(end);
-        unsafe { RelativeDname::from_slice_unchecked(&self.0.as_ref()[..end]) }
+        unsafe {
+            RelativeDname::from_slice_unchecked(&self.0.as_ref()[..end])
+        }
     }
 
     /// Returns a part of the name indicated by start and end positions.
@@ -429,12 +449,17 @@ impl<Octets: AsRef<[u8]> + ?Sized> RelativeDname<Octets> {
     ///
     /// The method panics if the position is not the beginning of a label
     /// or is beyond the end of the name.
-    pub fn range_from<'a>(&'a self, begin: usize) -> RelativeDname<<&'a Octets as OctetsRef>::Range>
+    pub fn range_from<'a>(
+        &'a self,
+        begin: usize,
+    ) -> RelativeDname<<&'a Octets as OctetsRef>::Range>
     where
         &'a Octets: OctetsRef,
     {
         self.check_index(begin);
-        unsafe { RelativeDname::from_octets_unchecked(self.0.range_from(begin)) }
+        unsafe {
+            RelativeDname::from_octets_unchecked(self.0.range_from(begin))
+        }
     }
 
     /// Returns the part of the name ending before the given position.
@@ -448,7 +473,10 @@ impl<Octets: AsRef<[u8]> + ?Sized> RelativeDname<Octets> {
     ///
     /// The method panics if the position is not the beginning of a label
     /// or is beyond the end of the name.
-    pub fn range_to<'a>(&'a self, end: usize) -> RelativeDname<<&'a Octets as OctetsRef>::Range>
+    pub fn range_to<'a>(
+        &'a self,
+        end: usize,
+    ) -> RelativeDname<<&'a Octets as OctetsRef>::Range>
     where
         &'a Octets: OctetsRef,
     {
@@ -547,7 +575,10 @@ impl<Octets: AsRef<[u8]>> RelativeDname<Octets> {
     /// [`ends_with`] doesn’t return `true`.
     ///
     /// [`ends_with`]: #method.ends_with
-    pub fn strip_suffix<N: ToRelativeDname>(&mut self, base: &N) -> Result<(), StripSuffixError>
+    pub fn strip_suffix<N: ToRelativeDname>(
+        &mut self,
+        base: &N,
+    ) -> Result<(), StripSuffixError>
     where
         for<'a> &'a Octets: OctetsRef<Range = Octets>,
     {
@@ -571,7 +602,9 @@ impl<Octets: ?Sized> ops::Deref for RelativeDname<Octets> {
     }
 }
 
-impl<Octets: AsRef<T> + ?Sized, T: ?Sized> AsRef<T> for RelativeDname<Octets> {
+impl<Octets: AsRef<T> + ?Sized, T: ?Sized> AsRef<T>
+    for RelativeDname<Octets>
+{
     fn as_ref(&self) -> &T {
         self.0.as_ref()
     }
@@ -579,12 +612,16 @@ impl<Octets: AsRef<T> + ?Sized, T: ?Sized> AsRef<T> for RelativeDname<Octets> {
 
 //--- OctetsFrom
 
-impl<Octets, SrcOctets> OctetsFrom<RelativeDname<SrcOctets>> for RelativeDname<Octets>
+impl<Octets, SrcOctets> OctetsFrom<RelativeDname<SrcOctets>>
+    for RelativeDname<Octets>
 where
     Octets: OctetsFrom<SrcOctets>,
 {
-    fn octets_from(source: RelativeDname<SrcOctets>) -> Result<Self, ShortBuf> {
-        Octets::octets_from(source.0).map(|octets| unsafe { Self::from_octets_unchecked(octets) })
+    fn octets_from(
+        source: RelativeDname<SrcOctets>,
+    ) -> Result<Self, ShortBuf> {
+        Octets::octets_from(source.0)
+            .map(|octets| unsafe { Self::from_octets_unchecked(octets) })
     }
 }
 
@@ -618,11 +655,17 @@ impl<Octets: AsRef<[u8]> + ?Sized> ToRelativeDname for RelativeDname<Octets> {
 //--- Compose
 
 impl<Octets: AsRef<[u8]> + ?Sized> Compose for RelativeDname<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(self.0.as_ref())
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             for label in self.iter_labels() {
                 label.compose_canonical(target)?;
@@ -804,10 +847,14 @@ impl fmt::Display for RelativeDnameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             RelativeDnameError::BadLabel(err) => err.fmt(f),
-            RelativeDnameError::CompressedName => f.write_str("compressed domain name"),
+            RelativeDnameError::CompressedName => {
+                f.write_str("compressed domain name")
+            }
             RelativeDnameError::ShortInput => ParseError::ShortInput.fmt(f),
             RelativeDnameError::LongName => f.write_str("long domain name"),
-            RelativeDnameError::AbsoluteName => f.write_str("absolute domain name"),
+            RelativeDnameError::AbsoluteName => {
+                f.write_str("absolute domain name")
+            }
         }
     }
 }
@@ -851,11 +898,18 @@ mod test {
     fn impls() {
         fn assert_to_relative_dname<T: ToRelativeDname + ?Sized>(_: &T) {}
 
-        assert_to_relative_dname(RelativeDname::from_slice(b"\x03www".as_ref()).unwrap());
-        assert_to_relative_dname(&RelativeDname::from_octets(b"\x03www").unwrap());
-        assert_to_relative_dname(&RelativeDname::from_octets(b"\x03www".as_ref()).unwrap());
         assert_to_relative_dname(
-            &RelativeDname::from_octets(Vec::from(b"\x03www".as_ref())).unwrap(),
+            RelativeDname::from_slice(b"\x03www".as_ref()).unwrap(),
+        );
+        assert_to_relative_dname(
+            &RelativeDname::from_octets(b"\x03www").unwrap(),
+        );
+        assert_to_relative_dname(
+            &RelativeDname::from_octets(b"\x03www".as_ref()).unwrap(),
+        );
+        assert_to_relative_dname(
+            &RelativeDname::from_octets(Vec::from(b"\x03www".as_ref()))
+                .unwrap(),
         );
     }
 
@@ -865,7 +919,8 @@ mod test {
         fn assert_to_relative_dname<T: ToRelativeDname + ?Sized>(_: &T) {}
 
         assert_to_relative_dname(
-            &RelativeDname::from_octets(Bytes::from(b"\x03www".as_ref())).unwrap(),
+            &RelativeDname::from_octets(Bytes::from(b"\x03www".as_ref()))
+                .unwrap(),
         );
     }
 
@@ -969,11 +1024,13 @@ mod test {
     #[cfg(feature = "std")]
     fn into_absolute() {
         assert_eq!(
-            RelativeDname::from_octets(Vec::from(b"\x03www\x07example\x03com".as_ref()))
-                .unwrap()
-                .into_absolute()
-                .unwrap()
-                .as_slice(),
+            RelativeDname::from_octets(Vec::from(
+                b"\x03www\x07example\x03com".as_ref()
+            ))
+            .unwrap()
+            .into_absolute()
+            .unwrap()
+            .as_slice(),
             b"\x03www\x07example\x03com\0"
         );
 
@@ -1113,7 +1170,8 @@ mod test {
                 [true, true, true, false, false, false],
             ),
             (
-                RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap(),
+                RelativeDname::from_slice(b"\x03www\x07example\x03com")
+                    .unwrap(),
                 [true, true, true, true, false, false],
             ),
             (
@@ -1154,7 +1212,8 @@ mod test {
                 [true, false, true, false, false, false],
             ),
             (
-                RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap(),
+                RelativeDname::from_slice(b"\x03www\x07example\x03com")
+                    .unwrap(),
                 [true, false, false, true, true, true],
             ),
             (
@@ -1181,7 +1240,8 @@ mod test {
 
     #[test]
     fn is_label_start() {
-        let wec = RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
+        let wec =
+            RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
 
         assert!(wec.is_label_start(0)); // \x03
         assert!(!wec.is_label_start(1)); // w
@@ -1206,7 +1266,8 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn slice() {
-        let wec = RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
+        let wec =
+            RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
         assert_eq!(wec.slice(0, 4).as_slice(), b"\x03www");
         assert_eq!(wec.slice(0, 12).as_slice(), b"\x03www\x07example");
         assert_eq!(wec.slice(4, 12).as_slice(), b"\x07example");
@@ -1224,9 +1285,13 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn slice_from() {
-        let wec = RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
+        let wec =
+            RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
 
-        assert_eq!(wec.slice_from(0).as_slice(), b"\x03www\x07example\x03com");
+        assert_eq!(
+            wec.slice_from(0).as_slice(),
+            b"\x03www\x07example\x03com"
+        );
         assert_eq!(wec.slice_from(4).as_slice(), b"\x07example\x03com");
         assert_eq!(wec.slice_from(12).as_slice(), b"\x03com");
         assert_eq!(wec.slice_from(16).as_slice(), b"");
@@ -1238,7 +1303,8 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn slice_to() {
-        let wec = RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
+        let wec =
+            RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
 
         assert_eq!(wec.slice_to(0).as_slice(), b"");
         assert_eq!(wec.slice_to(4).as_slice(), b"\x03www");
@@ -1252,7 +1318,9 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn range() {
-        let wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
+        let wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
         assert_eq!(wec.range(0, 4).as_slice(), b"\x03www");
         assert_eq!(wec.range(0, 12).as_slice(), b"\x03www\x07example");
         assert_eq!(wec.range(4, 12).as_slice(), b"\x07example");
@@ -1270,9 +1338,14 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn range_from() {
-        let wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
+        let wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
 
-        assert_eq!(wec.range_from(0).as_slice(), b"\x03www\x07example\x03com");
+        assert_eq!(
+            wec.range_from(0).as_slice(),
+            b"\x03www\x07example\x03com"
+        );
         assert_eq!(wec.range_from(4).as_slice(), b"\x07example\x03com");
         assert_eq!(wec.range_from(12).as_slice(), b"\x03com");
         assert_eq!(wec.range_from(16).as_slice(), b"");
@@ -1284,7 +1357,9 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn range_to() {
-        let wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
+        let wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
 
         assert_eq!(wec.range_to(0).as_slice(), b"");
         assert_eq!(wec.range_to(4).as_slice(), b"\x03www");
@@ -1298,7 +1373,9 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn split_off() {
-        let wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
+        let wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
 
         let mut tmp = wec.clone();
         assert_eq!(tmp.split_off(0).as_slice(), b"\x03www\x07example\x03com");
@@ -1325,7 +1402,9 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn split_to() {
-        let wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
+        let wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
 
         let mut tmp = wec.clone();
         assert_eq!(tmp.split_to(0).as_slice(), b"");
@@ -1352,7 +1431,9 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn truncate() {
-        let wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
+        let wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
 
         let mut tmp = wec.clone();
         tmp.truncate(0);
@@ -1378,7 +1459,9 @@ mod test {
 
     #[test]
     fn split_first() {
-        let mut wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
+        let mut wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
 
         assert_eq!(wec.split_first().unwrap().as_slice(), b"\x03www");
         assert_eq!(wec.as_slice(), b"\x07example\x03com");
@@ -1394,7 +1477,9 @@ mod test {
 
     #[test]
     fn parent() {
-        let mut wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
+        let mut wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
 
         assert!(wec.parent());
         assert_eq!(wec.as_slice(), b"\x07example\x03com");
@@ -1410,11 +1495,17 @@ mod test {
 
     #[test]
     fn strip_suffix() {
-        let wec = RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref()).unwrap();
-        let ec = RelativeDname::from_octets(b"\x07example\x03com".as_ref()).unwrap();
+        let wec =
+            RelativeDname::from_octets(b"\x03www\x07example\x03com".as_ref())
+                .unwrap();
+        let ec = RelativeDname::from_octets(b"\x07example\x03com".as_ref())
+            .unwrap();
         let c = RelativeDname::from_octets(b"\x03com".as_ref()).unwrap();
-        let wen = RelativeDname::from_octets(b"\x03www\x07example\x03net".as_ref()).unwrap();
-        let en = RelativeDname::from_octets(b"\x07example\x03net".as_ref()).unwrap();
+        let wen =
+            RelativeDname::from_octets(b"\x03www\x07example\x03net".as_ref())
+                .unwrap();
+        let en = RelativeDname::from_octets(b"\x07example\x03net".as_ref())
+            .unwrap();
         let n = RelativeDname::from_slice(b"\x03net".as_ref()).unwrap();
 
         let mut tmp = wec.clone();
@@ -1454,14 +1545,20 @@ mod test {
             RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap(),
             &RelativeDname::from_octets(b"\x03www")
                 .unwrap()
-                .chain(RelativeDname::from_octets(b"\x07example\x03com").unwrap())
+                .chain(
+                    RelativeDname::from_octets(b"\x07example\x03com")
+                        .unwrap()
+                )
                 .unwrap()
         );
         assert_eq!(
             RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap(),
             &RelativeDname::from_octets(b"\x03wWw")
                 .unwrap()
-                .chain(RelativeDname::from_octets(b"\x07eXAMple\x03coM").unwrap())
+                .chain(
+                    RelativeDname::from_octets(b"\x07eXAMple\x03coM")
+                        .unwrap()
+                )
                 .unwrap()
         );
 
@@ -1473,7 +1570,10 @@ mod test {
             RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap(),
             &RelativeDname::from_octets(b"\x03www")
                 .unwrap()
-                .chain(RelativeDname::from_octets(b"\x073xample\x03com").unwrap())
+                .chain(
+                    RelativeDname::from_octets(b"\x073xample\x03com")
+                        .unwrap()
+                )
                 .unwrap()
         );
     }
@@ -1486,7 +1586,8 @@ mod test {
         let names = [
             RelativeDname::from_slice(b"\x07example").unwrap(),
             RelativeDname::from_slice(b"\x01a\x07example").unwrap(),
-            RelativeDname::from_slice(b"\x08yljkjljk\x01a\x07example").unwrap(),
+            RelativeDname::from_slice(b"\x08yljkjljk\x01a\x07example")
+                .unwrap(),
             RelativeDname::from_slice(b"\x01Z\x01a\x07example").unwrap(),
             RelativeDname::from_slice(b"\x04zABC\x01a\x07example").unwrap(),
             RelativeDname::from_slice(b"\x01z\x07example").unwrap(),
@@ -1508,8 +1609,10 @@ mod test {
             }
         }
 
-        let n1 = RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
-        let n2 = RelativeDname::from_slice(b"\x03wWw\x07eXAMple\x03Com").unwrap();
+        let n1 =
+            RelativeDname::from_slice(b"\x03www\x07example\x03com").unwrap();
+        let n2 =
+            RelativeDname::from_slice(b"\x03wWw\x07eXAMple\x03Com").unwrap();
         assert_eq!(n1.partial_cmp(&n2), Some(Ordering::Equal));
         assert_eq!(n1.cmp(&n2), Ordering::Equal);
     }

--- a/src/base/name/traits.rs
+++ b/src/base/name/traits.rs
@@ -1,6 +1,8 @@
 //! Domain name-related traits.
 //!
-use super::super::octets::{Compose, EmptyBuilder, FromBuilder, OctetsBuilder};
+use super::super::octets::{
+    Compose, EmptyBuilder, FromBuilder, OctetsBuilder,
+};
 use super::builder::PushError;
 use super::chain::{Chain, LongChainError};
 use super::dname::Dname;
@@ -42,7 +44,10 @@ pub trait ToLabelIter<'a> {
     }
 
     /// Determines whether `base` is a prefix of `self`.
-    fn starts_with<N: ToLabelIter<'a> + ?Sized>(&'a self, base: &'a N) -> bool {
+    fn starts_with<N: ToLabelIter<'a> + ?Sized>(
+        &'a self,
+        base: &'a N,
+    ) -> bool {
         let mut self_iter = self.iter_labels();
         let mut base_iter = base.iter_labels();
         loop {
@@ -170,7 +175,9 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     ///
     /// Domain names are compared ignoring ASCII case.
     fn name_eq<N: ToDname + ?Sized>(&self, other: &N) -> bool {
-        if let (Some(left), Some(right)) = (self.as_flat_slice(), other.as_flat_slice()) {
+        if let (Some(left), Some(right)) =
+            (self.as_flat_slice(), other.as_flat_slice())
+        {
             // We can do this because the length octets of each label are in
             // the ranged 0..64 which is before all ASCII letters.
             left.eq_ignore_ascii_case(right)
@@ -207,7 +214,9 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
 
     /// Returns the composed name ordering.
     fn composed_cmp<N: ToDname + ?Sized>(&self, other: &N) -> cmp::Ordering {
-        if let (Some(left), Some(right)) = (self.as_flat_slice(), other.as_flat_slice()) {
+        if let (Some(left), Some(right)) =
+            (self.as_flat_slice(), other.as_flat_slice())
+        {
             return left.cmp(right);
         }
         let mut self_iter = self.iter_labels();
@@ -230,17 +239,22 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     }
 
     /// Returns the lowercase composed ordering.
-    fn lowercase_composed_cmp<N: ToDname + ?Sized>(&self, other: &N) -> cmp::Ordering {
+    fn lowercase_composed_cmp<N: ToDname + ?Sized>(
+        &self,
+        other: &N,
+    ) -> cmp::Ordering {
         // Since there isn’t a `cmp_ignore_ascii_case` on slice, we don’t
         // gain much from the shortcut.
         let mut self_iter = self.iter_labels();
         let mut other_iter = other.iter_labels();
         loop {
             match (self_iter.next(), other_iter.next()) {
-                (Some(left), Some(right)) => match left.lowercase_composed_cmp(right) {
-                    cmp::Ordering::Equal => {}
-                    other => return other,
-                },
+                (Some(left), Some(right)) => {
+                    match left.lowercase_composed_cmp(right) {
+                        cmp::Ordering::Equal => {}
+                        other => return other,
+                    }
+                }
                 (None, None) => return cmp::Ordering::Equal,
                 _ => {
                     // The root label sorts before any other label, so we
@@ -295,7 +309,9 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     /// some types of names.
     ///
     /// [`RelativeDname`]: struct.RelativeDname.html
-    fn to_relative_dname<Octets>(&self) -> Result<RelativeDname<Octets>, PushError>
+    fn to_relative_dname<Octets>(
+        &self,
+    ) -> Result<RelativeDname<Octets>, PushError>
     where
         Octets: FromBuilder,
         <Octets as FromBuilder>::Builder: EmptyBuilder,
@@ -350,7 +366,10 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     }
 
     /// Returns a chain of this name and the provided name.
-    fn chain<N: ToEitherDname>(self, suffix: N) -> Result<Chain<Self, N>, LongChainError>
+    fn chain<N: ToEitherDname>(
+        self,
+        suffix: N,
+    ) -> Result<Chain<Self, N>, LongChainError>
     where
         Self: Sized,
     {
@@ -374,7 +393,9 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     ///
     /// Domain names are compared ignoring ASCII case.
     fn name_eq<N: ToRelativeDname + ?Sized>(&self, other: &N) -> bool {
-        if let (Some(left), Some(right)) = (self.as_flat_slice(), other.as_flat_slice()) {
+        if let (Some(left), Some(right)) =
+            (self.as_flat_slice(), other.as_flat_slice())
+        {
             left.eq_ignore_ascii_case(right)
         } else {
             self.iter_labels().eq(other.iter_labels())
@@ -395,7 +416,10 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     /// same name.
     ///
     /// [RFC4034-6.1]: https://tools.ietf.org/html/rfc4034#section-6.1
-    fn name_cmp<N: ToRelativeDname + ?Sized>(&self, other: &N) -> cmp::Ordering {
+    fn name_cmp<N: ToRelativeDname + ?Sized>(
+        &self,
+        other: &N,
+    ) -> cmp::Ordering {
         let mut self_iter = self.iter_labels();
         let mut other_iter = other.iter_labels();
         loop {

--- a/src/base/name/traits.rs
+++ b/src/base/name/traits.rs
@@ -1,17 +1,17 @@
 //! Domain name-related traits.
 //!
-/// This is a private module. Its public traits are re-exported by the parent.
-
-use core::cmp;
-#[cfg(feature = "std")] use std::borrow::Cow;
-#[cfg(feature = "bytes")] use bytes::Bytes;
 use super::super::octets::{Compose, EmptyBuilder, FromBuilder, OctetsBuilder};
 use super::builder::PushError;
 use super::chain::{Chain, LongChainError};
 use super::dname::Dname;
 use super::label::Label;
 use super::relative::RelativeDname;
-
+#[cfg(feature = "bytes")]
+use bytes::Bytes;
+/// This is a private module. Its public traits are re-exported by the parent.
+use core::cmp;
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
 //------------ ToLabelIter ---------------------------------------------------
 
@@ -31,7 +31,7 @@ pub trait ToLabelIter<'a> {
     /// This iterator types needs to be double ended so that we can deal with
     /// name suffixes. It needs to be cloneable to be able to cascade over
     /// parents of a name.
-    type LabelIter: Iterator<Item=&'a Label> + DoubleEndedIterator + Clone;
+    type LabelIter: Iterator<Item = &'a Label> + DoubleEndedIterator + Clone;
 
     /// Returns an iterator over the labels.
     fn iter_labels(&'a self) -> Self::LabelIter;
@@ -42,15 +42,15 @@ pub trait ToLabelIter<'a> {
     }
 
     /// Determines whether `base` is a prefix of `self`.
-    fn starts_with<N: ToLabelIter<'a> + ?Sized>(
-        &'a self, base: &'a N
-    ) -> bool {
+    fn starts_with<N: ToLabelIter<'a> + ?Sized>(&'a self, base: &'a N) -> bool {
         let mut self_iter = self.iter_labels();
         let mut base_iter = base.iter_labels();
         loop {
             match (self_iter.next(), base_iter.next()) {
                 (Some(sl), Some(bl)) => {
-                    if sl != bl { return false }
+                    if sl != bl {
+                        return false;
+                    }
                 }
                 (_, None) => return true,
                 (None, Some(_)) => return false,
@@ -59,18 +59,18 @@ pub trait ToLabelIter<'a> {
     }
 
     /// Determines whether `base` is a suffix of `self`.
-    fn ends_with<N: ToLabelIter<'a> + ?Sized>(
-        &'a self, base: &'a N
-    ) -> bool {
+    fn ends_with<N: ToLabelIter<'a> + ?Sized>(&'a self, base: &'a N) -> bool {
         let mut self_iter = self.iter_labels();
         let mut base_iter = base.iter_labels();
         loop {
             match (self_iter.next_back(), base_iter.next_back()) {
                 (Some(sl), Some(bl)) => {
-                    if sl != bl { return false }
+                    if sl != bl {
+                        return false;
+                    }
                 }
                 (_, None) => return true,
-                (None, Some(_)) =>  return false
+                (None, Some(_)) => return false,
             }
         }
     }
@@ -83,7 +83,6 @@ impl<'a, 'b, N: ToLabelIter<'b> + ?Sized> ToLabelIter<'b> for &'a N {
         (*self).iter_labels()
     }
 }
-
 
 //------------ ToDname -------------------------------------------------------
 
@@ -113,7 +112,7 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     fn to_dname<Octets>(&self) -> Result<Dname<Octets>, PushError>
     where
         Octets: FromBuilder,
-        <Octets as FromBuilder>::Builder: OctetsBuilder + EmptyBuilder
+        <Octets as FromBuilder>::Builder: OctetsBuilder + EmptyBuilder,
     {
         let mut builder = Octets::Builder::with_capacity(self.len());
         for label in self.iter_labels() {
@@ -144,9 +143,10 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     /// [`to_dname`]: #method.to_dname
     #[cfg(feature = "std")]
     fn to_cow(&self) -> Dname<std::borrow::Cow<[u8]>> {
-        let octets = self.as_flat_slice().map(Cow::Borrowed).unwrap_or_else(|| {
-            Cow::Owned(self.to_vec().into_octets())
-        });
+        let octets = self
+            .as_flat_slice()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(self.to_vec().into_octets()));
         unsafe { Dname::from_octets_unchecked(octets) }
     }
 
@@ -157,7 +157,7 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     }
 
     /// Returns the domain name assembled into a bytes value.
-    #[cfg(feature="bytes")] 
+    #[cfg(feature = "bytes")]
     fn to_bytes(&self) -> Dname<Bytes> {
         self.to_dname().unwrap()
     }
@@ -170,13 +170,11 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     ///
     /// Domain names are compared ignoring ASCII case.
     fn name_eq<N: ToDname + ?Sized>(&self, other: &N) -> bool {
-        if let (Some(left), Some(right)) = (self.as_flat_slice(),
-                                            other.as_flat_slice()) {
+        if let (Some(left), Some(right)) = (self.as_flat_slice(), other.as_flat_slice()) {
             // We can do this because the length octets of each label are in
             // the ranged 0..64 which is before all ASCII letters.
             left.eq_ignore_ascii_case(right)
-        }
-        else {
+        } else {
             self.iter_labels().eq(other.iter_labels())
         }
     }
@@ -196,35 +194,30 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
         let mut other_iter = other.iter_labels();
         loop {
             match (self_iter.next_back(), other_iter.next_back()) {
-                (Some(left), Some(right)) => {
-                    match left.cmp(right) {
-                        cmp::Ordering::Equal => {}
-                        res => return res
-                    }
-                }
+                (Some(left), Some(right)) => match left.cmp(right) {
+                    cmp::Ordering::Equal => {}
+                    res => return res,
+                },
                 (None, Some(_)) => return cmp::Ordering::Less,
                 (Some(_), None) => return cmp::Ordering::Greater,
-                (None, None) => return cmp::Ordering::Equal
+                (None, None) => return cmp::Ordering::Equal,
             }
         }
     }
 
     /// Returns the composed name ordering.
     fn composed_cmp<N: ToDname + ?Sized>(&self, other: &N) -> cmp::Ordering {
-        if let (Some(left), Some(right)) =
-                               (self.as_flat_slice(), other.as_flat_slice()) {
-            return left.cmp(right)
+        if let (Some(left), Some(right)) = (self.as_flat_slice(), other.as_flat_slice()) {
+            return left.cmp(right);
         }
         let mut self_iter = self.iter_labels();
         let mut other_iter = other.iter_labels();
         loop {
             match (self_iter.next(), other_iter.next()) {
-                (Some(left), Some(right)) => {
-                    match left.composed_cmp(right) {
-                        cmp::Ordering::Equal => { }
-                        other => return other
-                    }
-                }
+                (Some(left), Some(right)) => match left.composed_cmp(right) {
+                    cmp::Ordering::Equal => {}
+                    other => return other,
+                },
                 (None, None) => return cmp::Ordering::Equal,
                 _ => {
                     // The root label sorts before any other label, so we
@@ -237,22 +230,17 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
     }
 
     /// Returns the lowercase composed ordering.
-    fn lowercase_composed_cmp<N: ToDname + ?Sized>(
-        &self,
-        other: &N
-    ) -> cmp::Ordering {
+    fn lowercase_composed_cmp<N: ToDname + ?Sized>(&self, other: &N) -> cmp::Ordering {
         // Since there isn’t a `cmp_ignore_ascii_case` on slice, we don’t
         // gain much from the shortcut.
         let mut self_iter = self.iter_labels();
         let mut other_iter = other.iter_labels();
         loop {
             match (self_iter.next(), other_iter.next()) {
-                (Some(left), Some(right)) => {
-                    match left.lowercase_composed_cmp(right) {
-                        cmp::Ordering::Equal => { }
-                        other => return other
-                    }
-                }
+                (Some(left), Some(right)) => match left.lowercase_composed_cmp(right) {
+                    cmp::Ordering::Equal => {}
+                    other => return other,
+                },
                 (None, None) => return cmp::Ordering::Equal,
                 _ => {
                     // The root label sorts before any other label, so we
@@ -272,15 +260,13 @@ pub trait ToDname: Compose + for<'a> ToLabelIter<'a> {
         let mut labels = self.iter_labels();
         if labels.next().unwrap().is_wildcard() {
             (labels.count() - 1) as u8
-        }
-        else {
+        } else {
             labels.count() as u8
         }
     }
 }
 
-impl<'a, N: ToDname + ?Sized + 'a> ToDname for &'a N { }
-
+impl<'a, N: ToDname + ?Sized + 'a> ToDname for &'a N {}
 
 //------------ ToRelativeDname -----------------------------------------------
 
@@ -309,20 +295,16 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     /// some types of names.
     ///
     /// [`RelativeDname`]: struct.RelativeDname.html
-    fn to_relative_dname<Octets>(
-        &self
-    ) -> Result<RelativeDname<Octets>, PushError>
+    fn to_relative_dname<Octets>(&self) -> Result<RelativeDname<Octets>, PushError>
     where
         Octets: FromBuilder,
-        <Octets as FromBuilder>::Builder: EmptyBuilder
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
     {
         let mut builder = Octets::Builder::with_capacity(self.len());
         for label in self.iter_labels() {
             label.build(&mut builder)?;
         }
-        Ok(unsafe {
-            RelativeDname::from_octets_unchecked(builder.freeze()) 
-        })
+        Ok(unsafe { RelativeDname::from_octets_unchecked(builder.freeze()) })
     }
 
     /// Returns a byte slice of the content if possible.
@@ -343,9 +325,10 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     /// [`to_dname`]: #method.to_dname
     #[cfg(feature = "std")]
     fn to_cow(&self) -> RelativeDname<std::borrow::Cow<[u8]>> {
-        let octets = self.as_flat_slice().map(Cow::Borrowed).unwrap_or_else(|| {
-            Cow::Owned(self.to_vec().into_octets())
-        });
+        let octets = self
+            .as_flat_slice()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(self.to_vec().into_octets()));
         unsafe { RelativeDname::from_octets_unchecked(octets) }
     }
 
@@ -356,7 +339,7 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     }
 
     /// Returns the domain name assembled into a bytes value.
-    #[cfg(feature="bytes")] 
+    #[cfg(feature = "bytes")]
     fn to_bytes(&self) -> RelativeDname<Bytes> {
         self.to_relative_dname().unwrap()
     }
@@ -367,17 +350,18 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     }
 
     /// Returns a chain of this name and the provided name.
-    fn chain<N: ToEitherDname>(
-        self,
-        suffix: N
-    ) -> Result<Chain<Self, N>, LongChainError>
-    where Self: Sized {
+    fn chain<N: ToEitherDname>(self, suffix: N) -> Result<Chain<Self, N>, LongChainError>
+    where
+        Self: Sized,
+    {
         Chain::new(self, suffix)
     }
 
     /// Returns the absolute name by chaining it with the root label.
     fn chain_root(self) -> Chain<Self, Dname<&'static [u8]>>
-    where Self: Sized {
+    where
+        Self: Sized,
+    {
         // Appending the root label will always work.
         Chain::new(self, Dname::root()).unwrap()
     }
@@ -390,11 +374,9 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     ///
     /// Domain names are compared ignoring ASCII case.
     fn name_eq<N: ToRelativeDname + ?Sized>(&self, other: &N) -> bool {
-        if let (Some(left), Some(right)) = (self.as_flat_slice(),
-                                            other.as_flat_slice()) {
+        if let (Some(left), Some(right)) = (self.as_flat_slice(), other.as_flat_slice()) {
             left.eq_ignore_ascii_case(right)
-        }
-        else {
+        } else {
             self.iter_labels().eq(other.iter_labels())
         }
     }
@@ -413,30 +395,24 @@ pub trait ToRelativeDname: Compose + for<'a> ToLabelIter<'a> {
     /// same name.
     ///
     /// [RFC4034-6.1]: https://tools.ietf.org/html/rfc4034#section-6.1
-    fn name_cmp<N: ToRelativeDname + ?Sized>(
-        &self,
-        other: &N
-    ) -> cmp::Ordering {
+    fn name_cmp<N: ToRelativeDname + ?Sized>(&self, other: &N) -> cmp::Ordering {
         let mut self_iter = self.iter_labels();
         let mut other_iter = other.iter_labels();
         loop {
             match (self_iter.next_back(), other_iter.next_back()) {
-                (Some(left), Some(right)) => {
-                    match left.cmp(right) {
-                        cmp::Ordering::Equal => {}
-                        res => return res
-                    }
-                }
+                (Some(left), Some(right)) => match left.cmp(right) {
+                    cmp::Ordering::Equal => {}
+                    res => return res,
+                },
                 (None, Some(_)) => return cmp::Ordering::Less,
                 (Some(_), None) => return cmp::Ordering::Greater,
-                (None, None) => return cmp::Ordering::Equal
+                (None, None) => return cmp::Ordering::Equal,
             }
         }
     }
 }
 
-impl<'a, N: ToRelativeDname + ?Sized + 'a> ToRelativeDname for &'a N { }
-
+impl<'a, N: ToRelativeDname + ?Sized + 'a> ToRelativeDname for &'a N {}
 
 //------------ ToEitherDname -------------------------------------------------
 
@@ -448,7 +424,6 @@ impl<'a, N: ToRelativeDname + ?Sized + 'a> ToRelativeDname for &'a N { }
 /// for [`ToLabelIter`].
 ///
 /// [`ToLabelIter`]: trait.ToLabelIter.html
-pub trait ToEitherDname: Compose + for<'a> ToLabelIter<'a> { }
+pub trait ToEitherDname: Compose + for<'a> ToLabelIter<'a> {}
 
-impl<N: Compose + for<'a> ToLabelIter<'a>> ToEitherDname for N { }
-
+impl<N: Compose + for<'a> ToLabelIter<'a>> ToEitherDname for N {}

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -82,7 +82,8 @@ impl<Octets> UncertainDname<Octets> {
         <Octets as FromBuilder>::Builder: EmptyBuilder,
         C: IntoIterator<Item = char>,
     {
-        let mut builder = DnameBuilder::<<Octets as FromBuilder>::Builder>::new();
+        let mut builder =
+            DnameBuilder::<<Octets as FromBuilder>::Builder>::new();
         builder.append_chars(chars)?;
         if builder.in_label() || builder.is_empty() {
             Ok(builder.finish().into())
@@ -169,7 +170,10 @@ impl<Octets> UncertainDname<Octets> {
     ///     struct.RelativeDname.html#method.into_absolute
     pub fn into_absolute(
         self,
-    ) -> Result<Dname<<<Octets as IntoBuilder>::Builder as OctetsBuilder>::Octets>, PushError>
+    ) -> Result<
+        Dname<<<Octets as IntoBuilder>::Builder as OctetsBuilder>::Octets>,
+        PushError,
+    >
     where
         Octets: AsRef<[u8]> + IntoBuilder,
         <Octets as IntoBuilder>::Builder: OctetsBuilder<Octets = Octets>,
@@ -227,7 +231,10 @@ impl<Octets> UncertainDname<Octets> {
     /// be absolute. If the name is already absolute, the chain will be the
     /// name itself. If it is relative, if will be the concatenation of the
     /// name and `suffix`.
-    pub fn chain<S: ToEitherDname>(self, suffix: S) -> Result<Chain<Self, S>, LongChainError>
+    pub fn chain<S: ToEitherDname>(
+        self,
+        suffix: S,
+    ) -> Result<Chain<Self, S>, LongChainError>
     where
         Octets: AsRef<[u8]>,
     {
@@ -276,7 +283,8 @@ impl<Octets: AsRef<T>, T> AsRef<T> for UncertainDname<Octets> {
 
 //--- PartialEq, and Eq
 
-impl<Octets, Other> PartialEq<UncertainDname<Other>> for UncertainDname<Octets>
+impl<Octets, Other> PartialEq<UncertainDname<Other>>
+    for UncertainDname<Octets>
 where
     Octets: AsRef<[u8]>,
     Other: AsRef<[u8]>,
@@ -331,17 +339,27 @@ impl<'a, Octets: AsRef<[u8]>> IntoIterator for &'a UncertainDname<Octets> {
 //--- Compose
 
 impl<Octets: AsRef<[u8]>> Compose for UncertainDname<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         match *self {
             UncertainDname::Absolute(ref name) => name.compose(target),
             UncertainDname::Relative(ref name) => name.compose(target),
         }
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         match *self {
-            UncertainDname::Absolute(ref name) => name.compose_canonical(target),
-            UncertainDname::Relative(ref name) => name.compose_canonical(target),
+            UncertainDname::Absolute(ref name) => {
+                name.compose_canonical(target)
+            }
+            UncertainDname::Relative(ref name) => {
+                name.compose_canonical(target)
+            }
         }
     }
 }
@@ -350,7 +368,9 @@ impl<Octets: AsRef<[u8]>> Compose for UncertainDname<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for UncertainDname<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         if let Ok(()) = scanner.skip_literal(".") {
             return Ok(UncertainDname::root());
         }
@@ -371,7 +391,9 @@ impl Scan for UncertainDname<Bytes> {
                                 return Err(FromStrError::from(err).into());
                             }
                         } else {
-                            return Err(FromStrError::IllegalCharacter(ch).into());
+                            return Err(
+                                FromStrError::IllegalCharacter(ch).into()
+                            );
                         }
                     }
                     Symbol::DecimalEscape(ch) => {

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -2,24 +2,26 @@
 //!
 //! This is a private module. Its public types are re-exported by the parent.
 
-use core::{fmt, hash, str};
-#[cfg(feature = "std")] use std::vec::Vec;
-#[cfg(feature = "bytes")] use bytes::Bytes;
-#[cfg(feature = "master")] use bytes::BytesMut;
-#[cfg(feature="master")] use crate::master::scan::{
-    CharSource, Scan, Scanner, ScanError
-};
 use super::super::octets::{
-    Compose, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, ShortBuf
+    Compose, EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, ShortBuf,
 };
-#[cfg(feature = "master")] use super::super::str::Symbol;
+#[cfg(feature = "master")]
+use super::super::str::Symbol;
 use super::builder::{DnameBuilder, FromStrError, PushError};
 use super::chain::{Chain, LongChainError};
 use super::dname::Dname;
 use super::label::Label;
 use super::relative::{DnameIter, RelativeDname};
 use super::traits::{ToEitherDname, ToLabelIter};
-
+#[cfg(feature = "master")]
+use crate::master::scan::{CharSource, Scan, ScanError, Scanner};
+#[cfg(feature = "bytes")]
+use bytes::Bytes;
+#[cfg(feature = "master")]
+use bytes::BytesMut;
+use core::{fmt, hash, str};
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 //------------ UncertainDname ------------------------------------------------
 
@@ -46,13 +48,17 @@ impl<Octets> UncertainDname<Octets> {
 
     /// Creates a new uncertain domain name containing the root label only.
     pub fn root() -> Self
-    where Octets: From<&'static [u8]> {
+    where
+        Octets: From<&'static [u8]>,
+    {
         UncertainDname::Absolute(Dname::root())
     }
 
     /// Creates a new uncertain yet empty domain name.
     pub fn empty() -> Self
-    where Octets: From<&'static [u8]> {
+    where
+        Octets: From<&'static [u8]>,
+    {
         UncertainDname::Relative(RelativeDname::empty())
     }
 
@@ -74,20 +80,17 @@ impl<Octets> UncertainDname<Octets> {
     where
         Octets: FromBuilder,
         <Octets as FromBuilder>::Builder: EmptyBuilder,
-        C: IntoIterator<Item=char>
+        C: IntoIterator<Item = char>,
     {
-        let mut builder =
-            DnameBuilder::<<Octets as FromBuilder>::Builder>::new();
+        let mut builder = DnameBuilder::<<Octets as FromBuilder>::Builder>::new();
         builder.append_chars(chars)?;
         if builder.in_label() || builder.is_empty() {
             Ok(builder.finish().into())
-        }
-        else {
+        } else {
             Ok(builder.into_dname()?.into())
         }
     }
 }
-
 
 impl UncertainDname<&'static [u8]> {
     /// Creates an empty relative name atop a slice reference.
@@ -114,7 +117,7 @@ impl UncertainDname<Vec<u8>> {
     }
 }
 
-#[cfg(feature="bytes")] 
+#[cfg(feature = "bytes")]
 impl UncertainDname<Bytes> {
     /// Creates an empty relative name atop a bytes value.
     pub fn empty_bytes() -> Self {
@@ -145,7 +148,7 @@ impl<Octets> UncertainDname<Octets> {
     pub fn as_absolute(&self) -> Option<&Dname<Octets>> {
         match *self {
             UncertainDname::Absolute(ref name) => Some(name),
-            _ => None
+            _ => None,
         }
     }
 
@@ -165,18 +168,15 @@ impl<Octets> UncertainDname<Octets> {
     /// [`RelativeDname::into_absolute`]:
     ///     struct.RelativeDname.html#method.into_absolute
     pub fn into_absolute(
-        self
-    ) -> Result<
-        Dname<<<Octets as IntoBuilder>::Builder as OctetsBuilder>::Octets>,
-        PushError
-    >
+        self,
+    ) -> Result<Dname<<<Octets as IntoBuilder>::Builder as OctetsBuilder>::Octets>, PushError>
     where
         Octets: AsRef<[u8]> + IntoBuilder,
         <Octets as IntoBuilder>::Builder: OctetsBuilder<Octets = Octets>,
     {
         match self {
             UncertainDname::Absolute(name) => Ok(name),
-            UncertainDname::Relative(name) => name.into_absolute()
+            UncertainDname::Relative(name) => name.into_absolute(),
         }
     }
 
@@ -186,8 +186,7 @@ impl<Octets> UncertainDname<Octets> {
     pub fn try_into_absolute(self) -> Result<Dname<Octets>, Self> {
         if let UncertainDname::Absolute(name) = self {
             Ok(name)
-        }
-        else {
+        } else {
             Err(self)
         }
     }
@@ -198,8 +197,7 @@ impl<Octets> UncertainDname<Octets> {
     pub fn try_into_relative(self) -> Result<RelativeDname<Octets>, Self> {
         if let UncertainDname::Relative(name) = self {
             Ok(name)
-        }
-        else {
+        } else {
             Err(self)
         }
     }
@@ -208,13 +206,15 @@ impl<Octets> UncertainDname<Octets> {
     pub fn as_octets(&self) -> &Octets {
         match *self {
             UncertainDname::Absolute(ref name) => name.as_octets(),
-            UncertainDname::Relative(ref name) => name.as_octets()
+            UncertainDname::Relative(ref name) => name.as_octets(),
         }
     }
 
     /// Returns an octets slice with the raw content of the name.
     pub fn as_slice(&self) -> &[u8]
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         match *self {
             UncertainDname::Absolute(ref name) => name.as_slice(),
             UncertainDname::Relative(ref name) => name.as_slice(),
@@ -227,15 +227,13 @@ impl<Octets> UncertainDname<Octets> {
     /// be absolute. If the name is already absolute, the chain will be the
     /// name itself. If it is relative, if will be the concatenation of the
     /// name and `suffix`.
-    pub fn chain<S: ToEitherDname>(
-        self,
-        suffix: S
-    ) -> Result<Chain<Self, S>, LongChainError>
-    where Octets: AsRef<[u8]> {
+    pub fn chain<S: ToEitherDname>(self, suffix: S) -> Result<Chain<Self, S>, LongChainError>
+    where
+        Octets: AsRef<[u8]>,
+    {
         Chain::new_uncertain(self, suffix)
     }
 }
-
 
 //--- From
 
@@ -251,7 +249,6 @@ impl<Octets> From<RelativeDname<Octets>> for UncertainDname<Octets> {
     }
 }
 
-
 //--- FromStr
 
 impl<Octets> str::FromStr for UncertainDname<Octets>
@@ -266,7 +263,6 @@ where
     }
 }
 
-
 //--- AsRef
 
 impl<Octets: AsRef<T>, T> AsRef<T> for UncertainDname<Octets> {
@@ -278,25 +274,25 @@ impl<Octets: AsRef<T>, T> AsRef<T> for UncertainDname<Octets> {
     }
 }
 
-
 //--- PartialEq, and Eq
 
-impl<Octets, Other> PartialEq<UncertainDname<Other>>
-for UncertainDname<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+impl<Octets, Other> PartialEq<UncertainDname<Other>> for UncertainDname<Octets>
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &UncertainDname<Other>) -> bool {
         use UncertainDname::*;
 
         match (self, other) {
             (&Absolute(ref l), &Absolute(ref r)) => l.eq(r),
             (&Relative(ref l), &Relative(ref r)) => l.eq(r),
-            _ => false
+            _ => false,
         }
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for UncertainDname<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for UncertainDname<Octets> {}
 
 //--- Hash
 
@@ -308,10 +304,9 @@ impl<Octets: AsRef<[u8]>> hash::Hash for UncertainDname<Octets> {
     }
 }
 
-
 //--- ToLabelIter
 
-impl<'a, Octets: AsRef<[u8]>> ToLabelIter<'a> for UncertainDname<Octets>  {
+impl<'a, Octets: AsRef<[u8]>> ToLabelIter<'a> for UncertainDname<Octets> {
     type LabelIter = DnameIter<'a>;
 
     fn iter_labels(&'a self) -> Self::LabelIter {
@@ -321,7 +316,6 @@ impl<'a, Octets: AsRef<[u8]>> ToLabelIter<'a> for UncertainDname<Octets>  {
         }
     }
 }
-
 
 //--- IntoIterator
 
@@ -334,44 +328,31 @@ impl<'a, Octets: AsRef<[u8]>> IntoIterator for &'a UncertainDname<Octets> {
     }
 }
 
-
 //--- Compose
 
 impl<Octets: AsRef<[u8]>> Compose for UncertainDname<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         match *self {
             UncertainDname::Absolute(ref name) => name.compose(target),
             UncertainDname::Relative(ref name) => name.compose(target),
         }
     }
-    
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         match *self {
-            UncertainDname::Absolute(ref name) => {
-                name.compose_canonical(target)
-            }
-            UncertainDname::Relative(ref name) => {
-                name.compose_canonical(target)
-            }
+            UncertainDname::Absolute(ref name) => name.compose_canonical(target),
+            UncertainDname::Relative(ref name) => name.compose_canonical(target),
         }
     }
 }
 
-
 //--- Scan
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for UncertainDname<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>)
-                           -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         if let Ok(()) = scanner.skip_literal(".") {
-            return Ok(UncertainDname::root())
+            return Ok(UncertainDname::root());
         }
         scanner.scan_word(
             DnameBuilder::<BytesMut>::new(),
@@ -380,25 +361,22 @@ impl Scan for UncertainDname<Bytes> {
                     Symbol::Char('.') => {
                         if name.in_label() {
                             name.end_label();
-                        }
-                        else {
-                            return Err(FromStrError::EmptyLabel.into())
+                        } else {
+                            return Err(FromStrError::EmptyLabel.into());
                         }
                     }
                     Symbol::Char(ch) | Symbol::SimpleEscape(ch) => {
                         if ch.is_ascii() {
                             if let Err(err) = name.push(ch as u8) {
-                                return Err(FromStrError::from(err).into())
+                                return Err(FromStrError::from(err).into());
                             }
-                        }
-                        else {
-                            return Err(FromStrError::IllegalCharacter(ch)
-                                                    .into())
+                        } else {
+                            return Err(FromStrError::IllegalCharacter(ch).into());
                         }
                     }
                     Symbol::DecimalEscape(ch) => {
                         if let Err(err) = name.push(ch) {
-                            return Err(FromStrError::from(err).into())
+                            return Err(FromStrError::from(err).into());
                         }
                     }
                 }
@@ -407,15 +385,13 @@ impl Scan for UncertainDname<Bytes> {
             |name| {
                 if name.in_label() || name.is_empty() {
                     Ok(UncertainDname::from(name.finish()))
-                }
-                else {
+                } else {
                     Ok(UncertainDname::from(name.into_dname().unwrap()))
                 }
-            }
+            },
         )
     }
 }
-
 
 //--- Display and Debug
 
@@ -441,61 +417,87 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for UncertainDname<Octets> {
     }
 }
 
-
 //============ Testing =======================================================
 
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod test {
-    use std::string::String;
-    use std::str::FromStr;
     use super::*;
+    use std::str::FromStr;
+    use std::string::String;
 
     #[test]
     fn from_str() {
-
         type U = UncertainDname<Vec<u8>>;
 
         fn name(s: &str) -> U {
             U::from_str(s).unwrap()
         }
 
-        assert_eq!(name("www.example.com").as_relative().unwrap().as_slice(),
-                   b"\x03www\x07example\x03com");
-        assert_eq!(name("www.example.com.").as_absolute().unwrap().as_slice(),
-                   b"\x03www\x07example\x03com\0");
+        assert_eq!(
+            name("www.example.com").as_relative().unwrap().as_slice(),
+            b"\x03www\x07example\x03com"
+        );
+        assert_eq!(
+            name("www.example.com.").as_absolute().unwrap().as_slice(),
+            b"\x03www\x07example\x03com\0"
+        );
 
-        assert_eq!(name(r"www\.example.com").as_slice(),
-                   b"\x0bwww.example\x03com");
-        assert_eq!(name(r"w\119w.example.com").as_slice(),
-                   b"\x03www\x07example\x03com");
-        assert_eq!(name(r"w\000w.example.com").as_slice(),
-                   b"\x03w\0w\x07example\x03com");
+        assert_eq!(
+            name(r"www\.example.com").as_slice(),
+            b"\x0bwww.example\x03com"
+        );
+        assert_eq!(
+            name(r"w\119w.example.com").as_slice(),
+            b"\x03www\x07example\x03com"
+        );
+        assert_eq!(
+            name(r"w\000w.example.com").as_slice(),
+            b"\x03w\0w\x07example\x03com"
+        );
 
-        assert_eq!(U::from_str(r"w\01"),
-                   Err(FromStrError::UnexpectedEnd));
-        assert_eq!(U::from_str(r"w\"),
-                   Err(FromStrError::UnexpectedEnd));
-        assert_eq!(U::from_str(r"www..example.com"),
-                   Err(FromStrError::EmptyLabel));
-        assert_eq!(U::from_str(r"www.example.com.."),
-                   Err(FromStrError::EmptyLabel));
-        assert_eq!(U::from_str(r".www.example.com"),
-                   Err(FromStrError::EmptyLabel));
-        assert_eq!(U::from_str(r"www.\[322].example.com"),
-                   Err(FromStrError::BinaryLabel));
-        assert_eq!(U::from_str(r"www.\2example.com"),
-                   Err(FromStrError::IllegalEscape));
-        assert_eq!(U::from_str(r"www.\29example.com"),
-                   Err(FromStrError::IllegalEscape));
-        assert_eq!(U::from_str(r"www.\299example.com"),
-                   Err(FromStrError::IllegalEscape));
-        assert_eq!(U::from_str(r"www.\892example.com"),
-                   Err(FromStrError::IllegalEscape));
-        assert_eq!(U::from_str("www.e\0ample.com"),
-                   Err(FromStrError::IllegalCharacter('\0')));
-        assert_eq!(U::from_str("www.eüample.com"),
-                   Err(FromStrError::IllegalCharacter('ü')));
+        assert_eq!(U::from_str(r"w\01"), Err(FromStrError::UnexpectedEnd));
+        assert_eq!(U::from_str(r"w\"), Err(FromStrError::UnexpectedEnd));
+        assert_eq!(
+            U::from_str(r"www..example.com"),
+            Err(FromStrError::EmptyLabel)
+        );
+        assert_eq!(
+            U::from_str(r"www.example.com.."),
+            Err(FromStrError::EmptyLabel)
+        );
+        assert_eq!(
+            U::from_str(r".www.example.com"),
+            Err(FromStrError::EmptyLabel)
+        );
+        assert_eq!(
+            U::from_str(r"www.\[322].example.com"),
+            Err(FromStrError::BinaryLabel)
+        );
+        assert_eq!(
+            U::from_str(r"www.\2example.com"),
+            Err(FromStrError::IllegalEscape)
+        );
+        assert_eq!(
+            U::from_str(r"www.\29example.com"),
+            Err(FromStrError::IllegalEscape)
+        );
+        assert_eq!(
+            U::from_str(r"www.\299example.com"),
+            Err(FromStrError::IllegalEscape)
+        );
+        assert_eq!(
+            U::from_str(r"www.\892example.com"),
+            Err(FromStrError::IllegalEscape)
+        );
+        assert_eq!(
+            U::from_str("www.e\0ample.com"),
+            Err(FromStrError::IllegalCharacter('\0'))
+        );
+        assert_eq!(
+            U::from_str("www.eüample.com"),
+            Err(FromStrError::IllegalCharacter('ü'))
+        );
 
         // LongLabel
         let mut s = String::from("www.");
@@ -509,8 +511,7 @@ mod test {
             s.push('x');
         }
         s.push_str(".com");
-        assert_eq!(U::from_str(&s),
-                   Err(FromStrError::LongLabel));
+        assert_eq!(U::from_str(&s), Err(FromStrError::LongLabel));
 
         // Long Name
         let mut s = String::new();
@@ -531,4 +532,3 @@ mod test {
         assert_eq!(U::from_str(&s1), Err(FromStrError::LongName));
     }
 }
-

--- a/src/base/net.rs
+++ b/src/base/net.rs
@@ -39,7 +39,11 @@ mod nostd {
 
     impl fmt::Display for Ipv4Addr {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "{}.{}.{}.{}", self.0[0], self.0[1], self.0[2], self.0[3])
+            write!(
+                f,
+                "{}.{}.{}.{}",
+                self.0[0], self.0[1], self.0[2], self.0[3]
+            )
         }
     }
 
@@ -104,7 +108,9 @@ mod nostd {
                     )
                 }
                 _ => {
-                    fn find_zero_slice(segments: &[u16; 8]) -> (usize, usize) {
+                    fn find_zero_slice(
+                        segments: &[u16; 8],
+                    ) -> (usize, usize) {
                         let mut longest_span_len = 0;
                         let mut longest_span_at = 0;
                         let mut cur_span_len = 0;
@@ -131,7 +137,8 @@ mod nostd {
                         (longest_span_at, longest_span_len)
                     }
 
-                    let (zeros_at, zeros_len) = find_zero_slice(&self.segments());
+                    let (zeros_at, zeros_len) =
+                        find_zero_slice(&self.segments());
 
                     if zeros_len > 1 {
                         fn fmt_subslice(
@@ -149,7 +156,10 @@ mod nostd {
 
                         fmt_subslice(&self.segments()[..zeros_at], fmt)?;
                         fmt.write_str("::")?;
-                        fmt_subslice(&self.segments()[zeros_at + zeros_len..], fmt)
+                        fmt_subslice(
+                            &self.segments()[zeros_at + zeros_len..],
+                            fmt,
+                        )
                     } else {
                         let &[a, b, c, d, e, f, g, h] = &self.segments();
                         write!(

--- a/src/base/net.rs
+++ b/src/base/net.rs
@@ -8,11 +8,10 @@
 //! and doesn’t provide all the features the `std` version has.
 
 #[cfg(feature = "std")]
-pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, AddrParseError};
+pub use std::net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr};
 
 #[cfg(not(feature = "std"))]
 pub use self::nostd::*;
-
 
 #[cfg(not(feature = "std"))]
 mod nostd {
@@ -40,10 +39,7 @@ mod nostd {
 
     impl fmt::Display for Ipv4Addr {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(
-                f, "{}.{}.{}.{}",
-                self.0[0], self.0[1], self.0[2], self.0[3]
-            )
+            write!(f, "{}.{}.{}.{}", self.0[0], self.0[1], self.0[2], self.0[3])
         }
     }
 
@@ -87,14 +83,26 @@ mod nostd {
                 [0, 0, 0, 0, 0, 0, 0, 1] => write!(fmt, "::1"),
                 // Ipv4 Compatible address
                 [0, 0, 0, 0, 0, 0, g, h] => {
-                    write!(fmt, "::{}.{}.{}.{}", (g >> 8) as u8, g as u8,
-                           (h >> 8) as u8, h as u8)
+                    write!(
+                        fmt,
+                        "::{}.{}.{}.{}",
+                        (g >> 8) as u8,
+                        g as u8,
+                        (h >> 8) as u8,
+                        h as u8
+                    )
                 }
                 // Ipv4-Mapped address
                 [0, 0, 0, 0, 0, 0xffff, g, h] => {
-                    write!(fmt, "::ffff:{}.{}.{}.{}", (g >> 8) as u8, g as u8,
-                           (h >> 8) as u8, h as u8)
-                },
+                    write!(
+                        fmt,
+                        "::ffff:{}.{}.{}.{}",
+                        (g >> 8) as u8,
+                        g as u8,
+                        (h >> 8) as u8,
+                        h as u8
+                    )
+                }
                 _ => {
                     fn find_zero_slice(segments: &[u16; 8]) -> (usize, usize) {
                         let mut longest_span_len = 0;
@@ -123,13 +131,12 @@ mod nostd {
                         (longest_span_at, longest_span_len)
                     }
 
-                    let (zeros_at, zeros_len) = find_zero_slice(
-                        &self.segments()
-                    );
+                    let (zeros_at, zeros_len) = find_zero_slice(&self.segments());
 
                     if zeros_len > 1 {
                         fn fmt_subslice(
-                            segments: &[u16], fmt: &mut fmt::Formatter<'_>
+                            segments: &[u16],
+                            fmt: &mut fmt::Formatter<'_>,
                         ) -> fmt::Result {
                             if !segments.is_empty() {
                                 write!(fmt, "{:x}", segments[0])?;
@@ -142,9 +149,7 @@ mod nostd {
 
                         fmt_subslice(&self.segments()[..zeros_at], fmt)?;
                         fmt.write_str("::")?;
-                        fmt_subslice(
-                            &self.segments()[zeros_at + zeros_len..], fmt
-                        )
+                        fmt_subslice(&self.segments()[zeros_at + zeros_len..], fmt)
                     } else {
                         let &[a, b, c, d, e, f, g, h] = &self.segments();
                         write!(
@@ -157,7 +162,6 @@ mod nostd {
             }
         }
     }
-
 
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub enum IpAddr {
@@ -189,8 +193,6 @@ mod nostd {
         }
     }
 
-
     #[derive(Clone, Copy, Debug)]
     pub struct AddrParseError;
 }
-

--- a/src/base/octets.rs
+++ b/src/base/octets.rs
@@ -27,9 +27,9 @@
 //! A reference to an octets type implements [`OctetsRef`]. The main purpose
 //! of this trait is to allow cheaply taking a sub-sequence, called a ‘range’,
 //! out of the octets. For most types, ranges will be octet slices `&[u8]` but
-//! some shareable types (most notably `bytes::Bytes`) allow ranges to be 
+//! some shareable types (most notably `bytes::Bytes`) allow ranges to be
 //! owned values, thus avoiding the lifetime limitations a slice would
-//! bring. 
+//! bring.
 //!
 //! One type is special in that it is its own octets reference: `&[u8]`,
 //! referred to as an octets slice in the documentation. This means that you
@@ -58,7 +58,7 @@
 //!     unimplemented!()
 //! }
 //! ```
-//! 
+//!
 //! The where clause demands that whatever octets type is being used, a
 //! reference to it must be an octets ref. The return value refers to the
 //! range type defined for this octets ref. The lifetime argument is
@@ -142,16 +142,19 @@
 //! [`Parser`]: struct.Parser.html
 //! [`ShortBuf`]: struct.ShortBuf.html
 
-use core::{borrow, hash, fmt};
-use core::cmp::Ordering;
-use core::convert::TryFrom;
-#[cfg(feature = "std")] use std::borrow::Cow;
-#[cfg(feature = "std")] use std::vec::Vec;
-#[cfg(feature = "bytes")] use bytes::{Bytes, BytesMut};
-#[cfg(feature = "smallvec")] use smallvec::{Array, SmallVec};
 use super::name::ToDname;
 use super::net::{Ipv4Addr, Ipv6Addr};
-
+#[cfg(feature = "bytes")]
+use bytes::{Bytes, BytesMut};
+use core::cmp::Ordering;
+use core::convert::TryFrom;
+use core::{borrow, fmt, hash};
+#[cfg(feature = "smallvec")]
+use smallvec::{Array, SmallVec};
+#[cfg(feature = "std")]
+use std::borrow::Cow;
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 //============ Octets and Octet Builders =====================================
 
@@ -181,10 +184,8 @@ impl<'a> OctetsExt for &'a [u8] {
 impl<'a> OctetsExt for Cow<'a, [u8]> {
     fn truncate(&mut self, len: usize) {
         match *self {
-            Cow::Borrowed(ref mut slice) => {
-                *slice = &slice[..len]
-            }
-            Cow::Owned(ref mut vec) => vec.truncate(len)
+            Cow::Borrowed(ref mut slice) => *slice = &slice[..len],
+            Cow::Owned(ref mut vec) => vec.truncate(len),
         }
     }
 }
@@ -209,7 +210,6 @@ impl<A: Array<Item = u8>> OctetsExt for SmallVec<A> {
         self.truncate(len)
     }
 }
-
 
 //------------ OctetsRef -----------------------------------------------------
 
@@ -295,7 +295,7 @@ impl<'a> OctetsRef for &'a Vec<u8> {
 }
 
 #[cfg(feature = "bytes")]
-impl<'a> OctetsRef for &'a Bytes  {
+impl<'a> OctetsRef for &'a Bytes {
     type Range = Bytes;
 
     fn range(self, start: usize, end: usize) -> Self::Range {
@@ -312,7 +312,6 @@ impl<'a, A: Array<Item = u8>> OctetsRef for &'a SmallVec<A> {
     }
 }
 
-
 //------------ OctetsFrom ----------------------------------------------------
 
 /// Convert a type from one octets type to another.
@@ -328,7 +327,6 @@ pub trait OctetsFrom<Source>: Sized {
     fn octets_from(source: Source) -> Result<Self, ShortBuf>;
 }
 
-
 impl<'a, Source: AsRef<[u8]> + 'a> OctetsFrom<&'a Source> for &'a [u8] {
     fn octets_from(source: &'a Source) -> Result<Self, ShortBuf> {
         Ok(source.as_ref())
@@ -337,7 +335,9 @@ impl<'a, Source: AsRef<[u8]> + 'a> OctetsFrom<&'a Source> for &'a [u8] {
 
 #[cfg(feature = "std")]
 impl<Source> OctetsFrom<Source> for Vec<u8>
-where Self: From<Source> {
+where
+    Self: From<Source>,
+{
     fn octets_from(source: Source) -> Result<Self, ShortBuf> {
         Ok(From::from(source))
     }
@@ -345,7 +345,9 @@ where Self: From<Source> {
 
 #[cfg(feature = "bytes")]
 impl<Source> OctetsFrom<Source> for Bytes
-where Self: From<Source> {
+where
+    Self: From<Source>,
+{
     fn octets_from(source: Source) -> Result<Self, ShortBuf> {
         Ok(From::from(source))
     }
@@ -353,7 +355,9 @@ where Self: From<Source> {
 
 #[cfg(feature = "bytes")]
 impl<Source> OctetsFrom<Source> for BytesMut
-where Self: From<Source> {
+where
+    Self: From<Source>,
+{
     fn octets_from(source: Source) -> Result<Self, ShortBuf> {
         Ok(From::from(source))
     }
@@ -361,12 +365,14 @@ where Self: From<Source> {
 
 #[cfg(features = "smallvec")]
 impl<Source, A> OctetsFrom<Source> for SmallVec<A>
-where Source: AsRef<u8>, A: Array<Item = u8> {
+where
+    Source: AsRef<u8>,
+    A: Array<Item = u8>,
+{
     fn octets_from(source: Source) -> Result<Self, ShortBuf> {
         Ok(smallvec::ToSmallVec::to_smallvec(source.as_ref()))
     }
 }
-
 
 //------------ OctetsInto ----------------------------------------------------
 
@@ -379,7 +385,7 @@ where Source: AsRef<u8>, A: Array<Item = u8> {
 /// This is different from just `Into` in that the conversion may fail if the
 /// source sequence is longer than the space available for the target type.
 ///
-/// This trait has a blanket implementation for all pairs of types where 
+/// This trait has a blanket implementation for all pairs of types where
 /// `OctetsFrom` has been implemented.
 pub trait OctetsInto<Target> {
     /// Performs the conversion.
@@ -391,7 +397,6 @@ impl<Source, Target: OctetsFrom<Source>> OctetsInto<Target> for Source {
         Target::octets_from(self)
     }
 }
-
 
 //------------ OctetsBuilder -------------------------------------------------
 
@@ -451,7 +456,9 @@ pub trait OctetsBuilder: AsRef<[u8]> + AsMut<[u8]> + Sized {
     /// closure modified any already present data via `AsMut<[u8]>`, these
     /// modification will survive.
     fn append_all<F>(&mut self, op: F) -> Result<(), ShortBuf>
-    where F: FnOnce(&mut Self) -> Result<(), ShortBuf> {
+    where
+        F: FnOnce(&mut Self) -> Result<(), ShortBuf>,
+    {
         let pos = self.len();
         match op(self) {
             Ok(_) => Ok(()),
@@ -474,14 +481,10 @@ pub trait OctetsBuilder: AsRef<[u8]> + AsMut<[u8]> + Sized {
     ///
     /// The trait provides a default implementation which simply appends the
     /// name uncompressed.
-    fn append_compressed_dname<N: ToDname>(
-        &mut self,
-        name: &N
-    ) -> Result<(), ShortBuf> {
+    fn append_compressed_dname<N: ToDname>(&mut self, name: &N) -> Result<(), ShortBuf> {
         if let Some(slice) = name.as_flat_slice() {
             self.append_slice(slice)
-        }
-        else {
+        } else {
             self.append_all(|target| {
                 for label in name.iter_labels() {
                     label.build(target)?;
@@ -501,7 +504,9 @@ pub trait OctetsBuilder: AsRef<[u8]> + AsMut<[u8]> + Sized {
     /// closure adds more than 65535 octets or if any appending fails, the
     /// builder will be truncated to its previous length.
     fn u16_len_prefixed<F>(&mut self, op: F) -> Result<(), ShortBuf>
-    where F: FnOnce(&mut Self) -> Result<(), ShortBuf> {
+    where
+        F: FnOnce(&mut Self) -> Result<(), ShortBuf>,
+    {
         let pos = self.len();
         self.append_slice(&[0; 2])?;
         match op(self) {
@@ -510,11 +515,8 @@ pub trait OctetsBuilder: AsRef<[u8]> + AsMut<[u8]> + Sized {
                 if len > usize::from(u16::max_value()) {
                     self.truncate(pos);
                     Err(ShortBuf)
-                }
-                else {
-                    self.as_mut()[pos..pos + 2].copy_from_slice(
-                        &(len as u16).to_be_bytes()
-                    );
+                } else {
+                    self.as_mut()[pos..pos + 2].copy_from_slice(&(len as u16).to_be_bytes());
                     Ok(())
                 }
             }
@@ -544,7 +546,7 @@ impl OctetsBuilder for Vec<u8> {
     }
 }
 
-#[cfg(feature="bytes")]
+#[cfg(feature = "bytes")]
 impl OctetsBuilder for BytesMut {
     type Octets = Bytes;
 
@@ -580,7 +582,6 @@ impl<A: Array<Item = u8>> OctetsBuilder for SmallVec<A> {
     }
 }
 
-
 //------------ EmptyBuilder --------------------------------------------------
 
 /// An octets builder that can be newly created empty.
@@ -609,7 +610,7 @@ impl EmptyBuilder for Vec<u8> {
     }
 }
 
-#[cfg(feature="bytes")]
+#[cfg(feature = "bytes")]
 impl EmptyBuilder for BytesMut {
     fn empty() -> Self {
         BytesMut::new()
@@ -630,7 +631,6 @@ impl<A: Array<Item = u8>> EmptyBuilder for SmallVec<A> {
         SmallVec::with_capacity(capacity)
     }
 }
-
 
 //------------ IntoBuilder ---------------------------------------------------
 
@@ -670,7 +670,7 @@ impl<'a> IntoBuilder for Cow<'a, [u8]> {
     }
 }
 
-#[cfg(feature="bytes")]
+#[cfg(feature = "bytes")]
 impl IntoBuilder for Bytes {
     type Builder = BytesMut;
 
@@ -690,7 +690,6 @@ impl<A: Array<Item = u8>> IntoBuilder for SmallVec<A> {
         self
     }
 }
-
 
 //------------ FromBuilder ---------------------------------------------------
 
@@ -712,7 +711,7 @@ impl FromBuilder for Vec<u8> {
     }
 }
 
-#[cfg(feature="bytes")]
+#[cfg(feature = "bytes")]
 impl FromBuilder for Bytes {
     type Builder = BytesMut;
 
@@ -730,12 +729,11 @@ impl<A: Array<Item = u8>> FromBuilder for SmallVec<A> {
     }
 }
 
-
 //============ Parsing =======================================================
 
 //------------ Parser --------------------------------------------------------
 
-/// A parser for sequentially extracting data from an octets sequence. 
+/// A parser for sequentially extracting data from an octets sequence.
 ///
 /// The parser wraps an [octets reference] and remembers the read position on
 /// the referenced sequence. Methods allow reading out data and progressing
@@ -761,13 +759,21 @@ pub struct Parser<Ref> {
 impl<Ref> Parser<Ref> {
     /// Creates a new parser atop a reference to an octet sequence.
     pub fn from_ref(octets: Ref) -> Self
-    where Ref: AsRef<[u8]> {
-        Parser { pos: 0, len: octets.as_ref().len(), octets }
+    where
+        Ref: AsRef<[u8]>,
+    {
+        Parser {
+            pos: 0,
+            len: octets.as_ref().len(),
+            octets,
+        }
     }
 
     /// Returns the wrapped reference to the underlying octets sequence.
     pub fn octets_ref(&self) -> Ref
-    where Ref: Copy {
+    where
+        Ref: Copy,
+    {
         self.octets
     }
 
@@ -818,7 +824,9 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     ///
     /// The slice covers the entire sequence, not just the remaining data.
     pub fn as_slice_mut(&mut self) -> &mut [u8]
-    where Ref: AsMut<[u8]> {
+    where
+        Ref: AsMut<[u8]>,
+    {
         &mut self.octets.as_mut()[..self.len]
     }
 
@@ -848,8 +856,7 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     pub fn seek(&mut self, pos: usize) -> Result<(), ParseError> {
         if pos > self.len {
             Err(ParseError::ShortInput)
-        }
-        else {
+        } else {
             self.pos = pos;
             Ok(())
         }
@@ -861,8 +868,7 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     pub fn advance(&mut self, len: usize) -> Result<(), ParseError> {
         if len > self.remaining() {
             Err(ParseError::ShortInput)
-        }
-        else {
+        } else {
             self.pos += len;
             Ok(())
         }
@@ -879,8 +885,7 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     pub fn check_len(&self, len: usize) -> Result<(), ParseError> {
         if self.remaining() < len {
             Err(ParseError::ShortInput)
-        }
-        else {
+        } else {
             Ok(())
         }
     }
@@ -891,14 +896,13 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     ///
     /// Advances the parser by `len` octets. If there aren’t enough octats
     /// left, leaves the parser untouched and returns an error instead.
-    pub fn parse_octets(
-        &mut self,
-        len: usize
-    ) -> Result<Ref::Range, ParseError>
-    where Ref: OctetsRef {
+    pub fn parse_octets(&mut self, len: usize) -> Result<Ref::Range, ParseError>
+    where
+        Ref: OctetsRef,
+    {
         let end = self.pos + len;
         if end > self.len {
-            return Err(ParseError::ShortInput)
+            return Err(ParseError::ShortInput);
         }
         let res = self.octets.range(self.pos, end);
         self.pos = end;
@@ -1002,9 +1006,7 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     /// `ParseError::ShortInput`.
     ///
     //  XXX NEEDS TESTS!!!
-    pub fn parse_block<F, U>(
-        &mut self, limit: usize, op: F
-    ) -> Result<U, ParseError>
+    pub fn parse_block<F, U>(&mut self, limit: usize, op: F) -> Result<U, ParseError>
     where
         F: FnOnce(&mut Self) -> Result<U, ParseError>,
     {
@@ -1019,18 +1021,15 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
         self.len = len;
         let res = if self.pos != end {
             Err(ParseError::Form(FormError::new("trailing data in field")))
-        }
-        else if let Err(ParseError::ShortInput) = res {
+        } else if let Err(ParseError::ShortInput) = res {
             Err(ParseError::Form(FormError::new("short field")))
-        }
-        else {
+        } else {
             res
         };
         self.pos = end;
         res
     }
 }
-
 
 //------------ Parse ------------------------------------------------------
 
@@ -1040,7 +1039,7 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
 /// parser to create a value of itself. Because types may be generic over
 /// octets types, the trait is generic over the octets reference of the
 /// parser in question. Implementations should use minimal trait bounds
-/// matching the parser methods they use. 
+/// matching the parser methods they use.
 ///
 /// For types that are generic over an octets sequence, the reference type
 /// should be tied to the type’s own type argument. This will avoid having
@@ -1138,7 +1137,7 @@ impl<T: AsRef<[u8]>> Parse<T> for Ipv4Addr {
             u8::parse(parser)?,
             u8::parse(parser)?,
             u8::parse(parser)?,
-            u8::parse(parser)?
+            u8::parse(parser)?,
         ))
     }
 
@@ -1158,7 +1157,6 @@ impl<T: AsRef<[u8]>> Parse<T> for Ipv6Addr {
         parser.advance(16).map_err(Into::into)
     }
 }
-
 
 //============ Composing =====================================================
 
@@ -1186,108 +1184,72 @@ pub trait Compose {
     /// If the representation doesn’t fit into the builder, returns an error.
     /// In this case the target is considered undefined. If it is supposed to
     /// be reused, it needs to be reset specifically.
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf>;
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf>;
 
     /// Appends the canonical representation of the value to the target.
     ///
     /// If the representation doesn’t fit into the builder, returns an error.
     /// In this case the target is considered undefined. If it is supposed to
     /// be reused, it needs to be reset specifically.
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         self.compose(target)
     }
 }
 
 impl<'a, C: Compose + ?Sized> Compose for &'a C {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         (*self).compose(target)
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         (*self).compose_canonical(target)
     }
 }
 
 impl Compose for i8 {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&[*self as u8])
     }
 }
 
 impl Compose for u8 {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&[*self])
     }
 }
 
 impl Compose for i16 {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&self.to_be_bytes())
     }
 }
 
 impl Compose for u16 {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&self.to_be_bytes())
     }
 }
 
 impl Compose for i32 {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&self.to_be_bytes())
     }
 }
 
 impl Compose for u32 {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&self.to_be_bytes())
     }
 }
 
 impl Compose for Ipv4Addr {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&self.octets())
     }
 }
 
 impl Compose for Ipv6Addr {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&self.octets())
     }
 }
@@ -1488,13 +1450,11 @@ octets_array!(pub Octets1024 => 1024);
 octets_array!(pub Octets2048 => 2048);
 octets_array!(pub Octets4096 => 4096);
 
-
 //------------ OctetsVec -----------------------------------------------------
 
 /// A octets vector that doesn’t allocate for small sizes.
 #[cfg(feature = "smallvec")]
 pub type OctetsVec = SmallVec<[u8; 24]>;
-
 
 //============ Error Types ===================================================
 
@@ -1510,7 +1470,6 @@ pub type OctetsVec = SmallVec<[u8; 24]>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ShortBuf;
 
-
 //--- Display and Error
 
 impl fmt::Display for ShortBuf {
@@ -1520,8 +1479,7 @@ impl fmt::Display for ShortBuf {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ShortBuf { }
-
+impl std::error::Error for ShortBuf {}
 
 //--------- ParseError -------------------------------------------------------
 
@@ -1532,7 +1490,7 @@ pub enum ParseError {
     ShortInput,
 
     /// A formatting error occurred.
-    Form(FormError)
+    Form(FormError),
 }
 
 impl ParseError {
@@ -1542,7 +1500,6 @@ impl ParseError {
     }
 }
 
-
 //--- From
 
 impl From<FormError> for ParseError {
@@ -1551,23 +1508,19 @@ impl From<FormError> for ParseError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ParseError::ShortInput
-                => f.write_str("unexpected end of input"),
-            ParseError::Form(ref err)
-                => err.fmt(f)
+            ParseError::ShortInput => f.write_str("unexpected end of input"),
+            ParseError::Form(ref err) => err.fmt(f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ParseError { }
-
+impl std::error::Error for ParseError {}
 
 //------------ FormError -----------------------------------------------------
 
@@ -1586,7 +1539,6 @@ impl FormError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for FormError {
@@ -1596,8 +1548,7 @@ impl fmt::Display for FormError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for FormError { }
-
+impl std::error::Error for FormError {}
 
 //============ Testing =======================================================
 
@@ -1722,8 +1673,7 @@ mod test {
 
     #[test]
     fn parse_i32() {
-        let mut parser = Parser::from_static(
-            b"\x12\x34\x56\x78\xfd\x78\xa8\x4e\0\0\0");
+        let mut parser = Parser::from_static(b"\x12\x34\x56\x78\xfd\x78\xa8\x4e\0\0\0");
         assert_eq!(parser.parse_i32(), Ok(0x12345678));
         assert_eq!(parser.parse_i32(), Ok(-42424242));
         assert_eq!(parser.parse_i32(), Err(ParseError::ShortInput));
@@ -1731,11 +1681,9 @@ mod test {
 
     #[test]
     fn parse_u32() {
-        let mut parser = Parser::from_static(
-            b"\x12\x34\x56\x78\xfd\x78\xa8\x4e\0\0\0");
+        let mut parser = Parser::from_static(b"\x12\x34\x56\x78\xfd\x78\xa8\x4e\0\0\0");
         assert_eq!(parser.parse_u32(), Ok(0x12345678));
         assert_eq!(parser.parse_u32(), Ok(0xfd78a84e));
         assert_eq!(parser.parse_u32(), Err(ParseError::ShortInput));
     }
 }
-

--- a/src/base/octets.rs
+++ b/src/base/octets.rs
@@ -481,7 +481,10 @@ pub trait OctetsBuilder: AsRef<[u8]> + AsMut<[u8]> + Sized {
     ///
     /// The trait provides a default implementation which simply appends the
     /// name uncompressed.
-    fn append_compressed_dname<N: ToDname>(&mut self, name: &N) -> Result<(), ShortBuf> {
+    fn append_compressed_dname<N: ToDname>(
+        &mut self,
+        name: &N,
+    ) -> Result<(), ShortBuf> {
         if let Some(slice) = name.as_flat_slice() {
             self.append_slice(slice)
         } else {
@@ -516,7 +519,8 @@ pub trait OctetsBuilder: AsRef<[u8]> + AsMut<[u8]> + Sized {
                     self.truncate(pos);
                     Err(ShortBuf)
                 } else {
-                    self.as_mut()[pos..pos + 2].copy_from_slice(&(len as u16).to_be_bytes());
+                    self.as_mut()[pos..pos + 2]
+                        .copy_from_slice(&(len as u16).to_be_bytes());
                     Ok(())
                 }
             }
@@ -896,7 +900,10 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     ///
     /// Advances the parser by `len` octets. If there aren’t enough octats
     /// left, leaves the parser untouched and returns an error instead.
-    pub fn parse_octets(&mut self, len: usize) -> Result<Ref::Range, ParseError>
+    pub fn parse_octets(
+        &mut self,
+        len: usize,
+    ) -> Result<Ref::Range, ParseError>
     where
         Ref: OctetsRef,
     {
@@ -1006,7 +1013,11 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     /// `ParseError::ShortInput`.
     ///
     //  XXX NEEDS TESTS!!!
-    pub fn parse_block<F, U>(&mut self, limit: usize, op: F) -> Result<U, ParseError>
+    pub fn parse_block<F, U>(
+        &mut self,
+        limit: usize,
+        op: F,
+    ) -> Result<U, ParseError>
     where
         F: FnOnce(&mut Self) -> Result<U, ParseError>,
     {
@@ -1184,72 +1195,108 @@ pub trait Compose {
     /// If the representation doesn’t fit into the builder, returns an error.
     /// In this case the target is considered undefined. If it is supposed to
     /// be reused, it needs to be reset specifically.
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf>;
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf>;
 
     /// Appends the canonical representation of the value to the target.
     ///
     /// If the representation doesn’t fit into the builder, returns an error.
     /// In this case the target is considered undefined. If it is supposed to
     /// be reused, it needs to be reset specifically.
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         self.compose(target)
     }
 }
 
 impl<'a, C: Compose + ?Sized> Compose for &'a C {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         (*self).compose(target)
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         (*self).compose_canonical(target)
     }
 }
 
 impl Compose for i8 {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&[*self as u8])
     }
 }
 
 impl Compose for u8 {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&[*self])
     }
 }
 
 impl Compose for i16 {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.to_be_bytes())
     }
 }
 
 impl Compose for u16 {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.to_be_bytes())
     }
 }
 
 impl Compose for i32 {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.to_be_bytes())
     }
 }
 
 impl Compose for u32 {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.to_be_bytes())
     }
 }
 
 impl Compose for Ipv4Addr {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.octets())
     }
 }
 
 impl Compose for Ipv6Addr {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.octets())
     }
 }
@@ -1673,7 +1720,8 @@ mod test {
 
     #[test]
     fn parse_i32() {
-        let mut parser = Parser::from_static(b"\x12\x34\x56\x78\xfd\x78\xa8\x4e\0\0\0");
+        let mut parser =
+            Parser::from_static(b"\x12\x34\x56\x78\xfd\x78\xa8\x4e\0\0\0");
         assert_eq!(parser.parse_i32(), Ok(0x12345678));
         assert_eq!(parser.parse_i32(), Ok(-42424242));
         assert_eq!(parser.parse_i32(), Err(ParseError::ShortInput));
@@ -1681,7 +1729,8 @@ mod test {
 
     #[test]
     fn parse_u32() {
-        let mut parser = Parser::from_static(b"\x12\x34\x56\x78\xfd\x78\xa8\x4e\0\0\0");
+        let mut parser =
+            Parser::from_static(b"\x12\x34\x56\x78\xfd\x78\xa8\x4e\0\0\0");
         assert_eq!(parser.parse_u32(), Ok(0x12345678));
         assert_eq!(parser.parse_u32(), Ok(0xfd78a84e));
         assert_eq!(parser.parse_u32(), Err(ParseError::ShortInput));

--- a/src/base/opt/macros.rs
+++ b/src/base/opt/macros.rs
@@ -36,7 +36,7 @@ macro_rules! opt_types {
             }
         )* )*
 
-        
+
         //--- Compose
 
         impl<Octets: AsRef<[u8]>> Compose for AllOptData<Octets> {

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -14,17 +14,17 @@
 //! options. As with record data types in the [rdata] module, these are
 //! arranged in sub-modules according to the RFC that defined them and then
 //! re-exported here.
-//! 
+//!
 //! [RFC 6891]: https://tools.ietf.org/html/rfc6891
 //! [rdata]: ../../rdata/index.html
-
 
 //============ Sub-modules and Re-exports ====================================
 //
 // All of these are in a macro. The macro also defines `AllOptData`.
 
-#[macro_use] mod macros;
-opt_types!{
+#[macro_use]
+mod macros;
+opt_types! {
     rfc5001::{Nsid<Octets>};
     rfc6975::{Dau<Octets>, Dhu<Octets>, N3u<Octets>};
     rfc7314::{Expire};
@@ -37,23 +37,20 @@ opt_types!{
     rfc8914::{ExtendedError<Octets>};
 }
 
-
 //============ Module Content ================================================
 
-use core::{hash, fmt, mem, ops};
-use core::cmp::Ordering;
-use core::convert::TryInto;
-use core::marker::PhantomData;
-use super::iana::{OptionCode, OptRcode, Rtype};
 use super::header::Header;
+use super::iana::{OptRcode, OptionCode, Rtype};
 use super::name::ToDname;
 use super::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
-    ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 use super::rdata::RtypeRecordData;
 use super::record::Record;
-
+use core::cmp::Ordering;
+use core::convert::TryInto;
+use core::marker::PhantomData;
+use core::{fmt, hash, mem, ops};
 
 //------------ Opt -----------------------------------------------------------
 
@@ -99,39 +96,44 @@ impl<Octets: AsRef<[u8]>> Opt<Octets> {
     pub fn iter<Data>(&self) -> OptIter<&Octets, Data>
     where
         for<'a> &'a Octets: OctetsRef,
-        Data: for<'a> ParseOptData<&'a Octets>
+        Data: for<'a> ParseOptData<&'a Octets>,
     {
         OptIter::new(&self.octets)
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Opt<SrcOctets>> for Opt<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Opt<SrcOctets>) -> Result<Self, ShortBuf> {
         Octets::octets_from(source.octets).map(|octets| Opt { octets })
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<Octets, Other> PartialEq<Opt<Other>> for Opt<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Opt<Other>) -> bool {
         self.octets.as_ref().eq(other.octets.as_ref())
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Opt<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Opt<Octets> {}
 
 //--- PartialOrd and Ord
 
 impl<Octets, Other> PartialOrd<Opt<Other>> for Opt<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Opt<Other>) -> Option<Ordering> {
         self.octets.as_ref().partial_cmp(other.octets.as_ref())
     }
@@ -143,7 +145,6 @@ impl<Octets: AsRef<[u8]>> Ord for Opt<Octets> {
     }
 }
 
-
 //--- Hash
 
 impl<Octets: AsRef<[u8]>> hash::Hash for Opt<Octets> {
@@ -151,7 +152,6 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Opt<Octets> {
         self.octets.as_ref().hash(state)
     }
 }
-
 
 //--- Parse and Compose
 
@@ -168,21 +168,16 @@ impl<Ref: OctetsRef> Parse<Ref> for Opt<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Opt<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(self.octets.as_ref())
     }
 }
-
 
 //--- RtypeRecordData
 
 impl<Octets> RtypeRecordData for Opt<Octets> {
     const RTYPE: Rtype = Rtype::Opt;
 }
-
 
 //--- Display
 
@@ -200,7 +195,6 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Opt<Octets> {
         f.write_str(")")
     }
 }
-
 
 //------------ OptHeader -----------------------------------------------------
 
@@ -301,8 +295,7 @@ impl OptHeader {
     pub fn set_dnssec_ok(&mut self, value: bool) {
         if value {
             self.inner[7] |= 0x80
-        }
-        else {
+        } else {
             self.inner[7] &= 0x7F
         }
     }
@@ -310,19 +303,17 @@ impl OptHeader {
 
 impl Default for OptHeader {
     fn default() -> Self {
-        OptHeader { inner: [0, 0, 41, 0, 0, 0, 0, 0, 0] }
+        OptHeader {
+            inner: [0, 0, 41, 0, 0, 0, 0, 0, 0],
+        }
     }
 }
 
 impl Compose for OptHeader {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(&self.inner)
     }
 }
-
 
 //------------ OptRecord -----------------------------------------------------
 
@@ -364,7 +355,7 @@ impl<Octets> OptRecord<Octets> {
             ext_rcode: (record.ttl() >> 24) as u8,
             version: (record.ttl() >> 16) as u8,
             flags: record.ttl() as u16,
-            data: record.into_data()
+            data: record.into_data(),
         }
     }
 
@@ -412,7 +403,6 @@ impl<Octets> OptRecord<Octets> {
     }
 }
 
-
 //--- From
 
 impl<Octets, N: ToDname> From<Record<N, Opt<Octets>>> for OptRecord<Octets> {
@@ -421,11 +411,12 @@ impl<Octets, N: ToDname> From<Record<N, Opt<Octets>>> for OptRecord<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<OptRecord<SrcOctets>> for OptRecord<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: OptRecord<SrcOctets>) -> Result<Self, ShortBuf> {
         Ok(OptRecord {
             udp_payload_size: source.udp_payload_size,
@@ -436,7 +427,6 @@ where Octets: OctetsFrom<SrcOctets> {
         })
     }
 }
-
 
 //--- Deref and AsRef
 
@@ -453,7 +443,6 @@ impl<Octets> AsRef<Opt<Octets>> for OptRecord<Octets> {
         &self.data
     }
 }
-
 
 //------------ OptionHeader --------------------------------------------------
 
@@ -489,7 +478,6 @@ impl OptionHeader {
     }
 }
 
-
 //--- Parse and Compose
 
 impl<Octets: AsRef<[u8]>> Parse<Octets> for OptionHeader {
@@ -503,17 +491,13 @@ impl<Octets: AsRef<[u8]>> Parse<Octets> for OptionHeader {
 }
 
 impl Compose for OptionHeader {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.code.compose(target)?;
             self.len.compose(target)
         })
     }
 }
-
 
 //------------ OptIter -------------------------------------------------------
 
@@ -525,18 +509,21 @@ impl Compose for OptionHeader {
 /// particular option. After such an error you can continue to iterate until
 /// `None` indicates that you’ve reached the end of the record.
 #[derive(Clone, Debug)]
-pub struct OptIter<Ref: OctetsRef, D: ParseOptData<Ref>> { 
+pub struct OptIter<Ref: OctetsRef, D: ParseOptData<Ref>> {
     /// A parser for the OPT record data.
     parser: Parser<Ref>,
 
     /// The marker to remember which record data we use.
-    marker: PhantomData<D>
+    marker: PhantomData<D>,
 }
 
 impl<Ref: OctetsRef, D: ParseOptData<Ref>> OptIter<Ref, D> {
     /// Creates an iterator from a reference to the OPT record data.
     fn new(octets: Ref) -> Self {
-        OptIter { parser: Parser::from_ref(octets), marker: PhantomData }
+        OptIter {
+            parser: Parser::from_ref(octets),
+            marker: PhantomData,
+        }
     }
 
     /// Returns the next item from the parser.
@@ -547,32 +534,33 @@ impl<Ref: OctetsRef, D: ParseOptData<Ref>> OptIter<Ref, D> {
     fn next_step(&mut self) -> Result<Option<D>, ParseError> {
         let code = self.parser.parse_u16()?.into();
         let len = self.parser.parse_u16()? as usize;
-        self.parser.parse_block(len, |parser| {
-            D::parse_option(code, parser)
-        })
+        self.parser
+            .parse_block(len, |parser| D::parse_option(code, parser))
     }
 }
 
 impl<Ref, Data> Iterator for OptIter<Ref, Data>
-where Ref: OctetsRef, Data: ParseOptData<Ref> {
+where
+    Ref: OctetsRef,
+    Data: ParseOptData<Ref>,
+{
     type Item = Result<Data, ParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while self.parser.remaining() > 0 {
             match self.next_step() {
                 Ok(Some(res)) => return Some(Ok(res)),
-                Ok(None) => { }
+                Ok(None) => {}
                 Err(err) => {
                     // Advance to end so we’ll return None from now on.
                     self.parser.advance_to_end();
-                    return Some(Err(err))
+                    return Some(Err(err));
                 }
             }
         }
         None
     }
 }
-
 
 //------------ OptData -------------------------------------------------------
 
@@ -588,7 +576,6 @@ pub trait OptData: Compose + Sized {
     /// Returns the option code associated with this option.
     fn code(&self) -> OptionCode;
 }
-
 
 //------------ ParseOptData --------------------------------------------------
 
@@ -612,7 +599,6 @@ pub trait ParseOptData<Octets>: OptData {
         parser: &mut Parser<Octets>,
     ) -> Result<Option<Self>, ParseError>;
 }
-
 
 //------------ CodeOptData ---------------------------------------------------
 
@@ -639,21 +625,21 @@ impl<T: CodeOptData + Compose> OptData for T {
 }
 
 impl<Octets: AsRef<[u8]>, T> ParseOptData<Octets> for T
-where T: CodeOptData + Parse<Octets> + Compose + Sized {
+where
+    T: CodeOptData + Parse<Octets> + Compose + Sized,
+{
     fn parse_option(
         code: OptionCode,
         parser: &mut Parser<Octets>,
     ) -> Result<Option<Self>, ParseError> {
         if code == Self::CODE {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             parser.advance_to_end();
             Ok(None)
         }
     }
 }
-
 
 //------------ UnknownOptData ------------------------------------------------
 
@@ -692,17 +678,20 @@ impl<Octets> UnknownOptData<Octets> {
 
     /// Returns a slice of the option data.
     pub fn as_slice(&self) -> &[u8]
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         self.data.as_ref()
     }
 
     /// Returns a mutable slice of the option data.
     pub fn as_slice_mut(&mut self) -> &mut [u8]
-    where Octets: AsMut<[u8]> {
+    where
+        Octets: AsMut<[u8]>,
+    {
         self.data.as_mut()
     }
 }
-
 
 //--- Deref and DerefMut
 
@@ -719,7 +708,6 @@ impl<Octets> ops::DerefMut for UnknownOptData<Octets> {
         self.data_mut()
     }
 }
-
 
 //--- AsRef and AsMut
 
@@ -747,18 +735,13 @@ impl<Octets: AsMut<[u8]>> AsMut<[u8]> for UnknownOptData<Octets> {
     }
 }
 
-
 //--- Compose
 
 impl<Octets: AsRef<[u8]>> Compose for UnknownOptData<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(self.data.as_ref())
     }
 }
-
 
 //--- OptData
 
@@ -769,27 +752,30 @@ impl<Octets: AsRef<[u8]>> OptData for UnknownOptData<Octets> {
 }
 
 impl<Octets, Ref> ParseOptData<Ref> for UnknownOptData<Octets>
-where Octets: AsRef<[u8]>, Ref: OctetsRef<Range = Octets> {
+where
+    Octets: AsRef<[u8]>,
+    Ref: OctetsRef<Range = Octets>,
+{
     fn parse_option(
         code: OptionCode,
         parser: &mut Parser<Ref>,
     ) -> Result<Option<Self>, ParseError> {
         let len = parser.remaining();
-        parser.parse_octets(len)
+        parser
+            .parse_octets(len)
             .map(|data| Some(Self::from_octets(code, data)))
     }
 }
-
 
 //============ Tests =========================================================
 
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod test {
-    use std::vec::Vec;
-    use crate::base::record::ParsedRecord;
     use super::*;
-    use crate::base::{MessageBuilder, opt};
+    use crate::base::record::ParsedRecord;
+    use crate::base::{opt, MessageBuilder};
+    use std::vec::Vec;
 
     #[test]
     fn opt_record_header() {
@@ -803,7 +789,10 @@ mod test {
         0u16.compose(&mut buf).unwrap();
         let mut buf = Parser::from_ref(buf.as_slice());
         let record = ParsedRecord::parse(&mut buf)
-            .unwrap().into_record::<Opt<_>>().unwrap().unwrap();
+            .unwrap()
+            .into_record::<Opt<_>>()
+            .unwrap()
+            .unwrap();
         let record = OptRecord::from_record(record);
         assert_eq!(record.udp_payload_size(), 0x1234);
         assert_eq!(record.ext_rcode, OptRcode::BadVers.ext());
@@ -822,7 +811,8 @@ mod test {
                 mb.push(&nsid)?;
                 mb.push(&cookie)?;
                 Ok(())
-            }).unwrap();
+            })
+            .unwrap();
             mb.into_message()
         };
 
@@ -832,4 +822,3 @@ mod test {
         assert_eq!(Some(Ok(cookie)), opt.iter::<opt::Cookie>().next());
     }
 }
-

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -43,7 +43,8 @@ use super::header::Header;
 use super::iana::{OptRcode, OptionCode, Rtype};
 use super::name::ToDname;
 use super::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf,
 };
 use super::rdata::RtypeRecordData;
 use super::record::Record;
@@ -168,7 +169,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Opt<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Opt<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(self.octets.as_ref())
     }
 }
@@ -310,7 +314,10 @@ impl Default for OptHeader {
 }
 
 impl Compose for OptHeader {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.inner)
     }
 }
@@ -491,7 +498,10 @@ impl<Octets: AsRef<[u8]>> Parse<Octets> for OptionHeader {
 }
 
 impl Compose for OptionHeader {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.code.compose(target)?;
             self.len.compose(target)
@@ -738,7 +748,10 @@ impl<Octets: AsMut<[u8]>> AsMut<[u8]> for UnknownOptData<Octets> {
 //--- Compose
 
 impl<Octets: AsRef<[u8]>> Compose for UnknownOptData<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(self.data.as_ref())
     }
 }

--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -8,7 +8,8 @@ use super::cmp::CanonicalOrd;
 use super::iana::{Class, Rtype};
 use super::name::{ParsedDname, ToDname};
 use super::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf,
 };
 use core::cmp::Ordering;
 use core::{fmt, hash};
@@ -122,7 +123,9 @@ where
     NN: ToDname,
 {
     fn eq(&self, other: &Question<NN>) -> bool {
-        self.qname.name_eq(&other.qname) && self.qtype == other.qtype && self.qclass == other.qclass
+        self.qname.name_eq(&other.qname)
+            && self.qtype == other.qtype
+            && self.qclass == other.qclass
     }
 }
 
@@ -210,7 +213,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Question<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Question<N> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             target.append_compressed_dname(&self.qname)?;
             self.qtype.compose(target)?;
@@ -218,7 +224,10 @@ impl<N: ToDname> Compose for Question<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.qname.compose_canonical(target)?;
             self.qtype.compose_canonical(target)?;
@@ -277,7 +286,10 @@ pub trait AsQuestion {
     fn qclass(&self) -> Class;
 
     /// Produces the encoding of the question.
-    fn compose_question<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf>
+    fn compose_question<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf>
     where
         Self::Name: Compose,
     {
@@ -289,7 +301,10 @@ pub trait AsQuestion {
     }
 
     /// Produces the canoncial encoding of the question.
-    fn compose_question_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf>
+    fn compose_question_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf>
     where
         Self::Name: Compose,
     {

--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -4,16 +4,14 @@
 //! the question section of a DNS message and the `AsQuestion` trait for
 //! producing questions on the fly.
 
-use core::{fmt, hash};
-use core::cmp::Ordering;
 use super::cmp::CanonicalOrd;
 use super::iana::{Class, Rtype};
 use super::name::{ParsedDname, ToDname};
 use super::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, Parser, ParseError,
-    ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
-
+use core::cmp::Ordering;
+use core::{fmt, hash};
 
 //------------ Question ------------------------------------------------------
 
@@ -46,12 +44,20 @@ pub struct Question<N> {
 impl<N> Question<N> {
     /// Creates a new question from its three componets.
     pub fn new(qname: N, qtype: Rtype, qclass: Class) -> Self {
-        Question { qname, qtype, qclass }
+        Question {
+            qname,
+            qtype,
+            qclass,
+        }
     }
 
     /// Creates a new question from a name and record type, assuming class IN.
     pub fn new_in(qname: N, qtype: Rtype) -> Self {
-        Question { qname, qtype, qclass: Class::In }
+        Question {
+            qname,
+            qtype,
+            qclass: Class::In,
+        }
     }
 
     /// Converts the question into the qname.
@@ -59,7 +65,6 @@ impl<N> Question<N> {
         self.qname
     }
 }
-
 
 /// # Field Access
 ///
@@ -80,7 +85,6 @@ impl<N: ToDname> Question<N> {
     }
 }
 
-
 //--- From
 
 impl<N: ToDname> From<(N, Rtype, Class)> for Question<N> {
@@ -95,61 +99,68 @@ impl<N: ToDname> From<(N, Rtype)> for Question<N> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Name, SrcName> OctetsFrom<Question<SrcName>> for Question<Name>
-where Name: OctetsFrom<SrcName> {
+where
+    Name: OctetsFrom<SrcName>,
+{
     fn octets_from(source: Question<SrcName>) -> Result<Self, ShortBuf> {
         Ok(Question::new(
             Name::octets_from(source.qname)?,
-            source.qtype, source.qclass
+            source.qtype,
+            source.qclass,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<N, NN> PartialEq<Question<NN>> for Question<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn eq(&self, other: &Question<NN>) -> bool {
-        self.qname.name_eq(&other.qname)
-        && self.qtype == other.qtype
-        && self.qclass == other.qclass
+        self.qname.name_eq(&other.qname) && self.qtype == other.qtype && self.qclass == other.qclass
     }
 }
 
-impl<N: ToDname> Eq for Question<N> { }
-
+impl<N: ToDname> Eq for Question<N> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<N, NN> PartialOrd<Question<NN>> for Question<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn partial_cmp(&self, other: &Question<NN>) -> Option<Ordering> {
         match self.qname.name_cmp(&other.qname) {
-            Ordering::Equal => { }
-            other => return Some(other)
+            Ordering::Equal => {}
+            other => return Some(other),
         }
         match self.qtype.partial_cmp(&other.qtype) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         self.qclass.partial_cmp(&other.qclass)
     }
 }
 
 impl<N, NN> CanonicalOrd<Question<NN>> for Question<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn canonical_cmp(&self, other: &Question<NN>) -> Ordering {
         match self.qname.lowercase_composed_cmp(&other.qname) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.qtype.cmp(&other.qtype) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.qclass.cmp(&other.qclass)
     }
@@ -158,17 +169,16 @@ where N: ToDname, NN: ToDname {
 impl<N: ToDname> Ord for Question<N> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.qname.name_cmp(&other.qname) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.qtype.cmp(&other.qtype) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.qclass.cmp(&other.qclass)
     }
 }
-
 
 //--- Hash
 
@@ -180,7 +190,6 @@ impl<N: hash::Hash> hash::Hash for Question<N> {
     }
 }
 
-
 //--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Question<ParsedDname<Ref>> {
@@ -188,7 +197,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Question<ParsedDname<Ref>> {
         Ok(Question::new(
             ParsedDname::parse(parser)?,
             Rtype::parse(parser)?,
-            Class::parse(parser)?
+            Class::parse(parser)?,
         ))
     }
 
@@ -201,10 +210,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Question<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Question<N> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             target.append_compressed_dname(&self.qname)?;
             self.qtype.compose(target)?;
@@ -212,10 +218,7 @@ impl<N: ToDname> Compose for Question<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.qname.compose_canonical(target)?;
             self.qtype.compose_canonical(target)?;
@@ -223,7 +226,6 @@ impl<N: ToDname> Compose for Question<N> {
         })
     }
 }
-
 
 //--- Display and Debug
 
@@ -242,7 +244,6 @@ impl<N: fmt::Debug> fmt::Debug for Question<N> {
             .finish()
     }
 }
-
 
 //------------ AsQuestion ----------------------------------------------------
 
@@ -276,11 +277,10 @@ pub trait AsQuestion {
     fn qclass(&self) -> Class;
 
     /// Produces the encoding of the question.
-    fn compose_question<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf>
-    where Self::Name: Compose {
+    fn compose_question<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf>
+    where
+        Self::Name: Compose,
+    {
         target.append_all(|target| {
             target.append_compressed_dname(self.qname())?;
             self.qtype().compose(target)?;
@@ -289,11 +289,10 @@ pub trait AsQuestion {
     }
 
     /// Produces the canoncial encoding of the question.
-    fn compose_question_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf>
-    where Self::Name: Compose {
+    fn compose_question_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf>
+    where
+        Self::Name: Compose,
+    {
         target.append_all(|target| {
             self.qname().compose_canonical(target)?;
             self.qtype().compose_canonical(target)?;
@@ -337,16 +336,27 @@ impl<Name: ToDname> AsQuestion for Question<Name> {
 impl<Name: ToDname> AsQuestion for (Name, Rtype, Class) {
     type Name = Name;
 
-    fn qname(&self) -> &Self::Name { &self.0 }
-    fn qtype(&self) -> Rtype { self.1 }
-    fn qclass(&self) -> Class { self.2 }
+    fn qname(&self) -> &Self::Name {
+        &self.0
+    }
+    fn qtype(&self) -> Rtype {
+        self.1
+    }
+    fn qclass(&self) -> Class {
+        self.2
+    }
 }
 
 impl<Name: ToDname> AsQuestion for (Name, Rtype) {
     type Name = Name;
 
-    fn qname(&self) -> &Self::Name { &self.0 }
-    fn qtype(&self) -> Rtype { self.1 }
-    fn qclass(&self) -> Class { Class::In }
+    fn qname(&self) -> &Self::Name {
+        &self.0
+    }
+    fn qtype(&self) -> Rtype {
+        self.1
+    }
+    fn qclass(&self) -> Class {
+        Class::In
+    }
 }
-

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -25,10 +25,13 @@
 use super::cmp::CanonicalOrd;
 use super::iana::Rtype;
 use super::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf,
 };
 #[cfg(feature = "master")]
-use crate::master::scan::{CharSource, Scan, ScanError, Scanner, SyntaxError};
+use crate::master::scan::{
+    CharSource, Scan, ScanError, Scanner, SyntaxError,
+};
 #[cfg(feature = "master")]
 use bytes::{BufMut, Bytes, BytesMut};
 use core::cmp::Ordering;
@@ -76,7 +79,10 @@ pub trait ParseRecordData<Ref>: RecordData {
     ///
     /// If the function doesn’t want to process the data, it must not touch
     /// the parser. In particual, it must not advance it.
-    fn parse_data(rtype: Rtype, parser: &mut Parser<Ref>) -> Result<Option<Self>, ParseError>;
+    fn parse_data(
+        rtype: Rtype,
+        parser: &mut Parser<Ref>,
+    ) -> Result<Option<Self>, ParseError>;
 }
 
 //------------ RtypeRecordData -----------------------------------------------
@@ -111,7 +117,10 @@ impl<Octets, T> ParseRecordData<Octets> for T
 where
     T: RtypeRecordData + Parse<Octets> + Compose + Sized,
 {
-    fn parse_data(rtype: Rtype, parser: &mut Parser<Octets>) -> Result<Option<Self>, ParseError> {
+    fn parse_data(
+        rtype: Rtype,
+        parser: &mut Parser<Octets>,
+    ) -> Result<Option<Self>, ParseError> {
         if rtype == Self::RTYPE {
             Self::parse(parser).map(Some)
         } else {
@@ -176,7 +185,10 @@ impl UnknownRecordData<Bytes> {
     /// Scans the record data.
     ///
     /// This isn’t implemented via `Scan`, because we need the record type.
-    pub fn scan<C: CharSource>(rtype: Rtype, scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    pub fn scan<C: CharSource>(
+        rtype: Rtype,
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         scanner.skip_literal("\\#")?;
         let mut len = u16::scan(scanner)? as usize;
         let mut res = BytesMut::with_capacity(len);
@@ -211,11 +223,14 @@ impl UnknownRecordData<Bytes> {
 
 //--- OctetsFrom
 
-impl<Octets, SrcOctets> OctetsFrom<UnknownRecordData<SrcOctets>> for UnknownRecordData<Octets>
+impl<Octets, SrcOctets> OctetsFrom<UnknownRecordData<SrcOctets>>
+    for UnknownRecordData<Octets>
 where
     Octets: OctetsFrom<SrcOctets>,
 {
-    fn octets_from(source: UnknownRecordData<SrcOctets>) -> Result<Self, ShortBuf> {
+    fn octets_from(
+        source: UnknownRecordData<SrcOctets>,
+    ) -> Result<Self, ShortBuf> {
         Ok(UnknownRecordData {
             rtype: source.rtype,
             data: Octets::octets_from(source.data)?,
@@ -225,7 +240,8 @@ where
 
 //--- PartialEq and Eq
 
-impl<Octets, Other> PartialEq<UnknownRecordData<Other>> for UnknownRecordData<Octets>
+impl<Octets, Other> PartialEq<UnknownRecordData<Other>>
+    for UnknownRecordData<Octets>
 where
     Octets: AsRef<[u8]>,
     Other: AsRef<[u8]>,
@@ -239,17 +255,22 @@ impl<Octets: AsRef<[u8]>> Eq for UnknownRecordData<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
-impl<Octets, Other> PartialOrd<UnknownRecordData<Other>> for UnknownRecordData<Octets>
+impl<Octets, Other> PartialOrd<UnknownRecordData<Other>>
+    for UnknownRecordData<Octets>
 where
     Octets: AsRef<[u8]>,
     Other: AsRef<[u8]>,
 {
-    fn partial_cmp(&self, other: &UnknownRecordData<Other>) -> Option<Ordering> {
+    fn partial_cmp(
+        &self,
+        other: &UnknownRecordData<Other>,
+    ) -> Option<Ordering> {
         self.data.as_ref().partial_cmp(other.data.as_ref())
     }
 }
 
-impl<Octets, Other> CanonicalOrd<UnknownRecordData<Other>> for UnknownRecordData<Octets>
+impl<Octets, Other> CanonicalOrd<UnknownRecordData<Other>>
+    for UnknownRecordData<Octets>
 where
     Octets: AsRef<[u8]>,
     Other: AsRef<[u8]>,
@@ -268,7 +289,10 @@ impl<Octets: AsRef<[u8]>> Ord for UnknownRecordData<Octets> {
 //--- Compose, and Compress
 
 impl<Octets: AsRef<[u8]>> Compose for UnknownRecordData<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(self.data.as_ref())
     }
 }
@@ -286,7 +310,10 @@ where
     Octets: AsRef<[u8]>,
     Ref: OctetsRef<Range = Octets>,
 {
-    fn parse_data(rtype: Rtype, parser: &mut Parser<Ref>) -> Result<Option<Self>, ParseError> {
+    fn parse_data(
+        rtype: Rtype,
+        parser: &mut Parser<Ref>,
+    ) -> Result<Option<Self>, ParseError> {
         let rdlen = parser.remaining();
         parser
             .parse_octets(rdlen)

--- a/src/base/serial.rs
+++ b/src/base/serial.rs
@@ -8,9 +8,13 @@
 //! [`Serial`]: struct.Serial.html
 
 use super::cmp::CanonicalOrd;
-use super::octets::{Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf};
+use super::octets::{
+    Compose, OctetsBuilder, Parse, ParseError, Parser, ShortBuf,
+};
 #[cfg(feature = "master")]
-use crate::master::scan::{CharSource, Scan, ScanError, Scanner, SyntaxError};
+use crate::master::scan::{
+    CharSource, Scan, ScanError, Scanner, SyntaxError,
+};
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, TimeZone, Utc};
 use core::cmp::Ordering;
@@ -86,7 +90,9 @@ impl Serial {
     ///
     /// [RRSIG]: ../../rdata/rfc4034/struct.Rrsig.html
     #[cfg(feature = "master")]
-    pub fn scan_rrsig<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    pub fn scan_rrsig<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         scanner.scan_phrase(
             (0, [0u8; 14]),
             |&mut (ref mut pos, ref mut buf), symbol| {
@@ -198,7 +204,10 @@ impl<T: AsRef<[u8]>> Parse<T> for Serial {
 }
 
 impl Compose for Serial {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         self.0.compose(target)
     }
 }
@@ -207,7 +216,9 @@ impl Compose for Serial {
 
 #[cfg(feature = "master")]
 impl Scan for Serial {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         u32::scan(scanner).map(Into::into)
     }
 }
@@ -272,7 +283,9 @@ mod test {
         assert_eq!(Serial(0).add(4), Serial(4));
         assert_eq!(
             Serial(0xFF00_0000).add(0x0F00_0000),
-            Serial(((0xFF00_0000u64 + 0x0F00_0000u64) % 0x1_0000_0000) as u32)
+            Serial(
+                ((0xFF00_0000u64 + 0x0F00_0000u64) % 0x1_0000_0000) as u32
+            )
         );
     }
 
@@ -294,10 +307,16 @@ mod test {
         // s1 is said to be less than s2 if [...]
         // (i1 < i2 and i2 - i1 < 2^(SERIAL_BITS - 1))
         assert_eq!(Serial(12).partial_cmp(&Serial(13)), Some(Less));
-        assert_ne!(Serial(12).partial_cmp(&Serial(3_000_000_012)), Some(Less));
+        assert_ne!(
+            Serial(12).partial_cmp(&Serial(3_000_000_012)),
+            Some(Less)
+        );
 
         // or (i1 > i2 and i1 - i2 > 2^(SERIAL_BITS - 1))
-        assert_eq!(Serial(3_000_000_012).partial_cmp(&Serial(12)), Some(Less));
+        assert_eq!(
+            Serial(3_000_000_012).partial_cmp(&Serial(12)),
+            Some(Less)
+        );
         assert_ne!(Serial(13).partial_cmp(&Serial(12)), Some(Less));
 
         // s1 is said to be greater than s2 if [...]

--- a/src/base/str.rs
+++ b/src/base/str.rs
@@ -142,7 +142,12 @@ impl Symbol {
     pub fn is_word_char(self) -> bool {
         match self {
             Symbol::Char(ch) => {
-                ch != ' ' && ch != '\t' && ch != '(' && ch != ')' && ch != ';' && ch != '"'
+                ch != ' '
+                    && ch != '\t'
+                    && ch != '('
+                    && ch != ')'
+                    && ch != ';'
+                    && ch != '"'
             }
             _ => true,
         }

--- a/src/base/str.rs
+++ b/src/base/str.rs
@@ -3,9 +3,8 @@
 //! This module contains helper types for converting from and to string
 //! representation of types.
 
-use core::fmt;
 use super::octets::ParseError;
-
+use core::fmt;
 
 //------------ Symbol --------------------------------------------------------
 
@@ -34,14 +33,16 @@ impl Symbol {
     /// Returns the next symbol in the source, `Ok(None)` if the source has
     /// been exhausted, or an error if there wasn’t a valid symbol.
     pub fn from_chars<C>(chars: C) -> Result<Option<Self>, SymbolError>
-                      where C: IntoIterator<Item=char> {
+    where
+        C: IntoIterator<Item = char>,
+    {
         let mut chars = chars.into_iter();
         let ch = match chars.next() {
             Some(ch) => ch,
             None => return Ok(None),
         };
         if ch != '\\' {
-            return Ok(Some(Symbol::Char(ch)))
+            return Ok(Some(Symbol::Char(ch)));
         }
         match chars.next() {
             Some(ch) if ch.is_digit(10) => {
@@ -49,25 +50,25 @@ impl Symbol {
                 let ch2 = match chars.next() {
                     Some(ch) => match ch.to_digit(10) {
                         Some(ch) => ch * 10,
-                        None => return Err(SymbolError::BadEscape)
-                    }
-                    None => return Err(SymbolError::ShortInput)
+                        None => return Err(SymbolError::BadEscape),
+                    },
+                    None => return Err(SymbolError::ShortInput),
                 };
                 let ch3 = match chars.next() {
-                    Some(ch)  => match ch.to_digit(10) {
+                    Some(ch) => match ch.to_digit(10) {
                         Some(ch) => ch,
-                        None => return Err(SymbolError::BadEscape)
-                    }
-                    None => return Err(SymbolError::ShortInput)
+                        None => return Err(SymbolError::BadEscape),
+                    },
+                    None => return Err(SymbolError::ShortInput),
                 };
                 let res = ch + ch2 + ch3;
                 if res > 255 {
-                    return Err(SymbolError::BadEscape)
+                    return Err(SymbolError::BadEscape);
                 }
                 Ok(Some(Symbol::DecimalEscape(res as u8)))
             }
             Some(ch) => Ok(Some(Symbol::SimpleEscape(ch))),
-            None => Err(SymbolError::ShortInput)
+            None => Err(SymbolError::ShortInput),
         }
     }
 
@@ -80,11 +81,9 @@ impl Symbol {
     pub fn from_octet(ch: u8) -> Self {
         if ch == b' ' || ch == b'"' || ch == b'\\' || ch == b';' {
             Symbol::SimpleEscape(ch as char)
-        }
-        else if !(0x20..0x7F).contains(&ch) {
+        } else if !(0x20..0x7F).contains(&ch) {
             Symbol::DecimalEscape(ch)
-        }
-        else {
+        } else {
             Symbol::Char(ch as char)
         }
     }
@@ -105,8 +104,7 @@ impl Symbol {
             Symbol::Char(ch) | Symbol::SimpleEscape(ch) => {
                 if ch.is_ascii() && ch >= '\u{20}' && ch <= '\u{7E}' {
                     Ok(ch as u8)
-                }
-                else {
+                } else {
                     Err(BadSymbol(self))
                 }
             }
@@ -121,7 +119,7 @@ impl Symbol {
     pub fn into_char(self) -> Result<char, BadSymbol> {
         match self {
             Symbol::Char(ch) | Symbol::SimpleEscape(ch) => Ok(ch),
-            Symbol::DecimalEscape(_) => Err(BadSymbol(self))
+            Symbol::DecimalEscape(_) => Err(BadSymbol(self)),
         }
     }
 
@@ -130,10 +128,9 @@ impl Symbol {
         if let Symbol::Char(ch) = self {
             match ch.to_digit(base) {
                 Some(ch) => Ok(ch),
-                None => Err(BadSymbol(self))
+                None => Err(BadSymbol(self)),
             }
-        }
-        else {
+        } else {
             Err(BadSymbol(self))
         }
     }
@@ -145,14 +142,12 @@ impl Symbol {
     pub fn is_word_char(self) -> bool {
         match self {
             Symbol::Char(ch) => {
-                ch != ' ' && ch != '\t' && ch != '(' && ch != ')' &&
-                ch != ';' && ch != '"'
+                ch != ' ' && ch != '\t' && ch != '(' && ch != ')' && ch != ';' && ch != '"'
             }
-            _ => true
+            _ => true,
         }
     }
 }
-
 
 //--- From
 
@@ -161,7 +156,6 @@ impl From<char> for Symbol {
         Symbol::Char(ch)
     }
 }
-
 
 //--- Display
 
@@ -174,7 +168,6 @@ impl fmt::Display for Symbol {
         }
     }
 }
-
 
 //============ Error Types ===================================================
 
@@ -189,33 +182,28 @@ pub enum SymbolError {
     /// Unexpected end of input.
     ///
     /// This can only happen in a decimal escape sequence.
-    ShortInput
+    ShortInput,
 }
-
 
 //--- Display and Error
 
 impl fmt::Display for SymbolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            SymbolError::BadEscape
-                => f.write_str("illegal escape sequence"),
-            SymbolError::ShortInput
-                => ParseError::ShortInput.fmt(f)
+            SymbolError::BadEscape => f.write_str("illegal escape sequence"),
+            SymbolError::ShortInput => ParseError::ShortInput.fmt(f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for SymbolError { }
-
+impl std::error::Error for SymbolError {}
 
 //------------ BadSymbol -----------------------------------------------------
 
-/// A symbol with an unexpected value was encountered. 
+/// A symbol with an unexpected value was encountered.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BadSymbol(pub Symbol);
-
 
 //--- Display and Error
 
@@ -226,5 +214,4 @@ impl fmt::Display for BadSymbol {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for BadSymbol { }
-
+impl std::error::Error for BadSymbol {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //!   enables the `bytes`, `chrono`, and `std` features.
 //! * `ring`: enables crypto functionality via the [ring] crate.
 //! * `sign`: basic DNSSEC signing support. This will enable the [sign]
-//!   module and requires the `std` feature. Note that this will not directly 
+//!   module and requires the `std` feature. Note that this will not directly
 //!   enable actually signing. For that you will also need to pick a crypto
 //!   module via an additional feature. Currently we only support the `ring`
 //!   module, but support for OpenSSL is coming soon.
@@ -80,9 +80,11 @@
 
 #[cfg(any(feature = "std"))]
 #[allow(unused_imports)] // Import macros even if unused.
-#[macro_use] extern crate std;
+#[macro_use]
+extern crate std;
 
-#[macro_use] extern crate core;
+#[macro_use]
+extern crate core;
 
 pub mod base;
 pub mod master;
@@ -91,5 +93,5 @@ pub mod resolv;
 pub mod sign;
 pub mod test;
 pub mod tsig;
-pub mod validate;
 pub mod utils;
+pub mod validate;

--- a/src/master/entry.rs
+++ b/src/master/entry.rs
@@ -102,19 +102,28 @@ impl Entry {
         } else if let Ok(()) = Self::scan_blank(scanner) {
             Ok(Some(Entry::Blank))
         } else {
-            let record = Self::scan_record(scanner, last_owner, last_class, default_ttl)?;
+            let record = Self::scan_record(
+                scanner,
+                last_owner,
+                last_class,
+                default_ttl,
+            )?;
             Ok(Some(Entry::Record(record)))
         }
     }
 
-    fn scan_blank<C: CharSource>(scanner: &mut Scanner<C>) -> Result<(), ScanError> {
+    fn scan_blank<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<(), ScanError> {
         scanner.scan_opt_space()?;
         scanner.scan_newline()?;
         Ok(())
     }
 
     /// Tries to scan a control entry.
-    fn scan_control<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan_control<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         match ControlType::scan(scanner)? {
             ControlType::Origin => {
                 let name = Dname::scan(scanner)?;
@@ -146,7 +155,8 @@ impl Entry {
         default_ttl: Option<u32>,
     ) -> Result<MasterRecord, ScanError> {
         let owner = Self::scan_owner(scanner, last_owner)?;
-        let (ttl, class) = Self::scan_ttl_class(scanner, last_class, default_ttl)?;
+        let (ttl, class) =
+            Self::scan_ttl_class(scanner, last_class, default_ttl)?;
         let rtype = Rtype::scan(scanner)?;
         let rdata = MasterRecordData::scan(rtype, scanner)?;
         scanner.scan_newline()?;
@@ -196,11 +206,15 @@ impl Entry {
         };
         let ttl = match ttl.or(default_ttl) {
             Some(ttl) => ttl,
-            None => return Err(ScanError::Syntax(SyntaxError::NoDefaultTtl, pos)),
+            None => {
+                return Err(ScanError::Syntax(SyntaxError::NoDefaultTtl, pos))
+            }
         };
         let class = match class.or(last_class) {
             Some(class) => class,
-            None => return Err(ScanError::Syntax(SyntaxError::NoLastClass, pos)),
+            None => {
+                return Err(ScanError::Syntax(SyntaxError::NoLastClass, pos))
+            }
         };
         Ok((ttl, class))
     }
@@ -218,7 +232,9 @@ enum ControlType {
 }
 
 impl Scan for ControlType {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         let pos = scanner.pos();
         scanner.scan_string_word(|word| {
             if word.eq_ignore_ascii_case("$ORIGIN") {
@@ -238,4 +254,5 @@ impl Scan for ControlType {
 
 //------------ MasterRecord --------------------------------------------------
 
-pub type MasterRecord = Record<Dname<Bytes>, MasterRecordData<Bytes, Dname<Bytes>>>;
+pub type MasterRecord =
+    Record<Dname<Bytes>, MasterRecordData<Bytes, Dname<Bytes>>>;

--- a/src/master/mod.rs
+++ b/src/master/mod.rs
@@ -5,6 +5,5 @@
 
 pub mod entry;
 pub mod reader;
-pub mod source;
 pub mod scan;
-
+pub mod source;

--- a/src/master/reader.rs
+++ b/src/master/reader.rs
@@ -1,15 +1,13 @@
-
+use super::entry::{Entry, MasterRecord};
+use super::scan::{CharSource, Pos, ScanError, Scanner};
+use super::source::Utf8File;
+use crate::base::iana::Class;
+use crate::base::name::Dname;
+use bytes::Bytes;
 use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::string::String;
-use bytes::Bytes;
-use crate::base::iana::Class;
-use crate::base::name::Dname;
-use super::entry::{Entry, MasterRecord};
-use super::scan::{CharSource, Pos, ScanError, Scanner};
-use super::source::Utf8File;
-
 
 pub struct Reader<C: CharSource> {
     scanner: Option<Scanner<C>>,
@@ -22,7 +20,7 @@ impl<C: CharSource> Reader<C> {
         Reader {
             scanner: Some(Scanner::new(source)),
             ttl: None,
-            last: None
+            last: None,
         }
     }
 }
@@ -38,23 +36,22 @@ impl<C: CharSource> Reader<C> {
         loop {
             match self.next_entry() {
                 Ok(Some(Entry::Origin(origin))) => self.set_origin(origin),
-                Ok(Some(Entry::Include{ path, origin })) => {
+                Ok(Some(Entry::Include { path, origin })) => {
                     return Ok(Some(ReaderItem::Include { path, origin }))
                 }
                 Ok(Some(Entry::Ttl(ttl))) => self.ttl = Some(ttl),
-                Ok(Some(Entry::Control{ name, start })) => {
+                Ok(Some(Entry::Control { name, start })) => {
                     return Ok(Some(ReaderItem::Control { name, start }))
                 }
                 Ok(Some(Entry::Record(record))) => {
-                    self.last = Some((record.owner().clone(),
-                                      record.class()));
-                    return Ok(Some(ReaderItem::Record(record)))
+                    self.last = Some((record.owner().clone(), record.class()));
+                    return Ok(Some(ReaderItem::Record(record)));
                 }
-                Ok(Some(Entry::Blank)) => { }
+                Ok(Some(Entry::Blank)) => {}
                 Ok(None) => return Ok(None),
                 Err(err) => {
                     self.scanner = None;
-                    return Err(err)
+                    return Err(err);
                 }
             }
         }
@@ -68,12 +65,8 @@ impl<C: CharSource> Reader<C> {
             (&mut Some(ref mut scanner), &Some((ref owner, class))) => {
                 (scanner, Some(owner), Some(class))
             }
-            (&mut Some(ref mut scanner), _) => {
-                (scanner, None, None)
-            }
-            (&mut None, _) => {
-                return Ok(None)
-            }
+            (&mut Some(ref mut scanner), _) => (scanner, None, None),
+            (&mut None, _) => return Ok(None),
         };
         Entry::scan(scanner, owner, class, self.ttl)
     }
@@ -92,24 +85,32 @@ impl<C: CharSource> Iterator for Reader<C> {
         match self.next_record() {
             Ok(Some(res)) => Some(Ok(res)),
             Ok(None) => None,
-            Err(err) => Some(Err(err))
+            Err(err) => Some(Err(err)),
         }
     }
 }
 
-
 #[derive(Clone, Debug)]
 pub enum ReaderItem {
     Record(MasterRecord),
-    Include { path: PathBuf, origin: Option<Dname<Bytes>> },
-    Control { name: String, start: Pos },
+    Include {
+        path: PathBuf,
+        origin: Option<Dname<Bytes>>,
+    },
+    Control {
+        name: String,
+        start: Pos,
+    },
 }
 
 impl fmt::Display for ReaderItem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ReaderItem::Record(ref record) => write!(f, "{}", record),
-            ReaderItem::Include { ref path, ref origin } => {
+            ReaderItem::Include {
+                ref path,
+                ref origin,
+            } => {
                 write!(f, "$INCLUDE {}", path.display())?;
                 if let Some(ref origin) = *origin {
                     write!(f, " {}", origin)?;
@@ -123,17 +124,17 @@ impl fmt::Display for ReaderItem {
     }
 }
 
-
 //============ Test ==========================================================
 
 #[cfg(test)]
 mod test {
-    use crate::master::scan::ScanError;
     use super::*;
+    use crate::master::scan::ScanError;
 
     #[test]
     fn print() {
-        let reader = Reader::new(&"$ORIGIN ISI.EDU.
+        let reader = Reader::new(
+            &"$ORIGIN ISI.EDU.
 $TTL 86400
 @   IN  SOA     VENERA      Action\\.domains (
                                  20     ; SERIAL
@@ -157,7 +158,8 @@ VAXA    A       10.2.0.27
         A       128.9.0.33
 
 
-$INCLUDE <SUBSYS>ISI-MAILBOXES.TXT"[..]);
+$INCLUDE <SUBSYS>ISI-MAILBOXES.TXT"[..],
+        );
 
         for item in reader {
             match item {
@@ -165,9 +167,8 @@ $INCLUDE <SUBSYS>ISI-MAILBOXES.TXT"[..]);
                 Err(ScanError::Syntax(err, pos)) => {
                     panic!("{}:{}:  {:?}", pos.line(), pos.col(), err);
                 }
-                Err(err) => panic!("{:?}", err)
+                Err(err) => panic!("{:?}", err),
             }
         }
     }
 }
-

--- a/src/master/reader.rs
+++ b/src/master/reader.rs
@@ -44,7 +44,8 @@ impl<C: CharSource> Reader<C> {
                     return Ok(Some(ReaderItem::Control { name, start }))
                 }
                 Ok(Some(Entry::Record(record))) => {
-                    self.last = Some((record.owner().clone(), record.class()));
+                    self.last =
+                        Some((record.owner().clone(), record.class()));
                     return Ok(Some(ReaderItem::Record(record)));
                 }
                 Ok(Some(Entry::Blank)) => {}

--- a/src/master/scan.rs
+++ b/src/master/scan.rs
@@ -159,7 +159,9 @@ impl<C: CharSource> Scanner<C> {
                     return self.err(SyntaxError::Unexpected(ch));
                 }
             }
-            Some(Token::Newline) => return self.err(SyntaxError::UnexpectedNewline),
+            Some(Token::Newline) => {
+                return self.err(SyntaxError::UnexpectedNewline)
+            }
             None => return self.err(SyntaxError::UnexpectedEof),
         };
         while let Some(ch) = self.cond_read_symbol(Symbol::is_word_char)? {
@@ -182,7 +184,10 @@ impl<C: CharSource> Scanner<C> {
     /// to convert the value into something else via the closure `finalop`.
     /// This closure can fail, resulting in an error and back-tracking to
     /// the beginning of the phrase.
-    pub fn scan_string_word<U, G>(&mut self, finalop: G) -> Result<U, ScanError>
+    pub fn scan_string_word<U, G>(
+        &mut self,
+        finalop: G,
+    ) -> Result<U, ScanError>
     where
         G: FnOnce(String) -> Result<U, SyntaxError>,
     {
@@ -227,8 +232,12 @@ impl<C: CharSource> Scanner<C> {
     {
         match self.read()? {
             Some(Token::Symbol(Symbol::Char('"'))) => {}
-            Some(Token::Symbol(ch)) => return self.err(SyntaxError::Unexpected(ch)),
-            Some(Token::Newline) => return self.err(SyntaxError::UnexpectedNewline),
+            Some(Token::Symbol(ch)) => {
+                return self.err(SyntaxError::Unexpected(ch))
+            }
+            Some(Token::Newline) => {
+                return self.err(SyntaxError::UnexpectedNewline)
+            }
             None => return self.err(SyntaxError::UnexpectedEof),
         }
         loop {
@@ -239,7 +248,9 @@ impl<C: CharSource> Scanner<C> {
                         return self.err(err);
                     }
                 }
-                Some(Token::Newline) => return self.err(SyntaxError::UnexpectedNewline),
+                Some(Token::Newline) => {
+                    return self.err(SyntaxError::UnexpectedNewline)
+                }
                 None => return self.err(SyntaxError::UnexpectedEof),
             }
         }
@@ -280,7 +291,10 @@ impl<C: CharSource> Scanner<C> {
     /// a chance to convert the value into something else via the closure
     /// `finalop`. This closure can fail, resulting in an error and
     /// back-tracking to the beginning of the phrase.
-    pub fn scan_byte_phrase<U, G>(&mut self, finalop: G) -> Result<U, ScanError>
+    pub fn scan_byte_phrase<U, G>(
+        &mut self,
+        finalop: G,
+    ) -> Result<U, ScanError>
     where
         G: FnOnce(Bytes) -> Result<U, SyntaxError>,
     {
@@ -308,7 +322,10 @@ impl<C: CharSource> Scanner<C> {
     /// a chance to convert the value into something else via the closure
     /// `finalop`. This closure can fail, resulting in an error and
     /// back-tracking to the beginning of the phrase.
-    pub fn scan_string_phrase<U, G>(&mut self, finalop: G) -> Result<U, ScanError>
+    pub fn scan_string_phrase<U, G>(
+        &mut self,
+        finalop: G,
+    ) -> Result<U, ScanError>
     where
         G: FnOnce(String) -> Result<U, SyntaxError>,
     {
@@ -397,7 +414,8 @@ impl<C: CharSource> Scanner<C> {
                 Some(Token::Symbol(Symbol::Char(')'))) => {
                     if !quote {
                         if !self.paren {
-                            return self.err(SyntaxError::Unexpected(')'.into()));
+                            return self
+                                .err(SyntaxError::Unexpected(')'.into()));
                         }
                         self.paren = false
                     }
@@ -419,7 +437,9 @@ impl<C: CharSource> Scanner<C> {
             |left, symbol| {
                 let first = match left.chars().next() {
                     Some(ch) => ch,
-                    None => return Err(SyntaxError::Expected(literal.into())),
+                    None => {
+                        return Err(SyntaxError::Expected(literal.into()))
+                    }
                 };
                 match symbol {
                     Symbol::Char(ch) if ch == first => {
@@ -454,7 +474,9 @@ impl<C: CharSource> Scanner<C> {
     {
         self.scan_word(
             (BytesMut::new(), None), // result and optional first char.
-            |&mut (ref mut res, ref mut first), symbol| hex_symbolop(res, first, symbol),
+            |&mut (ref mut res, ref mut first), symbol| {
+                hex_symbolop(res, first, symbol)
+            },
             |(res, first)| {
                 if let Some(ch) = first {
                     Err(SyntaxError::Unexpected(Symbol::Char(
@@ -477,7 +499,9 @@ impl<C: CharSource> Scanner<C> {
         loop {
             let res = self.scan_word(
                 (&mut buf, None),
-                |&mut (ref mut buf, ref mut first), symbol| hex_symbolop(buf, first, symbol),
+                |&mut (ref mut buf, ref mut first), symbol| {
+                    hex_symbolop(buf, first, symbol)
+                },
                 |(_, first)| {
                     if let Some(ch) = first {
                         Err(SyntaxError::Unexpected(Symbol::Char(
@@ -504,7 +528,10 @@ impl<C: CharSource> Scanner<C> {
     ///
     /// In particular, this decodes the “base32hex” decoding definied in
     /// RFC 4648 without padding.
-    pub fn scan_base32hex_phrase<U, G>(&mut self, finalop: G) -> Result<U, ScanError>
+    pub fn scan_base32hex_phrase<U, G>(
+        &mut self,
+        finalop: G,
+    ) -> Result<U, ScanError>
     where
         G: FnOnce(Bytes) -> Result<U, SyntaxError>,
     {
@@ -515,12 +542,17 @@ impl<C: CharSource> Scanner<C> {
                     .push(symbol.into_char()?)
                     .map_err(SyntaxError::content)
             },
-            |decoder| finalop(decoder.finalize().map_err(SyntaxError::content)?),
+            |decoder| {
+                finalop(decoder.finalize().map_err(SyntaxError::content)?)
+            },
         )
     }
 
     /// Scans a sequence of phrases containing base64 encoded data.
-    pub fn scan_base64_phrases<U, G>(&mut self, finalop: G) -> Result<U, ScanError>
+    pub fn scan_base64_phrases<U, G>(
+        &mut self,
+        finalop: G,
+    ) -> Result<U, ScanError>
     where
         G: FnOnce(Bytes) -> Result<U, SyntaxError>,
     {
@@ -618,14 +650,18 @@ impl<C: CharSource> Scanner<C> {
                 let ch2 = match self.chars_next()? {
                     Some(ch) => match ch.to_digit(10) {
                         Some(ch) => ch * 10,
-                        None => return self.err_cur(SyntaxError::IllegalEscape),
+                        None => {
+                            return self.err_cur(SyntaxError::IllegalEscape)
+                        }
                     },
                     None => return self.err_cur(SyntaxError::UnexpectedEof),
                 };
                 let ch3 = match self.chars_next()? {
                     Some(ch) => match ch.to_digit(10) {
                         Some(ch) => ch,
-                        None => return self.err_cur(SyntaxError::IllegalEscape),
+                        None => {
+                            return self.err_cur(SyntaxError::IllegalEscape)
+                        }
                     },
                     None => return self.err_cur(SyntaxError::UnexpectedEof),
                 };
@@ -694,11 +730,13 @@ impl<C: CharSource> Scanner<C> {
                         ('\r', _) | ('\n', _) => {
                             self.newline = NewlineMode::Single(ch);
                             self.buf.push(Token::Newline);
-                            self.buf.push(Token::Symbol(Symbol::Char(second)));
+                            self.buf
+                                .push(Token::Symbol(Symbol::Char(second)));
                         }
                         _ => {
                             self.buf.push(Token::Symbol(Symbol::Char(ch)));
-                            self.buf.push(Token::Symbol(Symbol::Char(second)));
+                            self.buf
+                                .push(Token::Symbol(Symbol::Char(second)));
                         }
                     }
                     Ok(true)
@@ -783,7 +821,11 @@ impl<C: CharSource> Scanner<C> {
     }
 
     /// Reports an error at current position and then backtracks.
-    fn err_at<T>(&mut self, err: SyntaxError, pos: Pos) -> Result<T, ScanError> {
+    fn err_at<T>(
+        &mut self,
+        err: SyntaxError,
+        pos: Pos,
+    ) -> Result<T, ScanError> {
         self.cur = self.start;
         self.cur_pos = self.start_pos;
         Err(ScanError::Syntax(err, pos))
@@ -812,7 +854,10 @@ impl<C: CharSource> Scanner<C> {
         }
     }
 
-    fn cond_read_symbol<F>(&mut self, f: F) -> Result<Option<Symbol>, ScanError>
+    fn cond_read_symbol<F>(
+        &mut self,
+        f: F,
+    ) -> Result<Option<Symbol>, ScanError>
     where
         F: FnOnce(Symbol) -> bool,
     {
@@ -864,7 +909,8 @@ impl<C: CharSource> Scanner<C> {
                     None => break,
                     Some(Token::Symbol(Symbol::Char('('))) => {
                         let pos = self.cur_pos.prev();
-                        return self.err_at(SyntaxError::NestedParentheses, pos);
+                        return self
+                            .err_at(SyntaxError::NestedParentheses, pos);
                     }
                     Some(Token::Symbol(Symbol::Char(')'))) => {
                         self.paren = false;
@@ -886,7 +932,10 @@ impl<C: CharSource> Scanner<C> {
                     }
                     Some(Token::Symbol(Symbol::Char(')'))) => {
                         let pos = self.cur_pos.prev();
-                        return self.err_at(SyntaxError::Unexpected(')'.into()), pos);
+                        return self.err_at(
+                            SyntaxError::Unexpected(')'.into()),
+                            pos,
+                        );
                     }
                     _ => {}
                 }
@@ -903,12 +952,16 @@ impl<C: CharSource> Scanner<C> {
 #[cfg(feature = "bytes")]
 pub trait Scan: Sized {
     /// Scans a value from a master file.
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError>;
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError>;
 }
 
 #[cfg(feature = "bytes")]
 impl Scan for u32 {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         scanner.scan_phrase(
             0u32,
             |res, symbol| {
@@ -939,7 +992,9 @@ impl Scan for u32 {
 
 #[cfg(feature = "bytes")]
 impl Scan for u16 {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         scanner.scan_phrase(
             0u16,
             |res, symbol| {
@@ -970,7 +1025,9 @@ impl Scan for u16 {
 
 #[cfg(feature = "bytes")]
 impl Scan for u8 {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         scanner.scan_phrase(
             0u8,
             |res, symbol| {
@@ -1022,7 +1079,9 @@ impl Token {
     /// which need special treatment.
     fn is_non_paren_space(self) -> bool {
         match self {
-            Token::Symbol(Symbol::Char(ch)) => ch == ' ' || ch == '\t' || ch == '(' || ch == ')',
+            Token::Symbol(Symbol::Char(ch)) => {
+                ch == ' ' || ch == '\t' || ch == '(' || ch == ')'
+            }
             _ => false,
         }
     }
@@ -1208,27 +1267,55 @@ impl fmt::Display for SyntaxError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             SyntaxError::Expected(ref s) => write!(f, "expected '{}'", s),
-            SyntaxError::ExpectedNewline => f.write_str("expected a new line"),
+            SyntaxError::ExpectedNewline => {
+                f.write_str("expected a new line")
+            }
             SyntaxError::ExpectedSpace => f.write_str("expected white space"),
-            SyntaxError::IllegalEscape => f.write_str("invalid escape sequence"),
+            SyntaxError::IllegalEscape => {
+                f.write_str("invalid escape sequence")
+            }
             SyntaxError::IllegalInteger => f.write_str("illegal integer"),
-            SyntaxError::IllegalAddr(ref err) => write!(f, "illegal address: {}", err),
-            SyntaxError::IllegalName(ref err) => write!(f, "illegal domain name: {}", err),
-            SyntaxError::LongCharStr => f.write_str("character string too long"),
+            SyntaxError::IllegalAddr(ref err) => {
+                write!(f, "illegal address: {}", err)
+            }
+            SyntaxError::IllegalName(ref err) => {
+                write!(f, "illegal domain name: {}", err)
+            }
+            SyntaxError::LongCharStr => {
+                f.write_str("character string too long")
+            }
             SyntaxError::UnevenHexString => {
                 f.write_str("hex string with an odd number of characters")
             }
-            SyntaxError::LongGenericData => f.write_str("more data given than in the length byte"),
-            SyntaxError::NestedParentheses => f.write_str("nested parentheses"),
-            SyntaxError::NoDefaultTtl => f.write_str("omitted TTL but no default TTL given"),
-            SyntaxError::NoLastClass => f.write_str("omitted class but no previous class given"),
-            SyntaxError::NoLastOwner => f.write_str("omitted owner but no previous owner given"),
-            SyntaxError::NoOrigin => f.write_str("owner @ without preceding $ORIGIN"),
+            SyntaxError::LongGenericData => {
+                f.write_str("more data given than in the length byte")
+            }
+            SyntaxError::NestedParentheses => {
+                f.write_str("nested parentheses")
+            }
+            SyntaxError::NoDefaultTtl => {
+                f.write_str("omitted TTL but no default TTL given")
+            }
+            SyntaxError::NoLastClass => {
+                f.write_str("omitted class but no previous class given")
+            }
+            SyntaxError::NoLastOwner => {
+                f.write_str("omitted owner but no previous owner given")
+            }
+            SyntaxError::NoOrigin => {
+                f.write_str("owner @ without preceding $ORIGIN")
+            }
             SyntaxError::RelativeName => f.write_str("relative domain name"),
             SyntaxError::Unexpected(sym) => write!(f, "unexpected '{}'", sym),
-            SyntaxError::UnexpectedNewline => f.write_str("unexpected newline"),
-            SyntaxError::UnexpectedEof => f.write_str("unexpected end of file"),
-            SyntaxError::UnknownMnemonic => f.write_str("unexpected mnemomic"),
+            SyntaxError::UnexpectedNewline => {
+                f.write_str("unexpected newline")
+            }
+            SyntaxError::UnexpectedEof => {
+                f.write_str("unexpected end of file")
+            }
+            SyntaxError::UnknownMnemonic => {
+                f.write_str("unexpected mnemomic")
+            }
             SyntaxError::Content(ref content) => content.fmt(f),
         }
     }

--- a/src/master/source.rs
+++ b/src/master/source.rs
@@ -3,14 +3,13 @@
 //! This is here so we can read from things that aren’t ASCII or UTF-8.
 #![cfg(feature = "std")]
 
-use std::{char, error, fmt, io};
+use super::scan::CharSource;
 use std::boxed::Box;
-use std::io::Read;
 use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 use std::vec::Vec;
-use super::scan::CharSource;
-
+use std::{char, error, fmt, io};
 
 //------------ str -----------------------------------------------------------
 
@@ -24,7 +23,6 @@ impl<'a> CharSource for &'a str {
         Ok(Some(res))
     }
 }
-
 
 //------------ AsciiFile -----------------------------------------------------
 
@@ -45,7 +43,7 @@ impl AsciiFile {
                 let mut buffer = Vec::with_capacity(CAP);
                 buffer.set_len(CAP);
                 Some((buffer.into_boxed_slice(), 0, 0))
-            }
+            },
         }
     }
 
@@ -57,19 +55,15 @@ impl AsciiFile {
 
 impl CharSource for AsciiFile {
     fn next(&mut self) -> Result<Option<char>, io::Error> {
-        let err = if let Some((ref mut buf, ref mut len, ref mut pos))
-                                = self.buf {
+        let err = if let Some((ref mut buf, ref mut len, ref mut pos)) = self.buf {
             if *pos < *len {
                 let res = buf[*pos];
                 if res.is_ascii() {
                     *pos += 1;
-                    return Ok(Some(res as char))
+                    return Ok(Some(res as char));
                 }
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData, AsciiError(res)
-                ))
-            }
-            else {
+                Err(io::Error::new(io::ErrorKind::InvalidData, AsciiError(res)))
+            } else {
                 match self.file.read(buf) {
                     Ok(0) => Ok(None),
                     Ok(read_len) => {
@@ -77,24 +71,20 @@ impl CharSource for AsciiFile {
                         let res = buf[0];
                         if res.is_ascii() {
                             *pos = 1;
-                            return Ok(Some(res as char))
+                            return Ok(Some(res as char));
                         }
-                        Err(io::Error::new(
-                            io::ErrorKind::InvalidData, AsciiError(res)
-                        ))
+                        Err(io::Error::new(io::ErrorKind::InvalidData, AsciiError(res)))
                     }
-                    Err(err) => Err(err)
+                    Err(err) => Err(err),
                 }
             }
-        }
-        else {
+        } else {
             return Ok(None);
         };
         self.buf = None;
         err
     }
 }
-
 
 //------------ Utf8File ------------------------------------------------------
 
@@ -116,67 +106,68 @@ impl CharSource for Utf8File {
     fn next(&mut self) -> Result<Option<char>, io::Error> {
         let first = match self.0.next()? {
             Some(ch) => ch,
-            None => return Ok(None)
+            None => return Ok(None),
         };
-        if first.is_ascii() { //first < 0x80  {
-            return Ok(Some(first as char))
+        if first.is_ascii() {
+            //first < 0x80  {
+            return Ok(Some(first as char));
         }
         let second = match self.0.next()? {
             Some(ch) => ch,
             None => {
                 return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof, "unexpected EOF"
+                    io::ErrorKind::UnexpectedEof,
+                    "unexpected EOF",
                 ))
             }
         };
         if first < 0xC0 || second < 0x80 {
-            return Err(Utf8Error.into())
+            return Err(Utf8Error.into());
         }
         if first < 0xE0 {
             return Ok(Some(unsafe {
-                char::from_u32_unchecked(
-                    (u32::from(first & 0x1F)) << 6 |
-                    u32::from(second & 0x3F)
-                )
-            }))
+                char::from_u32_unchecked((u32::from(first & 0x1F)) << 6 | u32::from(second & 0x3F))
+            }));
         }
         let third = match self.0.next()? {
             Some(ch) => ch,
             None => {
                 return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof, "unexpected EOF"
+                    io::ErrorKind::UnexpectedEof,
+                    "unexpected EOF",
                 ))
             }
         };
         if third < 0x80 {
-            return Err(Utf8Error.into())
+            return Err(Utf8Error.into());
         }
         if first < 0xF0 {
             return Ok(Some(unsafe {
                 char::from_u32_unchecked(
-                    (u32::from(first & 0x0F)) << 12 |
-                    (u32::from(second & 0x3F)) << 6 |
-                    u32::from(third & 0x3F)
+                    (u32::from(first & 0x0F)) << 12
+                        | (u32::from(second & 0x3F)) << 6
+                        | u32::from(third & 0x3F),
                 )
-            }))
+            }));
         }
         let fourth = match self.0.next()? {
             Some(ch) => ch,
             None => {
                 return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof, "unexpected EOF"
+                    io::ErrorKind::UnexpectedEof,
+                    "unexpected EOF",
                 ))
             }
         };
         if first > 0xF7 || fourth < 0x80 {
-            return Err(Utf8Error.into())
+            return Err(Utf8Error.into());
         }
         Ok(Some(unsafe {
             char::from_u32_unchecked(
-                (u32::from(first & 0x07)) << 18 |
-                (u32::from(second & 0x3F)) << 12 |
-                (u32::from(third & 0x3F)) << 6 |
-                u32::from(fourth & 0x3F)
+                (u32::from(first & 0x07)) << 18
+                    | (u32::from(second & 0x3F)) << 12
+                    | (u32::from(third & 0x3F)) << 6
+                    | u32::from(fourth & 0x3F),
             )
         }))
     }
@@ -187,7 +178,6 @@ impl From<Utf8Error> for io::Error {
         io::Error::new(io::ErrorKind::Other, err)
     }
 }
-
 
 //------------ OctetFile -----------------------------------------------------
 
@@ -208,7 +198,7 @@ impl OctetFile {
                 let mut buffer = Vec::with_capacity(CAP);
                 buffer.set_len(CAP);
                 Some((buffer.into_boxed_slice(), 0, 0))
-            }
+            },
         }
     }
 
@@ -219,14 +209,12 @@ impl OctetFile {
 
     #[inline]
     fn next(&mut self) -> Result<Option<u8>, io::Error> {
-        let err = if let Some((ref mut buf, ref mut len, ref mut pos))
-                                = self.buf {
+        let err = if let Some((ref mut buf, ref mut len, ref mut pos)) = self.buf {
             if *pos < *len {
                 let res = buf[*pos];
                 *pos += 1;
-                return Ok(Some(res))
-            }
-            else {
+                return Ok(Some(res));
+            } else {
                 match self.file.read(buf) {
                     Ok(0) => Ok(None),
                     Ok(read_len) => {
@@ -234,17 +222,14 @@ impl OctetFile {
                         let res = buf[0];
                         if res.is_ascii() {
                             *pos = 1;
-                            return Ok(Some(res))
+                            return Ok(Some(res));
                         }
-                        Err(io::Error::new(
-                            io::ErrorKind::InvalidData, AsciiError(res)
-                        ))
+                        Err(io::Error::new(io::ErrorKind::InvalidData, AsciiError(res)))
                     }
-                    Err(err) => Err(err)
+                    Err(err) => Err(err),
                 }
             }
-        }
-        else {
+        } else {
             return Ok(None);
         };
         self.buf = None;
@@ -252,16 +237,13 @@ impl OctetFile {
     }
 }
 
-
 //=========== Error Types ===================================================
-
 
 //------------ AsciiError ----------------------------------------------------
 
 /// An error happened while reading an ASCII-only file.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AsciiError(u8);
-
 
 //--- Display and Error
 
@@ -271,15 +253,13 @@ impl fmt::Display for AsciiError {
     }
 }
 
-impl error::Error for AsciiError { }
-
+impl error::Error for AsciiError {}
 
 //------------ Utf8Error -----------------------------------------------------
 
 /// An error happened while reading a file encoded with UTF-8.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Utf8Error;
-
 
 //--- Display and Error
 
@@ -289,5 +269,4 @@ impl fmt::Display for Utf8Error {
     }
 }
 
-impl error::Error for Utf8Error { }
-
+impl error::Error for Utf8Error {}

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -33,7 +33,7 @@ macro_rules! rdata_types {
 
         /// Record data for all record types allowed in master files.
         ///
-        /// This enum collects the record data types for all currently 
+        /// This enum collects the record data types for all currently
         /// implemented record types that are allowed to be included in master
         /// files.
         #[derive(Clone)]
@@ -212,7 +212,7 @@ macro_rules! rdata_types {
         }
 
         //--- Hash
- 
+
         impl<O, N> core::hash::Hash for MasterRecordData<O, N>
         where O: AsRef<[u8]>, N: core::hash::Hash {
             fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
@@ -400,7 +400,7 @@ macro_rules! rdata_types {
 
         /// Record data for all record types.
         ///
-        /// This enum collects the record data types for all currently 
+        /// This enum collects the record data types for all currently
         /// implemented record types.
         #[derive(Clone)]
         #[non_exhaustive]
@@ -715,7 +715,7 @@ macro_rules! rdata_types {
             }
         }
 
-        
+
         //--- Display and Debug
 
         impl<O, N> core::fmt::Display for AllRecordData<O, N>
@@ -791,7 +791,6 @@ macro_rules! rdata_types {
 
     }
 }
-
 
 //------------ dname_type! --------------------------------------------------
 

--- a/src/rdata/mod.rs
+++ b/src/rdata/mod.rs
@@ -32,8 +32,8 @@ pub mod rfc2782;
 pub mod rfc2845;
 pub mod rfc3596;
 pub mod rfc4034;
-pub mod rfc6672;
 pub mod rfc5155;
+pub mod rfc6672;
 pub mod rfc7344;
 
 // The rdata_types! macro (defined in self::macros) reexports the record data
@@ -114,4 +114,3 @@ rdata_types! {
         }
     }
 }
-

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -10,14 +10,16 @@ use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::net::Ipv4Addr;
 use crate::base::octets::{
-    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError,
-    Parser, ShortBuf,
+    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef,
+    Parse, ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 use crate::base::serial::Serial;
 use crate::base::str::Symbol;
 #[cfg(feature = "master")]
-use crate::master::scan::{CharSource, Scan, ScanError, Scanner, SyntaxError};
+use crate::master::scan::{
+    CharSource, Scan, ScanError, Scanner, SyntaxError,
+};
 #[cfg(feature = "master")]
 use bytes::Bytes;
 #[cfg(feature = "bytes")]
@@ -111,7 +113,10 @@ impl<Octets: AsRef<[u8]>> Parse<Octets> for A {
 }
 
 impl Compose for A {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         self.addr.compose(target)
     }
 }
@@ -120,8 +125,11 @@ impl Compose for A {
 
 #[cfg(feature = "master")]
 impl Scan for A {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
-        scanner.scan_string_phrase(|res| A::from_str(&res).map_err(Into::into))
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
+        scanner
+            .scan_string_phrase(|res| A::from_str(&res).map_err(Into::into))
     }
 }
 
@@ -302,7 +310,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Hinfo<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Hinfo<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.cpu.compose(target)?;
             self.os.compose(target)
@@ -314,7 +325,9 @@ impl<Octets: AsRef<[u8]>> Compose for Hinfo<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Hinfo<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(CharStr::scan(scanner)?, CharStr::scan(scanner)?))
     }
 }
@@ -462,7 +475,8 @@ where
     NN: ToDname,
 {
     fn eq(&self, other: &Minfo<NN>) -> bool {
-        self.rmailbx.name_eq(&other.rmailbx) && self.emailbx.name_eq(&other.emailbx)
+        self.rmailbx.name_eq(&other.rmailbx)
+            && self.emailbx.name_eq(&other.emailbx)
     }
 }
 
@@ -522,14 +536,20 @@ impl<Ref: OctetsRef> Parse<Ref> for Minfo<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Minfo<N> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             target.append_compressed_dname(&self.rmailbx)?;
             target.append_compressed_dname(&self.emailbx)
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.rmailbx.compose_canonical(target)?;
             self.emailbx.compose_canonical(target)
@@ -541,7 +561,9 @@ impl<N: ToDname> Compose for Minfo<N> {
 
 #[cfg(feature = "master")]
 impl<N: Scan> Scan for Minfo<N> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(N::scan(scanner)?, N::scan(scanner)?))
     }
 }
@@ -631,7 +653,8 @@ where
     NN: ToDname,
 {
     fn eq(&self, other: &Mx<NN>) -> bool {
-        self.preference == other.preference && self.exchange.name_eq(&other.exchange)
+        self.preference == other.preference
+            && self.exchange.name_eq(&other.exchange)
     }
 }
 
@@ -687,14 +710,20 @@ impl<Ref: OctetsRef> Parse<Ref> for Mx<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Mx<N> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.preference.compose(target)?;
             target.append_compressed_dname(&self.exchange)
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.preference.compose(target)?;
             self.exchange.compose_canonical(target)
@@ -706,7 +735,9 @@ impl<N: ToDname> Compose for Mx<N> {
 
 #[cfg(feature = "master")]
 impl<N: Scan> Scan for Mx<N> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(u16::scan(scanner)?, N::scan(scanner)?))
     }
 }
@@ -853,7 +884,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Null<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Null<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(self.data.as_ref())
     }
 }
@@ -1160,7 +1194,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Soa<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Soa<N> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             buf.append_compressed_dname(&self.mname)?;
             buf.append_compressed_dname(&self.rname)?;
@@ -1172,7 +1209,10 @@ impl<N: ToDname> Compose for Soa<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.mname.compose_canonical(buf)?;
             self.rname.compose_canonical(buf)?;
@@ -1189,7 +1229,9 @@ impl<N: ToDname> Compose for Soa<N> {
 
 #[cfg(feature = "master")]
 impl<N: Scan> Scan for Soa<N> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             N::scan(scanner)?,
             N::scan(scanner)?,
@@ -1402,7 +1444,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Txt<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Txt<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(self.0.as_ref())
     }
 }
@@ -1411,7 +1456,9 @@ impl<Octets: AsRef<[u8]>> Compose for Txt<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Txt<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         scanner.scan_byte_phrase(|res| {
             let mut builder = TxtBuilder::new_bytes();
             if builder.append_slice(res.as_ref()).is_err() {
@@ -1553,7 +1600,8 @@ mod test {
     fn hinfo_octets_into() {
         use crate::octets::OctetsInto;
 
-        let hinfo: Hinfo<Vec<u8>> = Hinfo::new("1234".parse().unwrap(), "abcd".parse().unwrap());
+        let hinfo: Hinfo<Vec<u8>> =
+            Hinfo::new("1234".parse().unwrap(), "abcd".parse().unwrap());
         let hinfo_bytes: Hinfo<bytes::Bytes> = hinfo.octets_into().unwrap();
         assert_eq!(hinfo.cpu(), hinfo_bytes.cpu());
         assert_eq!(hinfo.os(), hinfo_bytes.os());
@@ -1565,9 +1613,12 @@ mod test {
         use crate::base::Dname;
         use crate::octets::OctetsInto;
 
-        let minfo: Minfo<Dname<Vec<u8>>> =
-            Minfo::new("a.example".parse().unwrap(), "b.example".parse().unwrap());
-        let minfo_bytes: Minfo<Dname<bytes::Bytes>> = minfo.octets_into().unwrap();
+        let minfo: Minfo<Dname<Vec<u8>>> = Minfo::new(
+            "a.example".parse().unwrap(),
+            "b.example".parse().unwrap(),
+        );
+        let minfo_bytes: Minfo<Dname<bytes::Bytes>> =
+            minfo.octets_into().unwrap();
         assert_eq!(minfo.rmailbx(), minfo_bytes.rmailbx());
         assert_eq!(minfo.emailbx(), minfo_bytes.emailbx());
     }

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -4,26 +4,27 @@
 //!
 //! [RFC 1035]: https://tools.ietf.org/html/rfc1035
 
-use core::{hash, fmt, ops};
-use core::cmp::Ordering;
-use core::str::FromStr;
-#[cfg(feature="bytes")] use bytes::BytesMut;
-#[cfg(feature="master")] use bytes::Bytes;
+use crate::base::charstr::CharStr;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
-use crate::base::charstr::CharStr;
-use crate::base::str::Symbol;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::net::Ipv4Addr;
 use crate::base::octets::{
-    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef,
-    Parse, ParseError, Parser, ShortBuf
+    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError,
+    Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 use crate::base::serial::Serial;
-#[cfg(feature="master")] use crate::master::scan::{
-    CharSource, ScanError, Scan, Scanner, SyntaxError
-};
+use crate::base::str::Symbol;
+#[cfg(feature = "master")]
+use crate::master::scan::{CharSource, Scan, ScanError, Scanner, SyntaxError};
+#[cfg(feature = "master")]
+use bytes::Bytes;
+#[cfg(feature = "bytes")]
+use bytes::BytesMut;
+use core::cmp::Ordering;
+use core::str::FromStr;
+use core::{fmt, hash, ops};
 
 //------------ A ------------------------------------------------------------
 
@@ -50,10 +51,13 @@ impl A {
         A::new(Ipv4Addr::new(a, b, c, d))
     }
 
-    pub fn addr(&self) -> Ipv4Addr { self.addr }
-    pub fn set_addr(&mut self, addr: Ipv4Addr) { self.addr = addr }
+    pub fn addr(&self) -> Ipv4Addr {
+        self.addr
+    }
+    pub fn set_addr(&mut self, addr: Ipv4Addr) {
+        self.addr = addr
+    }
 }
-
 
 //--- OctetsFrom
 
@@ -62,7 +66,6 @@ impl OctetsFrom<A> for A {
         Ok(source)
     }
 }
-
 
 //--- From and FromStr
 
@@ -87,7 +90,6 @@ impl FromStr for A {
     }
 }
 
-
 //--- CanonicalOrd
 
 impl CanonicalOrd for A {
@@ -95,7 +97,6 @@ impl CanonicalOrd for A {
         self.cmp(other)
     }
 }
-
 
 //--- Parse and Compose
 
@@ -110,21 +111,16 @@ impl<Octets: AsRef<[u8]>> Parse<Octets> for A {
 }
 
 impl Compose for A {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         self.addr.compose(target)
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")] 
+#[cfg(feature = "master")]
 impl Scan for A {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>)
-                           -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         scanner.scan_string_phrase(|res| A::from_str(&res).map_err(Into::into))
     }
 }
@@ -135,13 +131,11 @@ impl fmt::Display for A {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl RtypeRecordData for A {
     const RTYPE: Rtype = Rtype::A;
 }
-
 
 //--- Deref and DerefMut
 
@@ -159,7 +153,6 @@ impl ops::DerefMut for A {
     }
 }
 
-
 //--- AsRef and AsMut
 
 impl AsRef<Ipv4Addr> for A {
@@ -174,7 +167,6 @@ impl AsMut<Ipv4Addr> for A {
     }
 }
 
-
 //------------ Cname --------------------------------------------------------
 
 dname_type! {
@@ -186,7 +178,6 @@ dname_type! {
     /// The CNAME type is defined in RFC 1035, section 3.3.1.
     (Cname, Cname, cname)
 }
-
 
 //------------ Hinfo --------------------------------------------------------
 
@@ -219,51 +210,59 @@ impl<Octets> Hinfo<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Hinfo<SrcOctets>> for Hinfo<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Hinfo<SrcOctets>) -> Result<Self, ShortBuf> {
         Ok(Hinfo::new(
             CharStr::octets_from(source.cpu)?,
-            CharStr::octets_from(source.os)?
+            CharStr::octets_from(source.os)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<Octets, Other> PartialEq<Hinfo<Other>> for Hinfo<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Hinfo<Other>) -> bool {
         self.cpu.eq(&other.cpu) && self.os.eq(&other.os)
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Hinfo<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Hinfo<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<Octets, Other> PartialOrd<Hinfo<Other>> for Hinfo<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Hinfo<Other>) -> Option<Ordering> {
         match self.cpu.partial_cmp(&other.cpu) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         self.os.partial_cmp(&other.os)
     }
 }
 
 impl<Octets, Other> CanonicalOrd<Hinfo<Other>> for Hinfo<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Hinfo<Other>) -> Ordering {
         match self.cpu.canonical_cmp(&other.cpu) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.os.canonical_cmp(&other.os)
     }
@@ -272,13 +271,12 @@ where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
 impl<Octets: AsRef<[u8]>> Ord for Hinfo<Octets> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.cpu.cmp(&other.cpu) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.os.cmp(&other.os)
     }
 }
-
 
 //--- Hash
 
@@ -288,7 +286,6 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Hinfo<Octets> {
         self.os.hash(state);
     }
 }
-
 
 //--- Parse and Compose
 
@@ -305,10 +302,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Hinfo<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Hinfo<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.cpu.compose(target)?;
             self.os.compose(target)
@@ -316,13 +310,11 @@ impl<Octets: AsRef<[u8]>> Compose for Hinfo<Octets> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")] 
+#[cfg(feature = "master")]
 impl Scan for Hinfo<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>)
-                           -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(CharStr::scan(scanner)?, CharStr::scan(scanner)?))
     }
 }
@@ -332,7 +324,6 @@ impl<Octets: AsRef<[u8]>> fmt::Display for Hinfo<Octets> {
         write!(f, "{} {}", self.cpu, self.os)
     }
 }
-
 
 //--- Debug
 
@@ -345,13 +336,11 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Hinfo<Octets> {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<Octets> RtypeRecordData for Hinfo<Octets> {
     const RTYPE: Rtype = Rtype::Hinfo;
 }
-
 
 //------------ Mb -----------------------------------------------------------
 
@@ -364,7 +353,6 @@ dname_type! {
     (Mb, Mb, madname)
 }
 
-
 //------------ Md -----------------------------------------------------------
 
 dname_type! {
@@ -372,14 +360,13 @@ dname_type! {
     ///
     /// The MD record specifices a host which has a mail agent for
     /// the domain which should be able to deliver mail for the domain.
-    /// 
+    ///
     /// The MD record is obsolete. It is recommended to either reject the record
     /// or convert them into an Mx record at preference 0.
     ///
     /// The MD record type is defined in RFC 1035, section 3.3.4.
     (Md, Md, madname)
 }
-
 
 //------------ Mf -----------------------------------------------------------
 
@@ -388,14 +375,13 @@ dname_type! {
     ///
     /// The MF record specifices a host which has a mail agent for
     /// the domain which will be accept mail for forwarding to the domain.
-    /// 
+    ///
     /// The MF record is obsolete. It is recommended to either reject the record
     /// or convert them into an Mx record at preference 10.
     ///
     /// The MF record type is defined in RFC 1035, section 3.3.5.
     (Mf, Mf, madname)
 }
-
 
 //------------ Mg -----------------------------------------------------------
 
@@ -404,13 +390,12 @@ dname_type! {
     ///
     /// The MG record specifices a mailbox which is a member of the mail group
     /// specified by the domain name.
-    /// 
+    ///
     /// The MG record is experimental.
     ///
     /// The MG record type is defined in RFC 1035, section 3.3.6.
     (Mg, Mg, madname)
 }
-
 
 //------------ Minfo --------------------------------------------------------
 
@@ -455,41 +440,45 @@ impl<N> Minfo<N> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Name, SrcName> OctetsFrom<Minfo<SrcName>> for Minfo<Name>
-where Name: OctetsFrom<SrcName> {
+where
+    Name: OctetsFrom<SrcName>,
+{
     fn octets_from(source: Minfo<SrcName>) -> Result<Self, ShortBuf> {
         Ok(Minfo::new(
             Name::octets_from(source.rmailbx)?,
-            Name::octets_from(source.emailbx)?
+            Name::octets_from(source.emailbx)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<N, NN> PartialEq<Minfo<NN>> for Minfo<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn eq(&self, other: &Minfo<NN>) -> bool {
-        self.rmailbx.name_eq(&other.rmailbx)
-        && self.emailbx.name_eq(&other.emailbx)
+        self.rmailbx.name_eq(&other.rmailbx) && self.emailbx.name_eq(&other.emailbx)
     }
 }
 
-impl<N: ToDname> Eq for Minfo<N> { }
-
+impl<N: ToDname> Eq for Minfo<N> {}
 
 //--- PartialOrd, Ord, and CanonicalOrd
 
 impl<N, NN> PartialOrd<Minfo<NN>> for Minfo<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn partial_cmp(&self, other: &Minfo<NN>) -> Option<Ordering> {
         match self.rmailbx.name_cmp(&other.rmailbx) {
-            Ordering::Equal => { }
-            other => return Some(other)
+            Ordering::Equal => {}
+            other => return Some(other),
         }
         Some(self.emailbx.name_cmp(&other.emailbx))
     }
@@ -498,8 +487,8 @@ where N: ToDname, NN: ToDname {
 impl<N: ToDname> Ord for Minfo<N> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.rmailbx.name_cmp(&other.rmailbx) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.emailbx.name_cmp(&other.emailbx)
     }
@@ -508,13 +497,12 @@ impl<N: ToDname> Ord for Minfo<N> {
 impl<N: ToDname, NN: ToDname> CanonicalOrd<Minfo<NN>> for Minfo<N> {
     fn canonical_cmp(&self, other: &Minfo<NN>) -> Ordering {
         match self.rmailbx.lowercase_composed_cmp(&other.rmailbx) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.emailbx.lowercase_composed_cmp(&other.emailbx)
     }
 }
-
 
 //--- Parse and Compose
 
@@ -522,7 +510,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Minfo<ParsedDname<Ref>> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         Ok(Self::new(
             ParsedDname::parse(parser)?,
-            ParsedDname::parse(parser)?
+            ParsedDname::parse(parser)?,
         ))
     }
 
@@ -534,20 +522,14 @@ impl<Ref: OctetsRef> Parse<Ref> for Minfo<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Minfo<N> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             target.append_compressed_dname(&self.rmailbx)?;
             target.append_compressed_dname(&self.emailbx)
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.rmailbx.compose_canonical(target)?;
             self.emailbx.compose_canonical(target)
@@ -555,13 +537,11 @@ impl<N: ToDname> Compose for Minfo<N> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")] 
+#[cfg(feature = "master")]
 impl<N: Scan> Scan for Minfo<N> {
-    fn scan<C: CharSource>(scanner: &mut  Scanner<C>)
-                           -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(N::scan(scanner)?, N::scan(scanner)?))
     }
 }
@@ -572,13 +552,11 @@ impl<N: fmt::Display> fmt::Display for Minfo<N> {
     }
 }
 
-
 //--- RecordData
 
 impl<N> RtypeRecordData for Minfo<N> {
     const RTYPE: Rtype = Rtype::Minfo;
 }
-
 
 //------------ Mr -----------------------------------------------------------
 
@@ -587,13 +565,12 @@ dname_type! {
     ///
     /// The MR record specifices a mailbox which is the proper rename of the
     /// specified mailbox.
-    /// 
+    ///
     /// The MR record is experimental.
     ///
     /// The MR record type is defined in RFC 1035, section 3.3.8.
     (Mr, Mr, newname)
 }
-
 
 //------------ Mx -----------------------------------------------------------
 
@@ -612,7 +589,10 @@ pub struct Mx<N> {
 impl<N> Mx<N> {
     /// Creates a new Mx record data from the components.
     pub fn new(preference: u16, exchange: N) -> Self {
-        Mx { preference, exchange }
+        Mx {
+            preference,
+            exchange,
+        }
     }
 
     /// The preference for this record.
@@ -629,41 +609,45 @@ impl<N> Mx<N> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Name, SrcName> OctetsFrom<Mx<SrcName>> for Mx<Name>
-where Name: OctetsFrom<SrcName> {
+where
+    Name: OctetsFrom<SrcName>,
+{
     fn octets_from(source: Mx<SrcName>) -> Result<Self, ShortBuf> {
         Ok(Mx::new(
             source.preference,
-            Name::octets_from(source.exchange)?
+            Name::octets_from(source.exchange)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<N, NN> PartialEq<Mx<NN>> for Mx<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn eq(&self, other: &Mx<NN>) -> bool {
-        self.preference == other.preference
-        && self.exchange.name_eq(&other.exchange)
+        self.preference == other.preference && self.exchange.name_eq(&other.exchange)
     }
 }
 
-impl<N: ToDname> Eq for Mx<N> { }
-
+impl<N: ToDname> Eq for Mx<N> {}
 
 //--- PartialOrd, Ord, and CanonicalOrd
 
 impl<N, NN> PartialOrd<Mx<NN>> for Mx<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn partial_cmp(&self, other: &Mx<NN>) -> Option<Ordering> {
         match self.preference.partial_cmp(&other.preference) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         Some(self.exchange.name_cmp(&other.exchange))
     }
@@ -672,8 +656,8 @@ where N: ToDname, NN: ToDname {
 impl<N: ToDname> Ord for Mx<N> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.preference.cmp(&other.preference) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.exchange.name_cmp(&other.exchange)
     }
@@ -682,13 +666,12 @@ impl<N: ToDname> Ord for Mx<N> {
 impl<N: ToDname, NN: ToDname> CanonicalOrd<Mx<NN>> for Mx<N> {
     fn canonical_cmp(&self, other: &Mx<NN>) -> Ordering {
         match self.preference.cmp(&other.preference) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.exchange.lowercase_composed_cmp(&other.exchange)
     }
 }
-
 
 //--- Parse and Compose
 
@@ -704,20 +687,14 @@ impl<Ref: OctetsRef> Parse<Ref> for Mx<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Mx<N> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.preference.compose(target)?;
             target.append_compressed_dname(&self.exchange)
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.preference.compose(target)?;
             self.exchange.compose_canonical(target)
@@ -725,13 +702,11 @@ impl<N: ToDname> Compose for Mx<N> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")] 
+#[cfg(feature = "master")]
 impl<N: Scan> Scan for Mx<N> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>)
-                           -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(u16::scan(scanner)?, N::scan(scanner)?))
     }
 }
@@ -742,13 +717,11 @@ impl<N: fmt::Display> fmt::Display for Mx<N> {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<N> RtypeRecordData for Mx<N> {
     const RTYPE: Rtype = Rtype::Mx;
 }
-
 
 //------------ Ns -----------------------------------------------------------
 
@@ -760,7 +733,6 @@ dname_type! {
     /// The NS record type is defined in RFC 1035, section 3.3.11.
     (Ns, Ns, nsdname)
 }
-
 
 //------------ Null ---------------------------------------------------------
 
@@ -797,7 +769,6 @@ impl<Octets: AsRef<[u8]>> Null<Octets> {
     }
 }
 
-
 //--- From
 
 impl<Octets> From<Octets> for Null<Octets> {
@@ -806,42 +777,48 @@ impl<Octets> From<Octets> for Null<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Null<SrcOctets>> for Null<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Null<SrcOctets>) -> Result<Self, ShortBuf> {
-        Octets::octets_from(source.data).map(|octets| {
-            Self::new(octets)
-        })
+        Octets::octets_from(source.data).map(|octets| Self::new(octets))
     }
 }
-
 
 //--- PartialEq and Eq
 
 impl<Octets, Other> PartialEq<Null<Other>> for Null<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Null<Other>) -> bool {
         self.data.as_ref().eq(other.data.as_ref())
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Null<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Null<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<Octets, Other> PartialOrd<Null<Other>> for Null<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Null<Other>) -> Option<Ordering> {
         self.data.as_ref().partial_cmp(other.data.as_ref())
     }
 }
 
 impl<Octets, Other> CanonicalOrd<Null<Other>> for Null<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Null<Other>) -> Ordering {
         self.data.as_ref().cmp(other.data.as_ref())
     }
@@ -853,7 +830,6 @@ impl<Octets: AsRef<[u8]>> Ord for Null<Octets> {
     }
 }
 
-
 //--- Hash
 
 impl<Octets: AsRef<[u8]>> hash::Hash for Null<Octets> {
@@ -861,7 +837,6 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Null<Octets> {
         self.data.as_ref().hash(state)
     }
 }
-
 
 //--- ParseAll and Compose
 
@@ -878,21 +853,16 @@ impl<Ref: OctetsRef> Parse<Ref> for Null<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Null<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(self.data.as_ref())
     }
 }
-
 
 //--- RtypeRecordData
 
 impl<Octets> RtypeRecordData for Null<Octets> {
     const RTYPE: Rtype = Rtype::Null;
 }
-
 
 //--- Deref
 
@@ -904,7 +874,6 @@ impl<Octets> ops::Deref for Null<Octets> {
     }
 }
 
-
 //--- AsRef
 
 impl<Octets: AsRef<Other>, Other> AsRef<Other> for Null<Octets> {
@@ -912,7 +881,6 @@ impl<Octets: AsRef<Other>, Other> AsRef<Other> for Null<Octets> {
         self.data.as_ref()
     }
 }
-
 
 //--- Display and Debug
 
@@ -934,7 +902,6 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Null<Octets> {
     }
 }
 
-
 //------------ Ptr ----------------------------------------------------------
 
 dname_type! {
@@ -953,7 +920,6 @@ impl<N> Ptr<N> {
     }
 }
 
-
 //------------ Soa ----------------------------------------------------------
 
 /// Soa record data.
@@ -970,14 +936,29 @@ pub struct Soa<N> {
     refresh: u32,
     retry: u32,
     expire: u32,
-    minimum:u32 
+    minimum: u32,
 }
 
 impl<N> Soa<N> {
     /// Creates new Soa record data from content.
-    pub fn new(mname: N, rname: N, serial: Serial,
-               refresh: u32, retry: u32, expire: u32, minimum: u32) -> Self {
-        Soa { mname, rname, serial, refresh, retry, expire, minimum }
+    pub fn new(
+        mname: N,
+        rname: N,
+        serial: Serial,
+        refresh: u32,
+        retry: u32,
+        expire: u32,
+        minimum: u32,
+    ) -> Self {
+        Soa {
+            mname,
+            rname,
+            serial,
+            refresh,
+            retry,
+            expire,
+            minimum,
+        }
     }
 
     /// The primary name server for the zone.
@@ -1016,11 +997,12 @@ impl<N> Soa<N> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Name, SrcName> OctetsFrom<Soa<SrcName>> for Soa<Name>
-where Name: OctetsFrom<SrcName> {
+where
+    Name: OctetsFrom<SrcName>,
+{
     fn octets_from(source: Soa<SrcName>) -> Result<Self, ShortBuf> {
         Ok(Soa::new(
             Name::octets_from(source.mname)?,
@@ -1029,56 +1011,62 @@ where Name: OctetsFrom<SrcName> {
             source.refresh,
             source.retry,
             source.expire,
-            source.minimum
+            source.minimum,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<N, NN> PartialEq<Soa<NN>> for Soa<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn eq(&self, other: &Soa<NN>) -> bool {
         self.mname.name_eq(&other.mname)
-        && self.rname.name_eq(&other.rname)
-        && self.serial == other.serial && self.refresh == other.refresh
-        && self.retry == other.retry && self.expire == other.expire
-        && self.minimum == other.minimum
+            && self.rname.name_eq(&other.rname)
+            && self.serial == other.serial
+            && self.refresh == other.refresh
+            && self.retry == other.retry
+            && self.expire == other.expire
+            && self.minimum == other.minimum
     }
 }
 
-impl<N: ToDname> Eq for Soa<N> { }
-
+impl<N: ToDname> Eq for Soa<N> {}
 
 //--- PartialOrd, Ord, and CanonicalOrd
 
 impl<N, NN> PartialOrd<Soa<NN>> for Soa<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn partial_cmp(&self, other: &Soa<NN>) -> Option<Ordering> {
         match self.mname.name_cmp(&other.mname) {
-            Ordering::Equal => { }
-            other => return Some(other)
+            Ordering::Equal => {}
+            other => return Some(other),
         }
         match self.rname.name_cmp(&other.rname) {
-            Ordering::Equal => { }
-            other => return Some(other)
+            Ordering::Equal => {}
+            other => return Some(other),
         }
         match u32::from(self.serial).partial_cmp(&u32::from(other.serial)) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.refresh.partial_cmp(&other.refresh) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.retry.partial_cmp(&other.retry) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.expire.partial_cmp(&other.expire) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         self.minimum.partial_cmp(&other.minimum)
     }
@@ -1087,28 +1075,28 @@ where N: ToDname, NN: ToDname {
 impl<N: ToDname> Ord for Soa<N> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.mname.name_cmp(&other.mname) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.rname.name_cmp(&other.rname) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match u32::from(self.serial).cmp(&u32::from(other.serial)) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.refresh.cmp(&other.refresh) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.retry.cmp(&other.retry) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.expire.cmp(&other.expire) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.minimum.cmp(&other.minimum)
     }
@@ -1117,33 +1105,32 @@ impl<N: ToDname> Ord for Soa<N> {
 impl<N: ToDname, NN: ToDname> CanonicalOrd<Soa<NN>> for Soa<N> {
     fn canonical_cmp(&self, other: &Soa<NN>) -> Ordering {
         match self.mname.lowercase_composed_cmp(&other.mname) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.rname.lowercase_composed_cmp(&other.rname) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.serial.canonical_cmp(&other.serial) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.refresh.cmp(&other.refresh) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.retry.cmp(&other.retry) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.expire.cmp(&other.expire) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.minimum.cmp(&other.minimum)
     }
 }
-
 
 //--- Parse and Compose
 
@@ -1156,7 +1143,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Soa<ParsedDname<Ref>> {
             u32::parse(parser)?,
             u32::parse(parser)?,
             u32::parse(parser)?,
-            u32::parse(parser)?
+            u32::parse(parser)?,
         ))
     }
 
@@ -1173,10 +1160,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Soa<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Soa<N> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             buf.append_compressed_dname(&self.mname)?;
             buf.append_compressed_dname(&self.rname)?;
@@ -1188,10 +1172,7 @@ impl<N: ToDname> Compose for Soa<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.mname.compose_canonical(buf)?;
             self.rname.compose_canonical(buf)?;
@@ -1204,35 +1185,44 @@ impl<N: ToDname> Compose for Soa<N> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")] 
+#[cfg(feature = "master")]
 impl<N: Scan> Scan for Soa<N> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>)
-                           -> Result<Self, ScanError> {
-        Ok(Self::new(N::scan(scanner)?, N::scan(scanner)?,
-                     Serial::scan(scanner)?, u32::scan(scanner)?,
-                     u32::scan(scanner)?, u32::scan(scanner)?,
-                     u32::scan(scanner)?))
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+        Ok(Self::new(
+            N::scan(scanner)?,
+            N::scan(scanner)?,
+            Serial::scan(scanner)?,
+            u32::scan(scanner)?,
+            u32::scan(scanner)?,
+            u32::scan(scanner)?,
+            u32::scan(scanner)?,
+        ))
     }
 }
 
 impl<N: fmt::Display> fmt::Display for Soa<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}. {}. {} {} {} {} {}",
-               self.mname, self.rname, self.serial, self.refresh, self.retry,
-               self.expire, self.minimum)
+        write!(
+            f,
+            "{}. {}. {} {} {} {} {}",
+            self.mname,
+            self.rname,
+            self.serial,
+            self.refresh,
+            self.retry,
+            self.expire,
+            self.minimum
+        )
     }
 }
-
 
 //--- RecordData
 
 impl<N> RtypeRecordData for Soa<N> {
     const RTYPE: Rtype = Rtype::Soa;
 }
-
 
 //------------ Txt ----------------------------------------------------------
 
@@ -1247,7 +1237,9 @@ pub struct Txt<Octets>(Octets);
 impl<Octets: FromBuilder> Txt<Octets> {
     /// Creates a new Txt record from a single character string.
     pub fn from_slice(text: &[u8]) -> Result<Self, ShortBuf>
-    where <Octets as FromBuilder>::Builder: EmptyBuilder {
+    where
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
         let mut builder = TxtBuilder::<Octets::Builder>::new();
         builder.append_slice(text)?;
         Ok(builder.finish())
@@ -1266,12 +1258,11 @@ impl<Octets: AsRef<[u8]>> Txt<Octets> {
     pub fn as_flat_slice(&self) -> Option<&[u8]> {
         if self.0.as_ref()[0] as usize == self.0.as_ref().len() - 1 {
             Some(&self.0.as_ref()[1..])
-        }
-        else {
+        } else {
             None
         }
     }
-    
+
     pub fn len(&self) -> usize {
         self.0.as_ref().len()
     }
@@ -1289,7 +1280,9 @@ impl<Octets: AsRef<[u8]>> Txt<Octets> {
     ///
     /// Access to the individual character strings is possible via iteration.
     pub fn text<T: FromBuilder>(&self) -> Result<T, ShortBuf>
-    where <T as FromBuilder>::Builder: EmptyBuilder {
+    where
+        <T as FromBuilder>::Builder: EmptyBuilder,
+    {
         // Capacity will be a few bytes too much. Probably better than
         // re-allocating.
         let mut res = T::Builder::with_capacity(self.len());
@@ -1300,16 +1293,16 @@ impl<Octets: AsRef<[u8]>> Txt<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Txt<SrcOctets>> for Txt<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Txt<SrcOctets>) -> Result<Self, ShortBuf> {
         Octets::octets_from(source.0).map(Self)
     }
 }
-
 
 //--- IntoIterator
 
@@ -1325,30 +1318,38 @@ impl<'a, Octets: AsRef<[u8]>> IntoIterator for &'a Txt<Octets> {
 //--- PartialEq and Eq
 
 impl<Octets, Other> PartialEq<Txt<Other>> for Txt<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Txt<Other>) -> bool {
-        self.iter().flat_map(|s| s.iter().copied()).eq(
-            other.iter().flat_map(|s| s.iter().copied())
-        )
+        self.iter()
+            .flat_map(|s| s.iter().copied())
+            .eq(other.iter().flat_map(|s| s.iter().copied()))
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Txt<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Txt<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<Octets, Other> PartialOrd<Txt<Other>> for Txt<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Txt<Other>) -> Option<Ordering> {
-        self.iter().flat_map(|s| s.iter().copied()).partial_cmp(
-            other.iter().flat_map(|s| s.iter().copied())
-        )
+        self.iter()
+            .flat_map(|s| s.iter().copied())
+            .partial_cmp(other.iter().flat_map(|s| s.iter().copied()))
     }
 }
 
 impl<Octets, Other> CanonicalOrd<Txt<Other>> for Txt<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Txt<Other>) -> Ordering {
         // Canonical comparison requires TXT RDATA to be canonically sorted in the wire format.
         // The TXT has each label prefixed by length, which must be taken into account.
@@ -1365,22 +1366,21 @@ where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
 
 impl<Octets: AsRef<[u8]>> Ord for Txt<Octets> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.iter().flat_map(|s| s.iter().copied()).cmp(
-            other.iter().flat_map(|s| s.iter().copied())
-        )
+        self.iter()
+            .flat_map(|s| s.iter().copied())
+            .cmp(other.iter().flat_map(|s| s.iter().copied()))
     }
 }
-
 
 //--- Hash
 
 impl<Octets: AsRef<[u8]>> hash::Hash for Txt<Octets> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.iter().flat_map(|s| s.iter().copied())
+        self.iter()
+            .flat_map(|s| s.iter().copied())
             .for_each(|c| c.hash(state))
     }
 }
-
 
 //--- ParseAll and Compose
 
@@ -1402,28 +1402,21 @@ impl<Ref: OctetsRef> Parse<Ref> for Txt<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Txt<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(self.0.as_ref())
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")] 
+#[cfg(feature = "master")]
 impl Scan for Txt<Bytes> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         scanner.scan_byte_phrase(|res| {
             let mut builder = TxtBuilder::new_bytes();
             if builder.append_slice(res.as_ref()).is_err() {
                 Err(SyntaxError::LongCharStr)
-            }
-            else {
+            } else {
                 Ok(builder.finish())
             }
         })
@@ -1441,7 +1434,6 @@ impl<Octets: AsRef<[u8]>> fmt::Display for Txt<Octets> {
     }
 }
 
-
 //--- Debug
 
 impl<Octets: AsRef<[u8]>> fmt::Debug for Txt<Octets> {
@@ -1452,13 +1444,11 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Txt<Octets> {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<Octets> RtypeRecordData for Txt<Octets> {
     const RTYPE: Rtype = Rtype::Txt;
 }
-
 
 //------------ TxtIter -------------------------------------------------------
 
@@ -1472,13 +1462,11 @@ impl<'a> Iterator for TxtIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.0.remaining() == 0 {
             None
-        }
-        else {
+        } else {
             Some(CharStr::parse(&mut self.0).unwrap().into_octets())
         }
     }
 }
-
 
 //------------ TxtBuilder ---------------------------------------------------
 
@@ -1496,12 +1484,12 @@ impl<Builder: OctetsBuilder + EmptyBuilder> TxtBuilder<Builder> {
     pub fn new() -> Self {
         TxtBuilder {
             builder: Builder::empty(),
-            start: None
+            start: None,
         }
     }
 }
 
-#[cfg(feature="bytes")] 
+#[cfg(feature = "bytes")]
 impl TxtBuilder<BytesMut> {
     pub fn new_bytes() -> Self {
         Self::new()
@@ -1514,7 +1502,7 @@ impl<Builder: OctetsBuilder> TxtBuilder<Builder> {
             let left = 255 - (self.builder.len() - (start + 1));
             if slice.len() < left {
                 self.builder.append_slice(slice)?;
-                return Ok(())
+                return Ok(());
             }
             let (append, left) = slice.split_at(left);
             self.builder.append_slice(append)?;
@@ -1552,24 +1540,20 @@ impl<Builder: OctetsBuilder + EmptyBuilder> Default for TxtBuilder<Builder> {
     }
 }
 
-
 //============ Testing ======================================================
 
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod test {
-    use std::vec::Vec;
     use super::*;
+    use std::vec::Vec;
 
     #[test]
     #[cfg(features = "bytes")]
     fn hinfo_octets_into() {
         use crate::octets::OctetsInto;
 
-        let hinfo: Hinfo<Vec<u8>> = Hinfo::new(
-            "1234".parse().unwrap(),
-            "abcd".parse().unwrap()
-        );
+        let hinfo: Hinfo<Vec<u8>> = Hinfo::new("1234".parse().unwrap(), "abcd".parse().unwrap());
         let hinfo_bytes: Hinfo<bytes::Bytes> = hinfo.octets_into().unwrap();
         assert_eq!(hinfo.cpu(), hinfo_bytes.cpu());
         assert_eq!(hinfo.os(), hinfo_bytes.os());
@@ -1581,12 +1565,9 @@ mod test {
         use crate::base::Dname;
         use crate::octets::OctetsInto;
 
-        let minfo: Minfo<Dname<Vec<u8>>> = Minfo::new(
-            "a.example".parse().unwrap(),
-            "b.example".parse().unwrap()
-        );
-        let minfo_bytes: Minfo<Dname<bytes::Bytes>> =
-            minfo.octets_into().unwrap();
+        let minfo: Minfo<Dname<Vec<u8>>> =
+            Minfo::new("a.example".parse().unwrap(), "b.example".parse().unwrap());
+        let minfo_bytes: Minfo<Dname<bytes::Bytes>> = minfo.octets_into().unwrap();
         assert_eq!(minfo.rmailbx(), minfo_bytes.rmailbx());
         assert_eq!(minfo.emailbx(), minfo_bytes.emailbx());
     }
@@ -1621,9 +1602,7 @@ mod test {
 
         // Empty
         let mut builder: TxtBuilder<Vec<u8>> = TxtBuilder::new();
-        assert!(builder
-            .append_slice(&[])
-            .is_ok());
+        assert!(builder.append_slice(&[]).is_ok());
         let empty = builder.finish();
         assert!(empty.is_empty());
         assert_eq!(0, empty.iter().count());
@@ -1658,11 +1637,14 @@ mod test {
             "brave-ledger-verification=66a7f27fb99949cc0c564ab98efcc58ea1bac3e97eb557c782ab2d44b49aefd7",
         ];
 
-        let records = data.iter().map(|e| {
-            let mut builder = TxtBuilder::<Vec<u8>>::new();
-            builder.append_slice(e.as_bytes()).unwrap();
-            builder.finish()
-        }).collect::<Vec<_>>();
+        let records = data
+            .iter()
+            .map(|e| {
+                let mut builder = TxtBuilder::<Vec<u8>>::new();
+                builder.append_slice(e.as_bytes()).unwrap();
+                builder.finish()
+            })
+            .collect::<Vec<_>>();
 
         // The canonical sort must sort by TXT labels which are prefixed by length byte first.
         let mut sorted = records.clone();

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -784,7 +784,7 @@ where
     Octets: OctetsFrom<SrcOctets>,
 {
     fn octets_from(source: Null<SrcOctets>) -> Result<Self, ShortBuf> {
-        Octets::octets_from(source.data).map(|octets| Self::new(octets))
+        Octets::octets_from(source.data).map(Self::new)
     }
 }
 

--- a/src/rdata/rfc2782.rs
+++ b/src/rdata/rfc2782.rs
@@ -4,20 +4,17 @@
 //!
 //! [RFC 2782]: https://tools.ietf.org/html/rfc2782
 
-use core::fmt;
-use core::cmp::Ordering;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, Parser, ParseError,
-    ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
-#[cfg(feature="master")] use crate::master::scan::{
-    CharSource, Scan, Scanner, ScanError
-};
-
+#[cfg(feature = "master")]
+use crate::master::scan::{CharSource, Scan, ScanError, Scanner};
+use core::cmp::Ordering;
+use core::fmt;
 
 //------------ Srv ---------------------------------------------------------
 
@@ -26,14 +23,19 @@ pub struct Srv<N> {
     priority: u16,
     weight: u16,
     port: u16,
-    target: N
+    target: N,
 }
 
 impl<N> Srv<N> {
     pub const RTYPE: Rtype = Rtype::Srv;
 
     pub fn new(priority: u16, weight: u16, port: u16, target: N) -> Self {
-        Srv { priority, weight, port, target }
+        Srv {
+            priority,
+            weight,
+            port,
+            target,
+        }
     }
 
     pub fn into_target(self) -> N {
@@ -57,51 +59,58 @@ impl<N> Srv<N> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Name, SrcName> OctetsFrom<Srv<SrcName>> for Srv<Name>
-where Name: OctetsFrom<SrcName> {
+where
+    Name: OctetsFrom<SrcName>,
+{
     fn octets_from(source: Srv<SrcName>) -> Result<Self, ShortBuf> {
         Ok(Srv::new(
-            source.priority, source.weight, source.port,
-            Name::octets_from(source.target)?
+            source.priority,
+            source.weight,
+            source.port,
+            Name::octets_from(source.target)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<N, NN> PartialEq<Srv<NN>> for Srv<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn eq(&self, other: &Srv<NN>) -> bool {
         self.priority == other.priority
-        && self.weight == other.weight
-        && self.port == other.port
-        && self.target.name_eq(&other.target)
+            && self.weight == other.weight
+            && self.port == other.port
+            && self.target.name_eq(&other.target)
     }
 }
 
-impl<N: ToDname> Eq for Srv<N> { }
-
+impl<N: ToDname> Eq for Srv<N> {}
 
 //--- PartialOrd, Ord, and CanonicalOrd
 
 impl<N, NN> PartialOrd<Srv<NN>> for Srv<N>
-where N: ToDname, NN: ToDname {
+where
+    N: ToDname,
+    NN: ToDname,
+{
     fn partial_cmp(&self, other: &Srv<NN>) -> Option<Ordering> {
         match self.priority.partial_cmp(&other.priority) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.weight.partial_cmp(&other.weight) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.port.partial_cmp(&other.port) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         Some(self.target.name_cmp(&other.target))
     }
@@ -110,16 +119,16 @@ where N: ToDname, NN: ToDname {
 impl<N: ToDname> Ord for Srv<N> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.priority.cmp(&other.priority) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.weight.cmp(&other.weight) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.port.cmp(&other.port) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.target.name_cmp(&other.target)
     }
@@ -128,21 +137,20 @@ impl<N: ToDname> Ord for Srv<N> {
 impl<N: ToDname, NN: ToDname> CanonicalOrd<Srv<NN>> for Srv<N> {
     fn canonical_cmp(&self, other: &Srv<NN>) -> Ordering {
         match self.priority.cmp(&other.priority) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.weight.cmp(&other.weight) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.port.cmp(&other.port) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.target.lowercase_composed_cmp(&other.target)
     }
 }
-
 
 //--- Parse, ParseAll, Compose and Compress
 
@@ -152,7 +160,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Srv<ParsedDname<Ref>> {
             u16::parse(parser)?,
             u16::parse(parser)?,
             u16::parse(parser)?,
-            ParsedDname::parse(parser)?
+            ParsedDname::parse(parser)?,
         ))
     }
 
@@ -165,10 +173,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Srv<ParsedDname<Ref>> {
 }
 
 impl<N: Compose> Compose for Srv<N> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.priority.compose(buf)?;
             self.weight.compose(buf)?;
@@ -177,10 +182,7 @@ impl<N: Compose> Compose for Srv<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.priority.compose(buf)?;
             self.weight.compose(buf)?;
@@ -190,29 +192,32 @@ impl<N: Compose> Compose for Srv<N> {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<N> RtypeRecordData for Srv<N> {
     const RTYPE: Rtype = Rtype::Srv;
 }
 
-
 //--- Scan and Display
- 
-#[cfg(feature="master")]
+
+#[cfg(feature = "master")]
 impl<N: Scan> Scan for Srv<N> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>)
-                           -> Result<Self, ScanError> {
-        Ok(Self::new(u16::scan(scanner)?, u16::scan(scanner)?,
-                     u16::scan(scanner)?, N::scan(scanner)?))
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+        Ok(Self::new(
+            u16::scan(scanner)?,
+            u16::scan(scanner)?,
+            u16::scan(scanner)?,
+            N::scan(scanner)?,
+        ))
     }
 }
 
 impl<N: fmt::Display> fmt::Display for Srv<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} {} {}", self.priority, self.weight, self.port,
-               self.target)
+        write!(
+            f,
+            "{} {} {} {}",
+            self.priority, self.weight, self.port, self.target
+        )
     }
 }
-

--- a/src/rdata/rfc2782.rs
+++ b/src/rdata/rfc2782.rs
@@ -8,7 +8,8 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature = "master")]
@@ -173,7 +174,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Srv<ParsedDname<Ref>> {
 }
 
 impl<N: Compose> Compose for Srv<N> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.priority.compose(buf)?;
             self.weight.compose(buf)?;
@@ -182,7 +186,10 @@ impl<N: Compose> Compose for Srv<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.priority.compose(buf)?;
             self.weight.compose(buf)?;
@@ -202,7 +209,9 @@ impl<N> RtypeRecordData for Srv<N> {
 
 #[cfg(feature = "master")]
 impl<N: Scan> Scan for Srv<N> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             u16::scan(scanner)?,

--- a/src/rdata/rfc2845.rs
+++ b/src/rdata/rfc2845.rs
@@ -8,7 +8,8 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Rtype, TsigRcode};
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 use crate::utils::base64;
@@ -175,12 +176,15 @@ impl<O, N> Tsig<O, N> {
 
 //--- OctetsFrom
 
-impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Tsig<SrcOctets, SrcName>> for Tsig<Octets, Name>
+impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Tsig<SrcOctets, SrcName>>
+    for Tsig<Octets, Name>
 where
     Octets: OctetsFrom<SrcOctets>,
     Name: OctetsFrom<SrcName>,
 {
-    fn octets_from(source: Tsig<SrcOctets, SrcName>) -> Result<Self, ShortBuf> {
+    fn octets_from(
+        source: Tsig<SrcOctets, SrcName>,
+    ) -> Result<Self, ShortBuf> {
         Ok(Tsig::new(
             Name::octets_from(source.algorithm)?,
             source.time_signed,
@@ -380,7 +384,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Tsig<Ref::Range, ParsedDname<Ref>> {
 }
 
 impl<O: AsRef<[u8]>, N: Compose> Compose for Tsig<O, N> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.algorithm.compose(buf)?;
             self.time_signed.compose(buf)?;
@@ -500,7 +507,8 @@ impl Time48 {
     /// Returns `true` iff `other` is at most `fudge` seconds before or after
     /// this value’s time.
     pub fn eq_fudged(self, other: Self, fudge: u64) -> bool {
-        self.0.saturating_sub(fudge) <= other.0 && self.0.saturating_add(fudge) >= other.0
+        self.0.saturating_sub(fudge) <= other.0
+            && self.0.saturating_add(fudge) >= other.0
     }
 }
 
@@ -527,7 +535,10 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for Time48 {
 }
 
 impl Compose for Time48 {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(&self.into_octets())
     }
 }

--- a/src/rdata/rfc3596.rs
+++ b/src/rdata/rfc3596.rs
@@ -4,25 +4,23 @@
 //!
 //! [RFC 3596]: https://tools.ietf.org/html/rfc3596
 
-use core::{fmt, ops};
-use core::cmp::Ordering;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::net::Ipv6Addr;
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, Parse, ParseError, Parser, ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, Parse, ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
-#[cfg(feature="master")] use crate::master::scan::{
-    CharSource, Scan, Scanner, ScanError
-};
-
+#[cfg(feature = "master")]
+use crate::master::scan::{CharSource, Scan, ScanError, Scanner};
+use core::cmp::Ordering;
+use core::{fmt, ops};
 
 //------------ Aaaa ---------------------------------------------------------
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Aaaa {
-    addr: Ipv6Addr
+    addr: Ipv6Addr,
 }
 
 impl Aaaa {
@@ -30,10 +28,13 @@ impl Aaaa {
         Aaaa { addr }
     }
 
-    pub fn addr(&self) -> Ipv6Addr { self.addr }
-    pub fn set_addr(&mut self, addr: Ipv6Addr) { self.addr = addr }
+    pub fn addr(&self) -> Ipv6Addr {
+        self.addr
+    }
+    pub fn set_addr(&mut self, addr: Ipv6Addr) {
+        self.addr = addr
+    }
 }
-
 
 //--- From and FromStr
 
@@ -58,7 +59,6 @@ impl core::str::FromStr for Aaaa {
     }
 }
 
-
 //--- OctetsFrom
 
 impl OctetsFrom<Aaaa> for Aaaa {
@@ -67,7 +67,6 @@ impl OctetsFrom<Aaaa> for Aaaa {
     }
 }
 
-
 //--- CanonicalOrd
 
 impl CanonicalOrd for Aaaa {
@@ -75,7 +74,6 @@ impl CanonicalOrd for Aaaa {
         self.cmp(other)
     }
 }
-
 
 //--- Parse, ParseAll, and Compose
 
@@ -90,24 +88,17 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for Aaaa {
 }
 
 impl Compose for Aaaa {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         self.addr.compose(target)
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for Aaaa {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>)
-                           -> Result<Self, ScanError> {
-        scanner.scan_string_phrase(|res| {
-            core::str::FromStr::from_str(&res).map_err(Into::into)
-        })
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+        scanner.scan_string_phrase(|res| core::str::FromStr::from_str(&res).map_err(Into::into))
     }
 }
 
@@ -117,13 +108,11 @@ impl fmt::Display for Aaaa {
     }
 }
 
-
 //--- RecordData
 
 impl RtypeRecordData for Aaaa {
     const RTYPE: Rtype = Rtype::Aaaa;
 }
-
 
 //--- Deref and DerefMut
 
@@ -141,7 +130,6 @@ impl ops::DerefMut for Aaaa {
     }
 }
 
-
 //--- AsRef and AsMut
 
 impl AsRef<Ipv6Addr> for Aaaa {
@@ -155,4 +143,3 @@ impl AsMut<Ipv6Addr> for Aaaa {
         &mut self.addr
     }
 }
-

--- a/src/rdata/rfc3596.rs
+++ b/src/rdata/rfc3596.rs
@@ -88,7 +88,10 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for Aaaa {
 }
 
 impl Compose for Aaaa {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         self.addr.compose(target)
     }
 }
@@ -97,8 +100,12 @@ impl Compose for Aaaa {
 
 #[cfg(feature = "master")]
 impl Scan for Aaaa {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
-        scanner.scan_string_phrase(|res| core::str::FromStr::from_str(&res).map_err(Into::into))
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
+        scanner.scan_string_phrase(|res| {
+            core::str::FromStr::from_str(&res).map_err(Into::into)
+        })
     }
 }
 

--- a/src/rdata/rfc4034.rs
+++ b/src/rdata/rfc4034.rs
@@ -10,8 +10,8 @@ use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::name::Dname;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef, Parse,
-    ParseError, Parser, ShortBuf,
+    Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsFrom,
+    OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 use crate::base::serial::Serial;
@@ -37,7 +37,12 @@ pub struct Dnskey<Octets> {
 }
 
 impl<Octets> Dnskey<Octets> {
-    pub fn new(flags: u16, protocol: u8, algorithm: SecAlg, public_key: Octets) -> Self {
+    pub fn new(
+        flags: u16,
+        protocol: u8,
+        algorithm: SecAlg,
+        public_key: Octets,
+    ) -> Self {
         Dnskey {
             flags,
             protocol,
@@ -261,7 +266,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Dnskey<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Dnskey<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.flags.compose(buf)?;
             self.protocol.compose(buf)?;
@@ -275,7 +283,9 @@ impl<Octets: AsRef<[u8]>> Compose for Dnskey<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Dnskey<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             u8::scan(scanner)?,
@@ -350,7 +360,10 @@ impl<Name> ProtoRrsig<Name> {
         }
     }
 
-    pub fn into_rrsig<Octets>(self, signature: Octets) -> Rrsig<Octets, Name> {
+    pub fn into_rrsig<Octets>(
+        self,
+        signature: Octets,
+    ) -> Rrsig<Octets, Name> {
         Rrsig::new(
             self.type_covered,
             self.algorithm,
@@ -388,7 +401,10 @@ where
 //--- Compose
 
 impl<Name: Compose> Compose for ProtoRrsig<Name> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.type_covered.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -401,7 +417,10 @@ impl<Name: Compose> Compose for ProtoRrsig<Name> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.type_covered.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -499,12 +518,15 @@ impl<Octets, Name> Rrsig<Octets, Name> {
 
 //--- OctetsFrom
 
-impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Rrsig<SrcOctets, SrcName>> for Rrsig<Octets, Name>
+impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Rrsig<SrcOctets, SrcName>>
+    for Rrsig<Octets, Name>
 where
     Octets: OctetsFrom<SrcOctets>,
     Name: OctetsFrom<SrcName>,
 {
-    fn octets_from(source: Rrsig<SrcOctets, SrcName>) -> Result<Self, ShortBuf> {
+    fn octets_from(
+        source: Rrsig<SrcOctets, SrcName>,
+    ) -> Result<Self, ShortBuf> {
         Ok(Rrsig::new(
             source.type_covered,
             source.algorithm,
@@ -704,7 +726,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Rrsig<Ref::Range, ParsedDname<Ref>> {
 }
 
 impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Rrsig<Octets, Name> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.type_covered.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -718,7 +743,10 @@ impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Rrsig<Octets, Name> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.type_covered.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -737,7 +765,9 @@ impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Rrsig<Octets, Name> {
 
 #[cfg(feature = "master")]
 impl Scan for Rrsig<Bytes, Dname<Bytes>> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             Rtype::scan(scanner)?,
             SecAlg::scan(scanner)?,
@@ -830,12 +860,15 @@ impl<Octets, Name> Nsec<Octets, Name> {
 
 //--- OctetsFrom
 
-impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Nsec<SrcOctets, SrcName>> for Nsec<Octets, Name>
+impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Nsec<SrcOctets, SrcName>>
+    for Nsec<Octets, Name>
 where
     Octets: OctetsFrom<SrcOctets>,
     Name: OctetsFrom<SrcName>,
 {
-    fn octets_from(source: Nsec<SrcOctets, SrcName>) -> Result<Self, ShortBuf> {
+    fn octets_from(
+        source: Nsec<SrcOctets, SrcName>,
+    ) -> Result<Self, ShortBuf> {
         Ok(Nsec::new(
             Name::octets_from(source.next_name)?,
             RtypeBitmap::octets_from(source.types)?,
@@ -910,7 +943,9 @@ where
 
 //--- Hash
 
-impl<Octets: AsRef<[u8]>, Name: hash::Hash> hash::Hash for Nsec<Octets, Name> {
+impl<Octets: AsRef<[u8]>, Name: hash::Hash> hash::Hash
+    for Nsec<Octets, Name>
+{
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.next_name.hash(state);
         self.types.hash(state);
@@ -934,7 +969,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec<Ref::Range, ParsedDname<Ref>> {
 }
 
 impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Nsec<Octets, Name> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.next_name.compose(target)?;
             self.types.compose(target)
@@ -948,7 +986,9 @@ impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Nsec<Octets, Name> {
 
 #[cfg(feature = "master")]
 impl<N: Scan> Scan for Nsec<Bytes, N> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(N::scan(scanner)?, RtypeBitmap::scan(scanner)?))
     }
 }
@@ -995,7 +1035,12 @@ pub struct Ds<Octets> {
 }
 
 impl<Octets> Ds<Octets> {
-    pub fn new(key_tag: u16, algorithm: SecAlg, digest_type: DigestAlg, digest: Octets) -> Self {
+    pub fn new(
+        key_tag: u16,
+        algorithm: SecAlg,
+        digest_type: DigestAlg,
+        digest: Octets,
+    ) -> Self {
         Ds {
             key_tag,
             algorithm,
@@ -1147,7 +1192,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Ds<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Ds<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.key_tag.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -1161,7 +1209,9 @@ impl<Octets: AsRef<[u8]>> Compose for Ds<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Ds<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             SecAlg::scan(scanner)?,
@@ -1272,7 +1322,8 @@ impl<Octets: AsRef<[u8]>> RtypeBitmap<Octets> {
         let (block, octet, mask) = split_rtype(rtype);
         let mut data = self.0.as_ref();
         while !data.is_empty() {
-            let ((window_num, window), next_data) = read_window(data).unwrap();
+            let ((window_num, window), next_data) =
+                read_window(data).unwrap();
             if window_num == block {
                 return !(window.len() <= octet || window[octet] & mask == 0);
             }
@@ -1292,7 +1343,8 @@ impl<T, Octets: AsRef<T>> AsRef<T> for RtypeBitmap<Octets> {
 
 //--- OctetsFrom
 
-impl<Octets, SrcOctets> OctetsFrom<RtypeBitmap<SrcOctets>> for RtypeBitmap<Octets>
+impl<Octets, SrcOctets> OctetsFrom<RtypeBitmap<SrcOctets>>
+    for RtypeBitmap<Octets>
 where
     Octets: OctetsFrom<SrcOctets>,
 {
@@ -1367,7 +1419,8 @@ impl<'a, Octets: AsRef<[u8]>> IntoIterator for &'a RtypeBitmap<Octets> {
 impl<Ref: OctetsRef> Parse<Ref> for RtypeBitmap<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = parser.remaining();
-        RtypeBitmap::from_octets(parser.parse_octets(len)?).map_err(Into::into)
+        RtypeBitmap::from_octets(parser.parse_octets(len)?)
+            .map_err(Into::into)
     }
 
     fn skip(parser: &mut Parser<Ref>) -> Result<(), ParseError> {
@@ -1377,7 +1430,10 @@ impl<Ref: OctetsRef> Parse<Ref> for RtypeBitmap<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for RtypeBitmap<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_slice(self.0.as_ref())
     }
 }
@@ -1386,7 +1442,9 @@ impl<Octets: AsRef<[u8]>> Compose for RtypeBitmap<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for RtypeBitmap<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         let mut builder = RtypeBitmapBuilder::<BytesMut>::new();
         while let Ok(rtype) = Rtype::scan(scanner) {
             builder.add(rtype).unwrap()
@@ -1468,13 +1526,19 @@ impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
         let mut pos = 0;
         while pos < self.buf.as_ref().len() {
             match self.buf.as_ref()[pos].cmp(&block) {
-                Ordering::Equal => return Ok(&mut self.buf.as_mut()[pos..pos + 34]),
+                Ordering::Equal => {
+                    return Ok(&mut self.buf.as_mut()[pos..pos + 34])
+                }
                 Ordering::Greater => {
                     let len = self.buf.as_ref().len() - pos;
                     self.buf.append_slice(&[0; 34])?;
                     let buf = self.buf.as_mut();
                     unsafe {
-                        ptr::copy(buf.as_ptr().add(pos), buf.as_mut_ptr().add(pos + 34), len);
+                        ptr::copy(
+                            buf.as_ptr().add(pos),
+                            buf.as_mut_ptr().add(pos + 34),
+                            len,
+                        );
                         ptr::write_bytes(buf.as_mut_ptr().add(pos), 0, 34);
                     }
                     buf[pos] = block;
@@ -1601,7 +1665,8 @@ impl<'a> Iterator for RtypeBitmapIter<'a> {
         if self.data.is_empty() {
             return None;
         }
-        let res = Rtype::from_int(self.block | (self.octet as u16) << 3 | self.bit);
+        let res =
+            Rtype::from_int(self.block | (self.octet as u16) << 3 | self.bit);
         self.advance();
         Some(res)
     }
@@ -1621,7 +1686,9 @@ impl From<RtypeBitmapError> for ParseError {
     fn from(err: RtypeBitmapError) -> ParseError {
         match err {
             RtypeBitmapError::ShortInput => ParseError::ShortInput,
-            RtypeBitmapError::BadRtypeBitmap => FormError::new("invalid NSEC bitmap").into(),
+            RtypeBitmapError::BadRtypeBitmap => {
+                FormError::new("invalid NSEC bitmap").into()
+            }
         }
     }
 }
@@ -1632,7 +1699,9 @@ impl fmt::Display for RtypeBitmapError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             RtypeBitmapError::ShortInput => ParseError::ShortInput.fmt(f),
-            RtypeBitmapError::BadRtypeBitmap => f.write_str("invalid record type bitmap"),
+            RtypeBitmapError::BadRtypeBitmap => {
+                f.write_str("invalid record type bitmap")
+            }
         }
     }
 }
@@ -1814,7 +1883,8 @@ mod test {
     #[test]
     #[cfg(feature = "bytes")]
     fn dnskey_flags() {
-        let dnskey = Dnskey::new(257, 3, SecAlg::RsaSha256, bytes::Bytes::new());
+        let dnskey =
+            Dnskey::new(257, 3, SecAlg::RsaSha256, bytes::Bytes::new());
         assert_eq!(dnskey.is_zsk(), true);
         assert_eq!(dnskey.is_secure_entry_point(), true);
         assert_eq!(dnskey.is_revoked(), false);

--- a/src/rdata/rfc4034.rs
+++ b/src/rdata/rfc4034.rs
@@ -4,26 +4,27 @@
 //!
 //! [RFC 4034]: https://tools.ietf.org/html/rfc4034
 
-use core::{fmt, hash, ptr};
-use core::cmp::Ordering;
-use core::convert::TryInto;
-#[cfg(feature = "std")] use std::vec::Vec;
-#[cfg(feature="master")] use bytes::{Bytes, BytesMut};
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
+#[cfg(feature = "master")]
+use crate::base::name::Dname;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsFrom,
-    OctetsRef, Parse, ParseError, Parser, ShortBuf
+    Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef, Parse,
+    ParseError, Parser, ShortBuf,
 };
-use crate::base::rdata::{RtypeRecordData};
+use crate::base::rdata::RtypeRecordData;
 use crate::base::serial::Serial;
-#[cfg(feature="master")] use crate::base::name::Dname;
-#[cfg(feature="master")] use crate::master::scan::{ 
-    CharSource, ScanError, Scan, Scanner
-};
+#[cfg(feature = "master")]
+use crate::master::scan::{CharSource, Scan, ScanError, Scanner};
 use crate::utils::base64;
-
+#[cfg(feature = "master")]
+use bytes::{Bytes, BytesMut};
+use core::cmp::Ordering;
+use core::convert::TryInto;
+use core::{fmt, hash, ptr};
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 //------------ Dnskey --------------------------------------------------------
 
@@ -36,12 +37,7 @@ pub struct Dnskey<Octets> {
 }
 
 impl<Octets> Dnskey<Octets> {
-    pub fn new(
-        flags: u16,
-        protocol: u8,
-        algorithm: SecAlg,
-        public_key: Octets)
-    -> Self {
+    pub fn new(flags: u16, protocol: u8, algorithm: SecAlg, public_key: Octets) -> Self {
         Dnskey {
             flags,
             protocol,
@@ -70,14 +66,12 @@ impl<Octets> Dnskey<Octets> {
         self.public_key
     }
 
-    pub fn convert<Other: From<Octets>>(
-        self
-    ) -> Dnskey<Other> {
+    pub fn convert<Other: From<Octets>>(self) -> Dnskey<Other> {
         Dnskey {
             flags: self.flags,
             protocol: self.protocol,
             algorithm: self.algorithm,
-            public_key: self.public_key.into()
+            public_key: self.public_key.into(),
         }
     }
 
@@ -104,7 +98,7 @@ impl<Octets> Dnskey<Octets> {
         self.flags() & 0b0000_0000_0000_0001 != 0
     }
 
-    /// Returns whether the Zone Key flag is set. 
+    /// Returns whether the Zone Key flag is set.
     ///
     /// If the flag is not set, the key MUST NOT be used to verify RRSIGs that
     /// cover RRSETs. See [RFC 4034, Section 2.1.1].
@@ -116,7 +110,9 @@ impl<Octets> Dnskey<Octets> {
 
     /// Returns the key tag for this DNSKEY data.
     pub fn key_tag(&self) -> u16
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         if self.algorithm == SecAlg::RsaMd5 {
             // The key tag is third-to-last and second-to-last octets of the
             // key as a big-endian u16. If we don’t have enough octets in the
@@ -125,14 +121,13 @@ impl<Octets> Dnskey<Octets> {
             if len > 2 {
                 u16::from_be_bytes(
                     self.public_key.as_ref()[len - 3..len - 1]
-                        .try_into().unwrap()
+                        .try_into()
+                        .unwrap(),
                 )
-            }
-            else {
+            } else {
                 0
             }
-        }
-        else {
+        } else {
             // Treat record data as a octet sequence. Add octets at odd
             // indexes as they are, add octets at even indexes shifted left
             // by 8 bits.
@@ -143,11 +138,11 @@ impl<Octets> Dnskey<Octets> {
             loop {
                 match iter.next() {
                     Some(&x) => res += u32::from(x) << 8,
-                    None => break
+                    None => break,
                 }
                 match iter.next() {
                     Some(&x) => res += u32::from(x),
-                    None => break
+                    None => break,
                 }
             }
             res += (res >> 16) & 0xFFFF;
@@ -156,58 +151,68 @@ impl<Octets> Dnskey<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Dnskey<SrcOctets>> for Dnskey<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Dnskey<SrcOctets>) -> Result<Self, ShortBuf> {
         Ok(Dnskey::new(
-            source.flags, source.protocol, source.algorithm,
+            source.flags,
+            source.protocol,
+            source.algorithm,
             Octets::octets_from(source.public_key)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
-impl<Octets, Other> PartialEq<Dnskey<Other>> for Dnskey<Octets> 
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+impl<Octets, Other> PartialEq<Dnskey<Other>> for Dnskey<Octets>
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Dnskey<Other>) -> bool {
         self.flags == other.flags
-        && self.protocol == other.protocol
-        && self.algorithm == other.algorithm
-        && self.public_key.as_ref() == other.public_key.as_ref()
+            && self.protocol == other.protocol
+            && self.algorithm == other.algorithm
+            && self.public_key.as_ref() == other.public_key.as_ref()
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Dnskey<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Dnskey<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
-impl<Octets, Other> PartialOrd<Dnskey<Other>> for Dnskey<Octets> 
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+impl<Octets, Other> PartialOrd<Dnskey<Other>> for Dnskey<Octets>
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Dnskey<Other>) -> Option<Ordering> {
         Some(self.canonical_cmp(other))
     }
 }
 
-impl<Octets, Other> CanonicalOrd<Dnskey<Other>> for Dnskey<Octets> 
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+impl<Octets, Other> CanonicalOrd<Dnskey<Other>> for Dnskey<Octets>
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Dnskey<Other>) -> Ordering {
         match self.flags.cmp(&other.flags) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.protocol.cmp(&other.protocol) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.algorithm.cmp(&other.algorithm) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.public_key.as_ref().cmp(other.public_key.as_ref())
     }
@@ -218,7 +223,6 @@ impl<Octets: AsRef<[u8]>> Ord for Dnskey<Octets> {
         self.canonical_cmp(other)
     }
 }
-
 
 //--- Hash
 
@@ -231,26 +235,25 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Dnskey<Octets> {
     }
 }
 
-
 //--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Dnskey<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = match parser.remaining().checked_sub(4) {
             Some(len) => len,
-            None => return Err(ParseError::ShortInput)
+            None => return Err(ParseError::ShortInput),
         };
         Ok(Self::new(
             u16::parse(parser)?,
             u8::parse(parser)?,
             SecAlg::parse(parser)?,
-            parser.parse_octets(len)?
+            parser.parse_octets(len)?,
         ))
     }
 
     fn skip(parser: &mut Parser<Ref>) -> Result<(), ParseError> {
         if parser.remaining() < 4 {
-            return Err(ParseError::ShortInput)
+            return Err(ParseError::ShortInput);
         }
         parser.advance_to_end();
         Ok(())
@@ -258,10 +261,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Dnskey<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Dnskey<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.flags.compose(buf)?;
             self.protocol.compose(buf)?;
@@ -271,19 +271,16 @@ impl<Octets: AsRef<[u8]>> Compose for Dnskey<Octets> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for Dnskey<Bytes> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             u8::scan(scanner)?,
             SecAlg::scan(scanner)?,
-            scanner.scan_base64_phrases(Ok)?
+            scanner.scan_base64_phrases(Ok)?,
         ))
     }
 }
@@ -294,7 +291,6 @@ impl<Octets: AsRef<[u8]>> fmt::Display for Dnskey<Octets> {
         base64::display(&self.public_key, f)
     }
 }
-
 
 //--- Debug
 
@@ -309,13 +305,11 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Dnskey<Octets> {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<Octets> RtypeRecordData for Dnskey<Octets> {
     const RTYPE: Rtype = Rtype::Dnskey;
 }
-
 
 //------------ ProtoRrsig ----------------------------------------------------
 
@@ -356,41 +350,45 @@ impl<Name> ProtoRrsig<Name> {
         }
     }
 
-    pub fn into_rrsig<Octets>(
-        self,
-        signature: Octets
-    ) -> Rrsig<Octets, Name> {
+    pub fn into_rrsig<Octets>(self, signature: Octets) -> Rrsig<Octets, Name> {
         Rrsig::new(
-            self.type_covered, self.algorithm, self.labels,
-            self.original_ttl, self.expiration, self.inception,
-            self.key_tag, self.signer_name, signature
+            self.type_covered,
+            self.algorithm,
+            self.labels,
+            self.original_ttl,
+            self.expiration,
+            self.inception,
+            self.key_tag,
+            self.signer_name,
+            signature,
         )
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Name, SrcName> OctetsFrom<ProtoRrsig<SrcName>> for ProtoRrsig<Name>
-where Name: OctetsFrom<SrcName> {
+where
+    Name: OctetsFrom<SrcName>,
+{
     fn octets_from(source: ProtoRrsig<SrcName>) -> Result<Self, ShortBuf> {
         Ok(ProtoRrsig::new(
-            source.type_covered, source.algorithm, source.labels,
-            source.original_ttl, source.expiration, source.inception,
+            source.type_covered,
+            source.algorithm,
+            source.labels,
+            source.original_ttl,
+            source.expiration,
+            source.inception,
             source.key_tag,
-            Name::octets_from(source.signer_name)?
+            Name::octets_from(source.signer_name)?,
         ))
     }
 }
 
-
 //--- Compose
 
 impl<Name: Compose> Compose for ProtoRrsig<Name> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.type_covered.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -403,10 +401,7 @@ impl<Name: Compose> Compose for ProtoRrsig<Name> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.type_covered.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -419,8 +414,6 @@ impl<Name: Compose> Compose for ProtoRrsig<Name> {
         })
     }
 }
-
-
 
 //------------ Rrsig ---------------------------------------------------------
 
@@ -448,7 +441,7 @@ impl<Octets, Name> Rrsig<Octets, Name> {
         inception: Serial,
         key_tag: u16,
         signer_name: Name,
-        signature: Octets
+        signature: Octets,
     ) -> Self {
         Rrsig {
             type_covered,
@@ -459,7 +452,7 @@ impl<Octets, Name> Rrsig<Octets, Name> {
             inception,
             key_tag,
             signer_name,
-            signature
+            signature,
         }
     }
 
@@ -504,18 +497,21 @@ impl<Octets, Name> Rrsig<Octets, Name> {
     }
 }
 
-
 //--- OctetsFrom
 
-impl<Octets, SrcOctets, Name, SrcName>
-    OctetsFrom<Rrsig<SrcOctets, SrcName>> for Rrsig<Octets, Name>
-where Octets: OctetsFrom<SrcOctets>, Name: OctetsFrom<SrcName> {
-    fn octets_from(
-        source: Rrsig<SrcOctets, SrcName>
-    ) -> Result<Self, ShortBuf> {
+impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Rrsig<SrcOctets, SrcName>> for Rrsig<Octets, Name>
+where
+    Octets: OctetsFrom<SrcOctets>,
+    Name: OctetsFrom<SrcName>,
+{
+    fn octets_from(source: Rrsig<SrcOctets, SrcName>) -> Result<Self, ShortBuf> {
         Ok(Rrsig::new(
-            source.type_covered, source.algorithm, source.labels,
-            source.original_ttl, source.expiration, source.inception,
+            source.type_covered,
+            source.algorithm,
+            source.labels,
+            source.original_ttl,
+            source.expiration,
+            source.inception,
             source.key_tag,
             Name::octets_from(source.signer_name)?,
             Octets::octets_from(source.signature)?,
@@ -523,103 +519,122 @@ where Octets: OctetsFrom<SrcOctets>, Name: OctetsFrom<SrcName> {
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<N, NN, O, OO> PartialEq<Rrsig<OO, NN>> for Rrsig<O, N>
-where N: ToDname, NN: ToDname, O: AsRef<[u8]>, OO: AsRef<[u8]> {
+where
+    N: ToDname,
+    NN: ToDname,
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+{
     fn eq(&self, other: &Rrsig<OO, NN>) -> bool {
         self.type_covered == other.type_covered
-        && self.algorithm == other.algorithm
-        && self.labels == other.labels
-        && self.original_ttl == other.original_ttl
-        && self.expiration.into_int() == other.expiration.into_int()
-        && self.inception.into_int() == other.inception.into_int()
-        && self.key_tag == other.key_tag
-        && self.signer_name.name_eq(&other.signer_name)
-        && self.signature.as_ref() == other.signature.as_ref()
+            && self.algorithm == other.algorithm
+            && self.labels == other.labels
+            && self.original_ttl == other.original_ttl
+            && self.expiration.into_int() == other.expiration.into_int()
+            && self.inception.into_int() == other.inception.into_int()
+            && self.key_tag == other.key_tag
+            && self.signer_name.name_eq(&other.signer_name)
+            && self.signature.as_ref() == other.signature.as_ref()
     }
 }
 
 impl<Octets, Name> Eq for Rrsig<Octets, Name>
-where Octets: AsRef<[u8]>, Name: ToDname { }
-
+where
+    Octets: AsRef<[u8]>,
+    Name: ToDname,
+{
+}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<N, NN, O, OO> PartialOrd<Rrsig<OO, NN>> for Rrsig<O, N>
-where N: ToDname, NN: ToDname, O: AsRef<[u8]>, OO: AsRef<[u8]> {
+where
+    N: ToDname,
+    NN: ToDname,
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Rrsig<OO, NN>) -> Option<Ordering> {
         match self.type_covered.partial_cmp(&other.type_covered) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.algorithm.partial_cmp(&other.algorithm) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.labels.partial_cmp(&other.labels) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.original_ttl.partial_cmp(&other.original_ttl) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.expiration.partial_cmp(&other.expiration) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.inception.partial_cmp(&other.inception) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.key_tag.partial_cmp(&other.key_tag) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.signer_name.name_cmp(&other.signer_name) {
-            Ordering::Equal => { }
-            other => return Some(other)
+            Ordering::Equal => {}
+            other => return Some(other),
         }
-        self.signature.as_ref().partial_cmp(other.signature.as_ref())
+        self.signature
+            .as_ref()
+            .partial_cmp(other.signature.as_ref())
     }
 }
 
 impl<N, NN, O, OO> CanonicalOrd<Rrsig<OO, NN>> for Rrsig<O, N>
-where N: ToDname, NN: ToDname, O: AsRef<[u8]>, OO: AsRef<[u8]> {
+where
+    N: ToDname,
+    NN: ToDname,
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Rrsig<OO, NN>) -> Ordering {
         match self.type_covered.cmp(&other.type_covered) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.algorithm.cmp(&other.algorithm) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.labels.cmp(&other.labels) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.original_ttl.cmp(&other.original_ttl) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.expiration.canonical_cmp(&other.expiration) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.inception.canonical_cmp(&other.inception) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.key_tag.cmp(&other.key_tag) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.signer_name.lowercase_composed_cmp(&other.signer_name) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.signature.as_ref().cmp(other.signature.as_ref())
     }
@@ -630,7 +645,6 @@ impl<O: AsRef<[u8]>, N: ToDname> Ord for Rrsig<O, N> {
         self.canonical_cmp(other)
     }
 }
-
 
 //--- Hash
 
@@ -648,7 +662,6 @@ impl<O: AsRef<[u8]>, N: hash::Hash> hash::Hash for Rrsig<O, N> {
     }
 }
 
-
 //--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Rrsig<Ref::Range, ParsedDname<Ref>> {
@@ -664,8 +677,15 @@ impl<Ref: OctetsRef> Parse<Ref> for Rrsig<Ref::Range, ParsedDname<Ref>> {
         let len = parser.remaining();
         let signature = parser.parse_octets(len)?;
         Ok(Self::new(
-            type_covered, algorithm, labels, original_ttl, expiration,
-            inception, key_tag, signer_name, signature
+            type_covered,
+            algorithm,
+            labels,
+            original_ttl,
+            expiration,
+            inception,
+            key_tag,
+            signer_name,
+            signature,
         ))
     }
 
@@ -684,10 +704,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Rrsig<Ref::Range, ParsedDname<Ref>> {
 }
 
 impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Rrsig<Octets, Name> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.type_covered.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -701,10 +718,7 @@ impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Rrsig<Octets, Name> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose_canonical<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.type_covered.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -719,14 +733,11 @@ impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Rrsig<Octets, Name> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for Rrsig<Bytes, Dname<Bytes>> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(
             Rtype::scan(scanner)?,
             SecAlg::scan(scanner)?,
@@ -736,27 +747,40 @@ impl Scan for Rrsig<Bytes, Dname<Bytes>> {
             Serial::scan_rrsig(scanner)?,
             u16::scan(scanner)?,
             Dname::scan(scanner)?,
-            scanner.scan_base64_phrases(Ok)?
+            scanner.scan_base64_phrases(Ok)?,
         ))
     }
 }
 
 impl<Octets, Name> fmt::Display for Rrsig<Octets, Name>
-where Octets: AsRef<[u8]>, Name: fmt::Display {
+where
+    Octets: AsRef<[u8]>,
+    Name: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} {} {} {} {} {} {}. ",
-               self.type_covered, self.algorithm, self.labels,
-               self.original_ttl, self.expiration, self.inception,
-               self.key_tag, self.signer_name)?;
+        write!(
+            f,
+            "{} {} {} {} {} {} {} {}. ",
+            self.type_covered,
+            self.algorithm,
+            self.labels,
+            self.original_ttl,
+            self.expiration,
+            self.inception,
+            self.key_tag,
+            self.signer_name
+        )?;
         base64::display(&self.signature, f)
     }
 }
 
-
 //--- Debug
 
 impl<Octets, Name> fmt::Debug for Rrsig<Octets, Name>
-where Octets: AsRef<[u8]>, Name: fmt::Debug {
+where
+    Octets: AsRef<[u8]>,
+    Name: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Rrsig")
             .field("type_covered", &self.type_covered)
@@ -772,13 +796,11 @@ where Octets: AsRef<[u8]>, Name: fmt::Debug {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<Octets, Name> RtypeRecordData for Rrsig<Octets, Name> {
     const RTYPE: Rtype = Rtype::Rrsig;
 }
-
 
 //------------ Nsec ----------------------------------------------------------
 
@@ -806,15 +828,14 @@ impl<Octets, Name> Nsec<Octets, Name> {
     }
 }
 
-
 //--- OctetsFrom
 
-impl<Octets, SrcOctets, Name, SrcName>
-    OctetsFrom<Nsec<SrcOctets, SrcName>> for Nsec<Octets, Name>
-where Octets: OctetsFrom<SrcOctets>, Name: OctetsFrom<SrcName> {
-    fn octets_from(
-        source: Nsec<SrcOctets, SrcName>
-    ) -> Result<Self, ShortBuf> {
+impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Nsec<SrcOctets, SrcName>> for Nsec<Octets, Name>
+where
+    Octets: OctetsFrom<SrcOctets>,
+    Name: OctetsFrom<SrcName>,
+{
+    fn octets_from(source: Nsec<SrcOctets, SrcName>) -> Result<Self, ShortBuf> {
         Ok(Nsec::new(
             Name::octets_from(source.next_name)?,
             RtypeBitmap::octets_from(source.types)?,
@@ -822,34 +843,35 @@ where Octets: OctetsFrom<SrcOctets>, Name: OctetsFrom<SrcName> {
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<O, OO, N, NN> PartialEq<Nsec<OO, NN>> for Nsec<O, N>
 where
-    O: AsRef<[u8]>, OO: AsRef<[u8]>,
-    N: ToDname, NN: ToDname,
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+    N: ToDname,
+    NN: ToDname,
 {
     fn eq(&self, other: &Nsec<OO, NN>) -> bool {
-        self.next_name.name_eq(&other.next_name)
-        && self.types == other.types
+        self.next_name.name_eq(&other.next_name) && self.types == other.types
     }
 }
 
-impl<O: AsRef<[u8]>, N: ToDname> Eq for Nsec<O, N> { }
-
+impl<O: AsRef<[u8]>, N: ToDname> Eq for Nsec<O, N> {}
 
 //--- PartialOrd, Ord, and CanonicalOrd
 
 impl<O, OO, N, NN> PartialOrd<Nsec<OO, NN>> for Nsec<O, N>
 where
-    O: AsRef<[u8]>, OO: AsRef<[u8]>,
-    N: ToDname, NN: ToDname,
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+    N: ToDname,
+    NN: ToDname,
 {
     fn partial_cmp(&self, other: &Nsec<OO, NN>) -> Option<Ordering> {
         match self.next_name.name_cmp(&other.next_name) {
-            Ordering::Equal => { }
-            other => return Some(other)
+            Ordering::Equal => {}
+            other => return Some(other),
         }
         self.types.partial_cmp(&self.types)
     }
@@ -857,30 +879,34 @@ where
 
 impl<O, OO, N, NN> CanonicalOrd<Nsec<OO, NN>> for Nsec<O, N>
 where
-    O: AsRef<[u8]>, OO: AsRef<[u8]>,
-    N: ToDname, NN: ToDname,
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+    N: ToDname,
+    NN: ToDname,
 {
     fn canonical_cmp(&self, other: &Nsec<OO, NN>) -> Ordering {
         // RFC 6840 says that Nsec::next_name is not converted to lower case.
         match self.next_name.composed_cmp(&other.next_name) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.types.cmp(&self.types)
     }
 }
 
 impl<O, N> Ord for Nsec<O, N>
-where O: AsRef<[u8]>, N: ToDname {
+where
+    O: AsRef<[u8]>,
+    N: ToDname,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         match self.next_name.name_cmp(&other.next_name) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.types.cmp(&self.types)
     }
 }
-
 
 //--- Hash
 
@@ -891,14 +917,13 @@ impl<Octets: AsRef<[u8]>, Name: hash::Hash> hash::Hash for Nsec<Octets, Name> {
     }
 }
 
-
 //--- ParseAll and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Nsec<Ref::Range, ParsedDname<Ref>> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         Ok(Nsec::new(
             ParsedDname::parse(parser)?,
-            RtypeBitmap::parse(parser)?
+            RtypeBitmap::parse(parser)?,
         ))
     }
 
@@ -909,10 +934,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec<Ref::Range, ParsedDname<Ref>> {
 }
 
 impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Nsec<Octets, Name> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|target| {
             self.next_name.compose(target)?;
             self.types.compose(target)
@@ -922,33 +944,32 @@ impl<Octets: AsRef<[u8]>, Name: Compose> Compose for Nsec<Octets, Name> {
     // Default compose_canonical is correct as we keep the case.
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl<N: Scan> Scan for Nsec<Bytes, N> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
-        Ok(Self::new(
-            N::scan(scanner)?,
-            RtypeBitmap::scan(scanner)?,
-        ))
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+        Ok(Self::new(N::scan(scanner)?, RtypeBitmap::scan(scanner)?))
     }
 }
 
 impl<Octets, Name> fmt::Display for Nsec<Octets, Name>
-where Octets: AsRef<[u8]>, Name: fmt::Display {
+where
+    Octets: AsRef<[u8]>,
+    Name: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}. {}", self.next_name, self.types)
     }
 }
 
-
 //--- Debug
 
 impl<Octets, Name> fmt::Debug for Nsec<Octets, Name>
-where Octets: AsRef<[u8]>, Name: fmt::Debug {
+where
+    Octets: AsRef<[u8]>,
+    Name: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Nsec")
             .field("next_name", &self.next_name)
@@ -957,13 +978,11 @@ where Octets: AsRef<[u8]>, Name: fmt::Debug {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<Octets, Name> RtypeRecordData for Nsec<Octets, Name> {
     const RTYPE: Rtype = Rtype::Nsec;
 }
-
 
 //------------ Ds -----------------------------------------------------------
 
@@ -976,13 +995,13 @@ pub struct Ds<Octets> {
 }
 
 impl<Octets> Ds<Octets> {
-    pub fn new(
-        key_tag: u16,
-        algorithm: SecAlg,
-        digest_type: DigestAlg,
-        digest: Octets
-    ) -> Self {
-        Ds { key_tag, algorithm, digest_type, digest }
+    pub fn new(key_tag: u16, algorithm: SecAlg, digest_type: DigestAlg, digest: Octets) -> Self {
+        Ds {
+            key_tag,
+            algorithm,
+            digest_type,
+            digest,
+        }
     }
 
     pub fn key_tag(&self) -> u16 {
@@ -1006,70 +1025,80 @@ impl<Octets> Ds<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Ds<SrcOctets>> for Ds<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Ds<SrcOctets>) -> Result<Self, ShortBuf> {
         Ok(Ds::new(
-            source.key_tag, source.algorithm, source.digest_type,
+            source.key_tag,
+            source.algorithm,
+            source.digest_type,
             Octets::octets_from(source.digest)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<Octets, Other> PartialEq<Ds<Other>> for Ds<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Ds<Other>) -> bool {
         self.key_tag == other.key_tag
-        && self.algorithm == other.algorithm
-        && self.digest_type == other.digest_type
-        && self.digest.as_ref().eq(other.digest.as_ref())
+            && self.algorithm == other.algorithm
+            && self.digest_type == other.digest_type
+            && self.digest.as_ref().eq(other.digest.as_ref())
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Ds<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Ds<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<Octets, Other> PartialOrd<Ds<Other>> for Ds<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Ds<Other>) -> Option<Ordering> {
         match self.key_tag.partial_cmp(&other.key_tag) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.algorithm.partial_cmp(&other.algorithm) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.digest_type.partial_cmp(&other.digest_type) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         self.digest.as_ref().partial_cmp(other.digest.as_ref())
     }
 }
 
 impl<Octets, Other> CanonicalOrd<Ds<Other>> for Ds<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Ds<Other>) -> Ordering {
         match self.key_tag.cmp(&other.key_tag) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.algorithm.cmp(&other.algorithm) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.digest_type.cmp(&other.digest_type) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.digest.as_ref().cmp(other.digest.as_ref())
     }
@@ -1080,7 +1109,6 @@ impl<Octets: AsRef<[u8]>> Ord for Ds<Octets> {
         self.canonical_cmp(other)
     }
 }
-
 
 //--- Hash
 
@@ -1093,20 +1121,19 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Ds<Octets> {
     }
 }
 
-
 //--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Ds<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = match parser.remaining().checked_sub(4) {
             Some(len) => len,
-            None => return Err(ParseError::ShortInput)
+            None => return Err(ParseError::ShortInput),
         };
         Ok(Self::new(
             u16::parse(parser)?,
             SecAlg::parse(parser)?,
             DigestAlg::parse(parser)?,
-            parser.parse_octets(len)?
+            parser.parse_octets(len)?,
         ))
     }
 
@@ -1120,10 +1147,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Ds<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Ds<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.key_tag.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -1133,14 +1157,11 @@ impl<Octets: AsRef<[u8]>> Compose for Ds<Octets> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for Ds<Bytes> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             SecAlg::scan(scanner)?,
@@ -1152,15 +1173,17 @@ impl Scan for Ds<Bytes> {
 
 impl<Octets: AsRef<[u8]>> fmt::Display for Ds<Octets> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} {} ", self.key_tag, self.algorithm,
-               self.digest_type)?;
+        write!(
+            f,
+            "{} {} {} ",
+            self.key_tag, self.algorithm, self.digest_type
+        )?;
         for ch in self.digest.as_ref() {
             write!(f, "{:02x}", ch)?
         }
         Ok(())
     }
 }
-
 
 //--- Debug
 
@@ -1175,13 +1198,11 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Ds<Octets> {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<Octets> RtypeRecordData for Ds<Octets> {
     const RTYPE: Rtype = Rtype::Ds;
 }
-
 
 //------------ RtypeBitmap ---------------------------------------------------
 
@@ -1190,13 +1211,15 @@ pub struct RtypeBitmap<Octets>(Octets);
 
 impl<Octets> RtypeBitmap<Octets> {
     pub fn from_octets(octets: Octets) -> Result<Self, RtypeBitmapError>
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         {
             let mut data = octets.as_ref();
             while !data.is_empty() {
                 // At least bitmap number and length must be present.
                 if data.len() < 2 {
-                    return Err(RtypeBitmapError::ShortInput)
+                    return Err(RtypeBitmapError::ShortInput);
                 }
 
                 let len = (data[1] as usize) + 2;
@@ -1206,10 +1229,10 @@ impl<Octets> RtypeBitmap<Octets> {
                     return Err(RtypeBitmapError::BadRtypeBitmap);
                 }
                 if len > 34 {
-                    return Err(RtypeBitmapError::BadRtypeBitmap)
+                    return Err(RtypeBitmapError::BadRtypeBitmap);
                 }
                 if data.len() < len {
-                    return Err(RtypeBitmapError::ShortInput)
+                    return Err(RtypeBitmapError::ShortInput);
                 }
                 data = &data[len..];
             }
@@ -1220,7 +1243,7 @@ impl<Octets> RtypeBitmap<Octets> {
     pub fn builder() -> RtypeBitmapBuilder<Octets::Builder>
     where
         Octets: FromBuilder,
-        <Octets as FromBuilder>::Builder: EmptyBuilder
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
     {
         RtypeBitmapBuilder::new()
     }
@@ -1232,7 +1255,9 @@ impl<Octets> RtypeBitmap<Octets> {
 
 impl<Octets: AsRef<[u8]>> RtypeBitmap<Octets> {
     pub fn as_slice(&self) -> &[u8]
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         self.0.as_ref()
     }
 
@@ -1241,7 +1266,9 @@ impl<Octets: AsRef<[u8]>> RtypeBitmap<Octets> {
     }
 
     pub fn contains(&self, rtype: Rtype) -> bool
-    where Octets: AsRef<[u8]> {
+    where
+        Octets: AsRef<[u8]>,
+    {
         let (block, octet, mask) = split_rtype(rtype);
         let mut data = self.0.as_ref();
         while !data.is_empty() {
@@ -1255,7 +1282,6 @@ impl<Octets: AsRef<[u8]>> RtypeBitmap<Octets> {
     }
 }
 
-
 //--- AsRef
 
 impl<T, Octets: AsRef<T>> AsRef<T> for RtypeBitmap<Octets> {
@@ -1264,41 +1290,48 @@ impl<T, Octets: AsRef<T>> AsRef<T> for RtypeBitmap<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
-impl<Octets, SrcOctets>
-    OctetsFrom<RtypeBitmap<SrcOctets>> for RtypeBitmap<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+impl<Octets, SrcOctets> OctetsFrom<RtypeBitmap<SrcOctets>> for RtypeBitmap<Octets>
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: RtypeBitmap<SrcOctets>) -> Result<Self, ShortBuf> {
         Octets::octets_from(source.0).map(RtypeBitmap)
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<O, OO> PartialEq<RtypeBitmap<OO>> for RtypeBitmap<O>
-where O: AsRef<[u8]>, OO: AsRef<[u8]> {
+where
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+{
     fn eq(&self, other: &RtypeBitmap<OO>) -> bool {
         self.0.as_ref().eq(other.0.as_ref())
     }
 }
 
-impl<O: AsRef<[u8]>> Eq for RtypeBitmap<O> { }
-
+impl<O: AsRef<[u8]>> Eq for RtypeBitmap<O> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<O, OO> PartialOrd<RtypeBitmap<OO>> for RtypeBitmap<O>
-where O: AsRef<[u8]>, OO: AsRef<[u8]> {
+where
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &RtypeBitmap<OO>) -> Option<Ordering> {
         self.0.as_ref().partial_cmp(other.0.as_ref())
     }
 }
 
 impl<O, OO> CanonicalOrd<RtypeBitmap<OO>> for RtypeBitmap<O>
-where O: AsRef<[u8]>, OO: AsRef<[u8]> {
+where
+    O: AsRef<[u8]>,
+    OO: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &RtypeBitmap<OO>) -> Ordering {
         self.0.as_ref().cmp(other.0.as_ref())
     }
@@ -1310,7 +1343,6 @@ impl<O: AsRef<[u8]>> Ord for RtypeBitmap<O> {
     }
 }
 
-
 //--- Hash
 
 impl<O: AsRef<[u8]>> hash::Hash for RtypeBitmap<O> {
@@ -1318,7 +1350,6 @@ impl<O: AsRef<[u8]>> hash::Hash for RtypeBitmap<O> {
         self.0.as_ref().hash(state)
     }
 }
-
 
 //--- IntoIterator
 
@@ -1330,7 +1361,6 @@ impl<'a, Octets: AsRef<[u8]>> IntoIterator for &'a RtypeBitmap<Octets> {
         self.iter()
     }
 }
-
 
 //--- Parse and Compose
 
@@ -1347,22 +1377,16 @@ impl<Ref: OctetsRef> Parse<Ref> for RtypeBitmap<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for RtypeBitmap<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_slice(self.0.as_ref())
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for RtypeBitmap<Bytes> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         let mut builder = RtypeBitmapBuilder::<BytesMut>::new();
         while let Ok(rtype) = Rtype::scan(scanner) {
             builder.add(rtype).unwrap()
@@ -1394,7 +1418,6 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for RtypeBitmap<Octets> {
     }
 }
 
-
 //------------ RtypeBitmapBuilder --------------------------------------------
 
 /// A builder for a record type bitmap.
@@ -1413,10 +1436,12 @@ pub struct RtypeBitmapBuilder<Builder> {
 
 impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
     pub fn new() -> Self
-    where Builder: EmptyBuilder {
+    where
+        Builder: EmptyBuilder,
+    {
         RtypeBitmapBuilder {
             // Start out with the capacity for one block.
-            buf: Builder::with_capacity(34)
+            buf: Builder::with_capacity(34),
         }
     }
 }
@@ -1443,31 +1468,19 @@ impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
         let mut pos = 0;
         while pos < self.buf.as_ref().len() {
             match self.buf.as_ref()[pos].cmp(&block) {
-                Ordering::Equal => {
-                    return Ok(&mut self.buf.as_mut()[pos..pos + 34])
-                }
+                Ordering::Equal => return Ok(&mut self.buf.as_mut()[pos..pos + 34]),
                 Ordering::Greater => {
                     let len = self.buf.as_ref().len() - pos;
                     self.buf.append_slice(&[0; 34])?;
                     let buf = self.buf.as_mut();
                     unsafe {
-                        ptr::copy(
-                            buf.as_ptr().add(pos),
-                            buf.as_mut_ptr().add(pos + 34),
-                            len
-                        );
-                        ptr::write_bytes(
-                            buf.as_mut_ptr().add(pos),
-                            0,
-                            34
-                        );
+                        ptr::copy(buf.as_ptr().add(pos), buf.as_mut_ptr().add(pos + 34), len);
+                        ptr::write_bytes(buf.as_mut_ptr().add(pos), 0, 34);
                     }
                     buf[pos] = block;
-                    return Ok(&mut buf[pos..pos + 34])
+                    return Ok(&mut buf[pos..pos + 34]);
                 }
-                Ordering::Less => {
-                    pos += 34
-                }
+                Ordering::Less => pos += 34,
             }
         }
 
@@ -1487,7 +1500,7 @@ impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
                     ptr::copy(
                         buf.as_ptr().add(src_pos),
                         buf.as_mut_ptr().add(dst_pos),
-                        len
+                        len,
                     )
                 }
             }
@@ -1499,16 +1512,16 @@ impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
     }
 }
 
-
 //--- Default
 
 impl<Builder> Default for RtypeBitmapBuilder<Builder>
-where Builder: OctetsBuilder + EmptyBuilder {
+where
+    Builder: OctetsBuilder + EmptyBuilder,
+{
     fn default() -> Self {
         Self::new()
     }
 }
-
 
 //------------ RtypeBitmapIter -----------------------------------------------
 
@@ -1529,7 +1542,7 @@ pub struct RtypeBitmapIter<'a> {
     octet: usize,
 
     /// Index of the next set bit in the current octet in the current block.
-    bit: u16
+    bit: u16,
 }
 
 impl<'a> RtypeBitmapIter<'a> {
@@ -1537,16 +1550,18 @@ impl<'a> RtypeBitmapIter<'a> {
         if data.is_empty() {
             RtypeBitmapIter {
                 data,
-                block: 0, len: 0, octet: 0, bit: 0
+                block: 0,
+                len: 0,
+                octet: 0,
+                bit: 0,
             }
-        }
-        else {
+        } else {
             let mut res = RtypeBitmapIter {
                 data: &data[2..],
                 block: u16::from(data[0]) << 8,
                 len: usize::from(data[1]),
                 octet: 0,
-                bit: 0
+                bit: 0,
             };
             if res.data[0] & 0x80 == 0 {
                 res.advance()
@@ -1573,7 +1588,7 @@ impl<'a> RtypeBitmapIter<'a> {
                 }
             }
             if self.data[self.octet] & (0x80 >> self.bit) != 0 {
-                return
+                return;
             }
         }
     }
@@ -1584,16 +1599,13 @@ impl<'a> Iterator for RtypeBitmapIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.data.is_empty() {
-            return None
+            return None;
         }
-        let res = Rtype::from_int(
-            self.block | (self.octet as u16) << 3 | self.bit
-        );
+        let res = Rtype::from_int(self.block | (self.octet as u16) << 3 | self.bit);
         self.advance();
         Some(res)
     }
 }
-
 
 //------------ RtypeBitmapError ----------------------------------------------
 
@@ -1603,37 +1615,30 @@ pub enum RtypeBitmapError {
     BadRtypeBitmap,
 }
 
-
 //--- From
 
 impl From<RtypeBitmapError> for ParseError {
     fn from(err: RtypeBitmapError) -> ParseError {
         match err {
             RtypeBitmapError::ShortInput => ParseError::ShortInput,
-            RtypeBitmapError::BadRtypeBitmap => {
-                FormError::new("invalid NSEC bitmap").into()
-            }
+            RtypeBitmapError::BadRtypeBitmap => FormError::new("invalid NSEC bitmap").into(),
         }
     }
 }
-
 
 //--- Display and Error
 
 impl fmt::Display for RtypeBitmapError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            RtypeBitmapError::ShortInput
-                => ParseError::ShortInput.fmt(f),
-            RtypeBitmapError::BadRtypeBitmap
-                => f.write_str("invalid record type bitmap")
+            RtypeBitmapError::ShortInput => ParseError::ShortInput.fmt(f),
+            RtypeBitmapError::BadRtypeBitmap => f.write_str("invalid record type bitmap"),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for RtypeBitmapError { }
-
+impl std::error::Error for RtypeBitmapError {}
 
 //------------ Friendly Helper Functions -------------------------------------
 
@@ -1643,36 +1648,36 @@ fn split_rtype(rtype: Rtype) -> (u8, usize, u8) {
     (
         (rtype >> 8) as u8,
         ((rtype & 0xFF) >> 3) as usize,
-        0b1000_0000 >> (rtype & 0x07)
+        0b1000_0000 >> (rtype & 0x07),
     )
 }
 
 /// Splits the next bitmap window from the bitmap and returns None when there's no next window.
 #[allow(clippy::type_complexity)]
 fn read_window(data: &[u8]) -> Option<((u8, &[u8]), &[u8])> {
-    data.split_first()
-        .and_then(|(n, data)| {
-            data.split_first()
-                .and_then(|(l, data)| if data.len() >= usize::from(*l) {
-                    let (window, data) = data.split_at(usize::from(*l));
-                    Some(((*n, window), data))
-                } else {
-                    None
-                })
+    data.split_first().and_then(|(n, data)| {
+        data.split_first().and_then(|(l, data)| {
+            if data.len() >= usize::from(*l) {
+                let (window, data) = data.split_at(usize::from(*l));
+                Some(((*n, window), data))
+            } else {
+                None
+            }
         })
+    })
 }
 
 //============ Test ==========================================================
 
 #[cfg(test)]
 mod test {
-    use crate::base::iana::Rtype;
     use super::*;
+    use crate::base::iana::Rtype;
 
     #[test]
     fn rtype_split() {
-        assert_eq!(split_rtype(Rtype::A),   (0, 0, 0b01000000));
-        assert_eq!(split_rtype(Rtype::Ns),  (0, 0, 0b00100000));
+        assert_eq!(split_rtype(Rtype::A), (0, 0, 0b01000000));
+        assert_eq!(split_rtype(Rtype::Ns), (0, 0, 0b00100000));
         assert_eq!(split_rtype(Rtype::Caa), (1, 0, 0b01000000));
     }
 
@@ -1727,10 +1732,17 @@ mod test {
 
         let mut builder = RtypeBitmapBuilder::new_vec();
         let types = vec![
-            Rtype::Ns, Rtype::Soa, Rtype::Mx, Rtype::Txt, Rtype::Rrsig,
-            Rtype::Dnskey, Rtype::Nsec3param, Rtype::Spf, Rtype::Caa
+            Rtype::Ns,
+            Rtype::Soa,
+            Rtype::Mx,
+            Rtype::Txt,
+            Rtype::Rrsig,
+            Rtype::Dnskey,
+            Rtype::Nsec3param,
+            Rtype::Spf,
+            Rtype::Caa,
         ];
-        for t in types.iter()  {
+        for t in types.iter() {
             builder.add(*t).unwrap();
         }
 
@@ -1744,7 +1756,9 @@ mod test {
     fn dnskey_key_tag() {
         assert_eq!(
             Dnskey::new(
-                256, 3, SecAlg::RsaSha256,
+                256,
+                3,
+                SecAlg::RsaSha256,
                 base64::decode(
                     "AwEAAcTQyaIe6nt3xSPOG2L/YfwBkOVTJN6mlnZ249O5Rtt3ZSRQHxQS\
                      W61AODYw6bvgxrrGq8eeOuenFjcSYgNAMcBYoEYYmKDW6e9EryW4ZaT/\
@@ -1753,13 +1767,17 @@ mod test {
                      bmuD3Py0IyjlBxzZUXbqLsRL9gYFkCqeTY29Ik7usuzMTa+JRSLz6KGS\
                      5RSJ7CTSMjZg8aNaUbN2dvGhakJPh92HnLvMA3TefFgbKJphFNPA3BWS\
                      KLZ02cRWXqM="
-                ).unwrap()
-            ).key_tag(),
+                )
+                .unwrap()
+            )
+            .key_tag(),
             59944
         );
         assert_eq!(
             Dnskey::new(
-                257, 3, SecAlg::RsaSha256,
+                257,
+                3,
+                SecAlg::RsaSha256,
                 base64::decode(
                     "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTO\
                     iW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN\
@@ -1769,20 +1787,26 @@ mod test {
                     pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLY\
                     A4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws\
                     9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU="
-                ).unwrap()
-            ).key_tag(),
+                )
+                .unwrap()
+            )
+            .key_tag(),
             20326
         );
         assert_eq!(
             Dnskey::new(
-                257, 3, SecAlg::RsaMd5,
+                257,
+                3,
+                SecAlg::RsaMd5,
                 base64::decode(
                     "AwEAAcVaA4jSBIGRrSzpecoJELvKE9+OMuFnL8mmUBsY\
                     lB6epN1CqX7NzwjDpi6VySiEXr0C4uTYkU/L1uMv2mHE\
                     AljThFDJ1GuozJ6gA7jf3lnaGppRg2IoVQ9IVmLORmjw\
                     C+7Eoi12SqybMTicD3Ezwa9XbG1iPjmjhbMrLh7MSQpX"
-                ).unwrap()
-            ).key_tag(),
+                )
+                .unwrap()
+            )
+            .key_tag(),
             18698
         );
     }
@@ -1790,12 +1814,9 @@ mod test {
     #[test]
     #[cfg(feature = "bytes")]
     fn dnskey_flags() {
-        let dnskey = Dnskey::new(
-            257, 3, SecAlg::RsaSha256, bytes::Bytes::new()
-        );
+        let dnskey = Dnskey::new(257, 3, SecAlg::RsaSha256, bytes::Bytes::new());
         assert_eq!(dnskey.is_zsk(), true);
         assert_eq!(dnskey.is_secure_entry_point(), true);
         assert_eq!(dnskey.is_revoked(), false);
     }
 }
-

--- a/src/rdata/rfc5155.rs
+++ b/src/rdata/rfc5155.rs
@@ -9,11 +9,14 @@ use crate::base::charstr::CharStr;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Nsec3HashAlg, Rtype};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature = "master")]
-use crate::master::scan::{CharSource, Scan, ScanError, Scanner, SyntaxError};
+use crate::master::scan::{
+    CharSource, Scan, ScanError, Scanner, SyntaxError,
+};
 use crate::utils::base32;
 #[cfg(feature = "master")]
 use bytes::Bytes;
@@ -229,7 +232,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec3<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Nsec3<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.hash_algorithm.compose(buf)?;
             self.flags.compose(buf)?;
@@ -245,7 +251,9 @@ impl<Octets: AsRef<[u8]>> Compose for Nsec3<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Nsec3<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             Nsec3HashAlg::scan(scanner)?,
             u8::scan(scanner)?,
@@ -258,7 +266,9 @@ impl Scan for Nsec3<Bytes> {
 }
 
 #[cfg(feature = "master")]
-fn scan_salt<C: CharSource>(scanner: &mut Scanner<C>) -> Result<CharStr<Bytes>, ScanError> {
+fn scan_salt<C: CharSource>(
+    scanner: &mut Scanner<C>,
+) -> Result<CharStr<Bytes>, ScanError> {
     if let Ok(()) = scanner.skip_literal("-") {
         Ok(CharStr::empty())
     } else {
@@ -267,8 +277,12 @@ fn scan_salt<C: CharSource>(scanner: &mut Scanner<C>) -> Result<CharStr<Bytes>, 
 }
 
 #[cfg(feature = "master")]
-fn scan_hash<C: CharSource>(scanner: &mut Scanner<C>) -> Result<CharStr<Bytes>, ScanError> {
-    scanner.scan_base32hex_phrase(|bytes| CharStr::from_bytes(bytes).map_err(SyntaxError::content))
+fn scan_hash<C: CharSource>(
+    scanner: &mut Scanner<C>,
+) -> Result<CharStr<Bytes>, ScanError> {
+    scanner.scan_base32hex_phrase(|bytes| {
+        CharStr::from_bytes(bytes).map_err(SyntaxError::content)
+    })
 }
 
 impl<Octets: AsRef<[u8]>> fmt::Display for Nsec3<Octets> {
@@ -346,7 +360,8 @@ impl<Octets> Nsec3param<Octets> {
 
 //--- OctetsFrom
 
-impl<Octets, SrcOctets> OctetsFrom<Nsec3param<SrcOctets>> for Nsec3param<Octets>
+impl<Octets, SrcOctets> OctetsFrom<Nsec3param<SrcOctets>>
+    for Nsec3param<Octets>
 where
     Octets: OctetsFrom<SrcOctets>,
 {
@@ -471,7 +486,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec3param<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Nsec3param<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.hash_algorithm.compose(buf)?;
             self.flags.compose(buf)?;
@@ -485,7 +503,9 @@ impl<Octets: AsRef<[u8]>> Compose for Nsec3param<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Nsec3param<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             Nsec3HashAlg::scan(scanner)?,
             u8::scan(scanner)?,

--- a/src/rdata/rfc5155.rs
+++ b/src/rdata/rfc5155.rs
@@ -4,23 +4,21 @@
 //!
 //! [RFC 5155]: https://tools.ietf.org/html/rfc5155
 
-use core::{fmt, hash};
-use core::cmp::Ordering;
-#[cfg(feature="master")] use bytes::Bytes;
+use super::rfc4034::RtypeBitmap;
 use crate::base::charstr::CharStr;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Nsec3HashAlg, Rtype};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
-    ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
-#[cfg(feature="master")] use crate::master::scan::{
-    CharSource, Scan, Scanner, ScanError, SyntaxError
-};
+#[cfg(feature = "master")]
+use crate::master::scan::{CharSource, Scan, ScanError, Scanner, SyntaxError};
 use crate::utils::base32;
-use super::rfc4034::RtypeBitmap;
-
+#[cfg(feature = "master")]
+use bytes::Bytes;
+use core::cmp::Ordering;
+use core::{fmt, hash};
 
 //------------ Nsec3 ---------------------------------------------------------
 
@@ -41,16 +39,23 @@ impl<Octets> Nsec3<Octets> {
         iterations: u16,
         salt: CharStr<Octets>,
         next_owner: CharStr<Octets>,
-        types: RtypeBitmap<Octets>
+        types: RtypeBitmap<Octets>,
     ) -> Self {
-        Nsec3 { hash_algorithm, flags, iterations, salt, next_owner, types }
+        Nsec3 {
+            hash_algorithm,
+            flags,
+            iterations,
+            salt,
+            next_owner,
+            types,
+        }
     }
 
     pub fn hash_algorithm(&self) -> Nsec3HashAlg {
         self.hash_algorithm
     }
 
-    pub fn flags(&self) -> u8 { 
+    pub fn flags(&self) -> u8 {
         self.flags
     }
 
@@ -75,14 +80,17 @@ impl<Octets> Nsec3<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Nsec3<SrcOctets>> for Nsec3<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Nsec3<SrcOctets>) -> Result<Self, ShortBuf> {
         Ok(Nsec3::new(
-            source.hash_algorithm, source.flags, source.iterations,
+            source.hash_algorithm,
+            source.flags,
+            source.iterations,
             CharStr::octets_from(source.salt)?,
             CharStr::octets_from(source.next_owner)?,
             RtypeBitmap::octets_from(source.types)?,
@@ -90,75 +98,82 @@ where Octets: OctetsFrom<SrcOctets> {
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<Octets, Other> PartialEq<Nsec3<Other>> for Nsec3<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Nsec3<Other>) -> bool {
         self.hash_algorithm == other.hash_algorithm
-        && self.flags == other.flags
-        && self.iterations == other.iterations
-        && self.salt == other.salt
-        && self.next_owner == other.next_owner
-        && self.types == other.types
+            && self.flags == other.flags
+            && self.iterations == other.iterations
+            && self.salt == other.salt
+            && self.next_owner == other.next_owner
+            && self.types == other.types
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Nsec3<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Nsec3<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<Octets, Other> PartialOrd<Nsec3<Other>> for Nsec3<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Nsec3<Other>) -> Option<Ordering> {
         match self.hash_algorithm.partial_cmp(&other.hash_algorithm) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.flags.partial_cmp(&other.flags) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.iterations.partial_cmp(&other.iterations) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.salt.partial_cmp(&other.salt) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.next_owner.partial_cmp(&other.next_owner) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         self.types.partial_cmp(&other.types)
     }
 }
 
 impl<Octets, Other> CanonicalOrd<Nsec3<Other>> for Nsec3<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Nsec3<Other>) -> Ordering {
         match self.hash_algorithm.cmp(&other.hash_algorithm) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.flags.cmp(&other.flags) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.iterations.cmp(&other.iterations) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.salt.canonical_cmp(&other.salt) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.next_owner.canonical_cmp(&other.next_owner) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.types.canonical_cmp(&other.types)
     }
@@ -169,7 +184,6 @@ impl<Octets: AsRef<[u8]>> Ord for Nsec3<Octets> {
         self.canonical_cmp(other)
     }
 }
-
 
 //--- Hash
 
@@ -184,19 +198,23 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Nsec3<Octets> {
     }
 }
 
-
 //--- ParseAll and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Nsec3<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let hash_algorithm = Nsec3HashAlg::parse(parser)?;
         let flags = u8::parse(parser)?;
-        let iterations = u16:: parse(parser)?;
+        let iterations = u16::parse(parser)?;
         let salt = CharStr::parse(parser)?;
         let next_owner = CharStr::parse(parser)?;
         let types = RtypeBitmap::parse(parser)?;
         Ok(Self::new(
-            hash_algorithm, flags, iterations, salt, next_owner, types
+            hash_algorithm,
+            flags,
+            iterations,
+            salt,
+            next_owner,
+            types,
         ))
     }
 
@@ -211,10 +229,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec3<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Nsec3<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.hash_algorithm.compose(buf)?;
             self.flags.compose(buf)?;
@@ -226,50 +241,41 @@ impl<Octets: AsRef<[u8]>> Compose for Nsec3<Octets> {
     }
 }
 
-
 //--- Scan, Display, and Debug
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for Nsec3<Bytes> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(
             Nsec3HashAlg::scan(scanner)?,
             u8::scan(scanner)?,
             u16::scan(scanner)?,
             scan_salt(scanner)?,
             scan_hash(scanner)?,
-            RtypeBitmap::scan(scanner)?
+            RtypeBitmap::scan(scanner)?,
         ))
     }
 }
 
-#[cfg(feature="master")]
-fn scan_salt<C: CharSource>(
-    scanner: &mut Scanner<C>
-) -> Result<CharStr<Bytes>, ScanError> {
-    if let Ok(()) = scanner.skip_literal("-") {    
+#[cfg(feature = "master")]
+fn scan_salt<C: CharSource>(scanner: &mut Scanner<C>) -> Result<CharStr<Bytes>, ScanError> {
+    if let Ok(()) = scanner.skip_literal("-") {
         Ok(CharStr::empty())
-    }
-    else {
+    } else {
         CharStr::scan_hex(scanner)
     }
 }
 
-#[cfg(feature="master")]
-fn scan_hash<C: CharSource>(
-    scanner: &mut Scanner<C>
-) -> Result<CharStr<Bytes>, ScanError> {
-    scanner.scan_base32hex_phrase(|bytes| {
-        CharStr::from_bytes(bytes).map_err(SyntaxError::content)
-    })
+#[cfg(feature = "master")]
+fn scan_hash<C: CharSource>(scanner: &mut Scanner<C>) -> Result<CharStr<Bytes>, ScanError> {
+    scanner.scan_base32hex_phrase(|bytes| CharStr::from_bytes(bytes).map_err(SyntaxError::content))
 }
 
 impl<Octets: AsRef<[u8]>> fmt::Display for Nsec3<Octets> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
-            f, "{} {} {} {:X} ",
+            f,
+            "{} {} {} {:X} ",
             self.hash_algorithm, self.flags, self.iterations, self.salt
         )?;
         base32::display_hex(&self.next_owner, f)?;
@@ -290,16 +296,13 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Nsec3<Octets> {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<Octets> RtypeRecordData for Nsec3<Octets> {
     const RTYPE: Rtype = Rtype::Nsec3;
 }
 
-
 //------------ Nsec3param ----------------------------------------------------
-
 
 #[derive(Clone)]
 pub struct Nsec3param<Octets> {
@@ -314,9 +317,14 @@ impl<Octets> Nsec3param<Octets> {
         hash_algorithm: Nsec3HashAlg,
         flags: u8,
         iterations: u16,
-        salt: CharStr<Octets>
+        salt: CharStr<Octets>,
     ) -> Self {
-        Nsec3param { hash_algorithm, flags, iterations, salt } 
+        Nsec3param {
+            hash_algorithm,
+            flags,
+            iterations,
+            salt,
+        }
     }
 
     pub fn hash_algorithm(&self) -> Nsec3HashAlg {
@@ -336,71 +344,80 @@ impl<Octets> Nsec3param<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
-impl<Octets, SrcOctets>
-    OctetsFrom<Nsec3param<SrcOctets>> for Nsec3param<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+impl<Octets, SrcOctets> OctetsFrom<Nsec3param<SrcOctets>> for Nsec3param<Octets>
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Nsec3param<SrcOctets>) -> Result<Self, ShortBuf> {
         Ok(Nsec3param::new(
-            source.hash_algorithm, source.flags, source.iterations,
+            source.hash_algorithm,
+            source.flags,
+            source.iterations,
             CharStr::octets_from(source.salt)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<Octets, Other> PartialEq<Nsec3param<Other>> for Nsec3param<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Nsec3param<Other>) -> bool {
         self.hash_algorithm == other.hash_algorithm
-        && self.flags == other.flags
-        && self.iterations == other.iterations
-        && self.salt == other.salt
+            && self.flags == other.flags
+            && self.iterations == other.iterations
+            && self.salt == other.salt
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Nsec3param<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Nsec3param<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<Octets, Other> PartialOrd<Nsec3param<Other>> for Nsec3param<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Nsec3param<Other>) -> Option<Ordering> {
         match self.hash_algorithm.partial_cmp(&other.hash_algorithm) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.flags.partial_cmp(&other.flags) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.iterations.partial_cmp(&other.iterations) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         self.salt.partial_cmp(&other.salt)
     }
 }
 
 impl<Octets, Other> CanonicalOrd<Nsec3param<Other>> for Nsec3param<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Nsec3param<Other>) -> Ordering {
         match self.hash_algorithm.cmp(&other.hash_algorithm) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.flags.cmp(&other.flags) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.iterations.cmp(&other.iterations) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.salt.canonical_cmp(&other.salt)
     }
@@ -409,21 +426,20 @@ where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
 impl<Octets: AsRef<[u8]>> Ord for Nsec3param<Octets> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.hash_algorithm.cmp(&other.hash_algorithm) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.flags.cmp(&other.flags) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.iterations.cmp(&other.iterations) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.salt.cmp(&other.salt)
     }
 }
-
 
 //--- Hash
 
@@ -435,7 +451,6 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Nsec3param<Octets> {
         self.salt.hash(state);
     }
 }
-
 
 //--- Parse, ParseAll, and Compose
 
@@ -456,10 +471,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec3param<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Nsec3param<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.hash_algorithm.compose(buf)?;
             self.flags.compose(buf)?;
@@ -469,19 +481,16 @@ impl<Octets: AsRef<[u8]>> Compose for Nsec3param<Octets> {
     }
 }
 
-
 //--- Scan, Display, and Debug
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for Nsec3param<Bytes> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(
             Nsec3HashAlg::scan(scanner)?,
             u8::scan(scanner)?,
             u16::scan(scanner)?,
-            scan_salt(scanner)?
+            scan_salt(scanner)?,
         ))
     }
 }
@@ -489,7 +498,8 @@ impl Scan for Nsec3param<Bytes> {
 impl<Octets: AsRef<[u8]>> fmt::Display for Nsec3param<Octets> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
-            f, "{} {} {} {:X}",
+            f,
+            "{} {} {} {:X}",
             self.hash_algorithm, self.flags, self.iterations, self.salt
         )
     }
@@ -506,10 +516,8 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Nsec3param<Octets> {
     }
 }
 
-
 //--- RtypeRecordData
 
 impl<Octets> RtypeRecordData for Nsec3param<Octets> {
     const RTYPE: Rtype = Rtype::Nsec3param;
 }
-

--- a/src/rdata/rfc6672.rs
+++ b/src/rdata/rfc6672.rs
@@ -2,8 +2,7 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
-    ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature = "master")]
@@ -27,10 +26,10 @@ dname_type! {
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod test {
-    use std::vec::Vec;
     use crate::base::name::Dname;
     use crate::rdata::rfc6672;
     use core::str::FromStr;
+    use std::vec::Vec;
 
     #[test]
     fn create_dname() {

--- a/src/rdata/rfc6672.rs
+++ b/src/rdata/rfc6672.rs
@@ -2,7 +2,8 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{ParsedDname, ToDname};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature = "master")]

--- a/src/rdata/rfc7344.rs
+++ b/src/rdata/rfc7344.rs
@@ -4,7 +4,8 @@
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
+    ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature = "master")]
@@ -26,7 +27,12 @@ pub struct Cdnskey<Octets> {
 }
 
 impl<Octets> Cdnskey<Octets> {
-    pub fn new(flags: u16, protocol: u8, algorithm: SecAlg, public_key: Octets) -> Self {
+    pub fn new(
+        flags: u16,
+        protocol: u8,
+        algorithm: SecAlg,
+        public_key: Octets,
+    ) -> Self {
         Cdnskey {
             flags,
             protocol,
@@ -162,7 +168,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Cdnskey<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Cdnskey<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.flags.compose(buf)?;
             self.protocol.compose(buf)?;
@@ -176,7 +185,9 @@ impl<Octets: AsRef<[u8]>> Compose for Cdnskey<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Cdnskey<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             u8::scan(scanner)?,
@@ -223,7 +234,12 @@ pub struct Cds<Octets> {
 }
 
 impl<Octets> Cds<Octets> {
-    pub fn new(key_tag: u16, algorithm: SecAlg, digest_type: DigestAlg, digest: Octets) -> Self {
+    pub fn new(
+        key_tag: u16,
+        algorithm: SecAlg,
+        digest_type: DigestAlg,
+        digest: Octets,
+    ) -> Self {
         Cds {
             key_tag,
             algorithm,
@@ -375,7 +391,10 @@ impl<Ref: OctetsRef> Parse<Ref> for Cds<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Cds<Octets> {
-    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(
+        &self,
+        target: &mut T,
+    ) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.key_tag.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -389,7 +408,9 @@ impl<Octets: AsRef<[u8]>> Compose for Cds<Octets> {
 
 #[cfg(feature = "master")]
 impl Scan for Cds<Bytes> {
-    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(
+        scanner: &mut Scanner<C>,
+    ) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             SecAlg::scan(scanner)?,

--- a/src/rdata/rfc7344.rs
+++ b/src/rdata/rfc7344.rs
@@ -1,21 +1,19 @@
 //! Record data from [RFC 7344]: CDS and CDNSKEY records.
 //!
 //! [RFC 7344]: https://tools.ietf.org/html/rfc7344
-use core::{fmt, hash};
-use core::cmp::Ordering;
-#[cfg(feature="master")] use bytes::Bytes;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
-    ShortBuf
+    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
-#[cfg(feature="master")] use crate::master::scan::{
-    CharSource, Scan, ScanError, Scanner
-};
+#[cfg(feature = "master")]
+use crate::master::scan::{CharSource, Scan, ScanError, Scanner};
 use crate::utils::base64;
-
+#[cfg(feature = "master")]
+use bytes::Bytes;
+use core::cmp::Ordering;
+use core::{fmt, hash};
 
 //------------ Cdnskey --------------------------------------------------------
 
@@ -28,12 +26,7 @@ pub struct Cdnskey<Octets> {
 }
 
 impl<Octets> Cdnskey<Octets> {
-    pub fn new(
-        flags: u16,
-        protocol: u8,
-        algorithm: SecAlg,
-        public_key: Octets
-    ) -> Self {
+    pub fn new(flags: u16, protocol: u8, algorithm: SecAlg, public_key: Octets) -> Self {
         Cdnskey {
             flags,
             protocol,
@@ -59,58 +52,68 @@ impl<Octets> Cdnskey<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Cdnskey<SrcOctets>> for Cdnskey<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Cdnskey<SrcOctets>) -> Result<Self, ShortBuf> {
         Ok(Cdnskey::new(
-            source.flags, source.protocol, source.algorithm,
+            source.flags,
+            source.protocol,
+            source.algorithm,
             Octets::octets_from(source.public_key)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
-impl<Octets, Other> PartialEq<Cdnskey<Other>> for Cdnskey<Octets> 
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+impl<Octets, Other> PartialEq<Cdnskey<Other>> for Cdnskey<Octets>
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Cdnskey<Other>) -> bool {
         self.flags == other.flags
-        && self.protocol == other.protocol
-        && self.algorithm == other.algorithm
-        && self.public_key.as_ref() == other.public_key.as_ref()
+            && self.protocol == other.protocol
+            && self.algorithm == other.algorithm
+            && self.public_key.as_ref() == other.public_key.as_ref()
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Cdnskey<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Cdnskey<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
-impl<Octets, Other> PartialOrd<Cdnskey<Other>> for Cdnskey<Octets> 
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+impl<Octets, Other> PartialOrd<Cdnskey<Other>> for Cdnskey<Octets>
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Cdnskey<Other>) -> Option<Ordering> {
         Some(self.canonical_cmp(other))
     }
 }
 
-impl<Octets, Other> CanonicalOrd<Cdnskey<Other>> for Cdnskey<Octets> 
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+impl<Octets, Other> CanonicalOrd<Cdnskey<Other>> for Cdnskey<Octets>
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Cdnskey<Other>) -> Ordering {
         match self.flags.cmp(&other.flags) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.protocol.cmp(&other.protocol) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.algorithm.cmp(&other.algorithm) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.public_key.as_ref().cmp(other.public_key.as_ref())
     }
@@ -121,7 +124,6 @@ impl<Octets: AsRef<[u8]>> Ord for Cdnskey<Octets> {
         self.canonical_cmp(other)
     }
 }
-
 
 //--- Hash
 
@@ -134,26 +136,25 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Cdnskey<Octets> {
     }
 }
 
-
 //--- ParseAll and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Cdnskey<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = match parser.remaining().checked_sub(4) {
             Some(len) => len,
-            None => return Err(ParseError::ShortInput)
+            None => return Err(ParseError::ShortInput),
         };
         Ok(Self::new(
             u16::parse(parser)?,
             u8::parse(parser)?,
             SecAlg::parse(parser)?,
-            parser.parse_octets(len)?
+            parser.parse_octets(len)?,
         ))
     }
 
     fn skip(parser: &mut Parser<Ref>) -> Result<(), ParseError> {
         if parser.remaining() < 4 {
-            return Err(ParseError::ShortInput)
+            return Err(ParseError::ShortInput);
         }
         parser.advance_to_end();
         Ok(())
@@ -161,10 +162,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Cdnskey<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Cdnskey<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.flags.compose(buf)?;
             self.protocol.compose(buf)?;
@@ -174,19 +172,16 @@ impl<Octets: AsRef<[u8]>> Compose for Cdnskey<Octets> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for Cdnskey<Bytes> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             u8::scan(scanner)?,
             SecAlg::scan(scanner)?,
-            scanner.scan_base64_phrases(Ok)?
+            scanner.scan_base64_phrases(Ok)?,
         ))
     }
 }
@@ -197,7 +192,6 @@ impl<Octets: AsRef<[u8]>> fmt::Display for Cdnskey<Octets> {
         base64::display(&self.public_key, f)
     }
 }
-
 
 //--- Debug
 
@@ -212,13 +206,11 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Cdnskey<Octets> {
     }
 }
 
-
 //--- RecordData
 
 impl<Octets> RtypeRecordData for Cdnskey<Octets> {
     const RTYPE: Rtype = Rtype::Cdnskey;
 }
-
 
 //------------ Cds -----------------------------------------------------------
 
@@ -231,13 +223,13 @@ pub struct Cds<Octets> {
 }
 
 impl<Octets> Cds<Octets> {
-    pub fn new(
-        key_tag: u16,
-        algorithm: SecAlg,
-        digest_type: DigestAlg,
-        digest: Octets
-    ) -> Self {
-        Cds { key_tag, algorithm, digest_type, digest }
+    pub fn new(key_tag: u16, algorithm: SecAlg, digest_type: DigestAlg, digest: Octets) -> Self {
+        Cds {
+            key_tag,
+            algorithm,
+            digest_type,
+            digest,
+        }
     }
 
     pub fn key_tag(&self) -> u16 {
@@ -261,70 +253,80 @@ impl<Octets> Cds<Octets> {
     }
 }
 
-
 //--- OctetsFrom
 
 impl<Octets, SrcOctets> OctetsFrom<Cds<SrcOctets>> for Cds<Octets>
-where Octets: OctetsFrom<SrcOctets> {
+where
+    Octets: OctetsFrom<SrcOctets>,
+{
     fn octets_from(source: Cds<SrcOctets>) -> Result<Self, ShortBuf> {
         Ok(Cds::new(
-            source.key_tag, source.algorithm, source.digest_type,
+            source.key_tag,
+            source.algorithm,
+            source.digest_type,
             Octets::octets_from(source.digest)?,
         ))
     }
 }
 
-
 //--- PartialEq and Eq
 
 impl<Octets, Other> PartialEq<Cds<Other>> for Cds<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn eq(&self, other: &Cds<Other>) -> bool {
         self.key_tag == other.key_tag
-        && self.algorithm == other.algorithm
-        && self.digest_type == other.digest_type
-        && self.digest.as_ref().eq(other.digest.as_ref())
+            && self.algorithm == other.algorithm
+            && self.digest_type == other.digest_type
+            && self.digest.as_ref().eq(other.digest.as_ref())
     }
 }
 
-impl<Octets: AsRef<[u8]>> Eq for Cds<Octets> { }
-
+impl<Octets: AsRef<[u8]>> Eq for Cds<Octets> {}
 
 //--- PartialOrd, CanonicalOrd, and Ord
 
 impl<Octets, Other> PartialOrd<Cds<Other>> for Cds<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn partial_cmp(&self, other: &Cds<Other>) -> Option<Ordering> {
         match self.key_tag.partial_cmp(&other.key_tag) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.algorithm.partial_cmp(&other.algorithm) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         match self.digest_type.partial_cmp(&other.digest_type) {
-            Some(Ordering::Equal) => { }
-            other => return other
+            Some(Ordering::Equal) => {}
+            other => return other,
         }
         self.digest.as_ref().partial_cmp(other.digest.as_ref())
     }
 }
 
 impl<Octets, Other> CanonicalOrd<Cds<Other>> for Cds<Octets>
-where Octets: AsRef<[u8]>, Other: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+    Other: AsRef<[u8]>,
+{
     fn canonical_cmp(&self, other: &Cds<Other>) -> Ordering {
         match self.key_tag.cmp(&other.key_tag) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.algorithm.cmp(&other.algorithm) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         match self.digest_type.cmp(&other.digest_type) {
-            Ordering::Equal => { }
-            other => return other
+            Ordering::Equal => {}
+            other => return other,
         }
         self.digest.as_ref().cmp(other.digest.as_ref())
     }
@@ -335,7 +337,6 @@ impl<Octets: AsRef<[u8]>> Ord for Cds<Octets> {
         self.canonical_cmp(other)
     }
 }
-
 
 //--- Hash
 
@@ -348,20 +349,19 @@ impl<Octets: AsRef<[u8]>> hash::Hash for Cds<Octets> {
     }
 }
 
-
 //--- Parse and Compose
 
 impl<Ref: OctetsRef> Parse<Ref> for Cds<Ref::Range> {
     fn parse(parser: &mut Parser<Ref>) -> Result<Self, ParseError> {
         let len = match parser.remaining().checked_sub(4) {
             Some(len) => len,
-            None => return Err(ParseError::ShortInput)
+            None => return Err(ParseError::ShortInput),
         };
         Ok(Self::new(
             u16::parse(parser)?,
             SecAlg::parse(parser)?,
             DigestAlg::parse(parser)?,
-            parser.parse_octets(len)?
+            parser.parse_octets(len)?,
         ))
     }
 
@@ -375,10 +375,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Cds<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Cds<Octets> {
-    fn compose<T: OctetsBuilder>(
-        &self,
-        target: &mut T
-    ) -> Result<(), ShortBuf> {
+    fn compose<T: OctetsBuilder>(&self, target: &mut T) -> Result<(), ShortBuf> {
         target.append_all(|buf| {
             self.key_tag.compose(buf)?;
             self.algorithm.compose(buf)?;
@@ -388,14 +385,11 @@ impl<Octets: AsRef<[u8]>> Compose for Cds<Octets> {
     }
 }
 
-
 //--- Scan and Display
 
-#[cfg(feature="master")]
+#[cfg(feature = "master")]
 impl Scan for Cds<Bytes> {
-    fn scan<C: CharSource>(
-        scanner: &mut Scanner<C>
-    ) -> Result<Self, ScanError> {
+    fn scan<C: CharSource>(scanner: &mut Scanner<C>) -> Result<Self, ScanError> {
         Ok(Self::new(
             u16::scan(scanner)?,
             SecAlg::scan(scanner)?,
@@ -407,15 +401,17 @@ impl Scan for Cds<Bytes> {
 
 impl<Octets: AsRef<[u8]>> fmt::Display for Cds<Octets> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} {} ", self.key_tag, self.algorithm,
-               self.digest_type)?;
+        write!(
+            f,
+            "{} {} {} ",
+            self.key_tag, self.algorithm, self.digest_type
+        )?;
         for ch in self.digest.as_ref() {
             write!(f, "{:02x}", ch)?
         }
         Ok(())
     }
 }
-
 
 //--- Debug
 
@@ -429,7 +425,6 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for Cds<Octets> {
             .finish()
     }
 }
-
 
 //--- RtypeRecordData
 

--- a/src/resolv/lookup/mod.rs
+++ b/src/resolv/lookup/mod.rs
@@ -10,4 +10,3 @@ pub use self::srv::lookup_srv;
 pub mod addr;
 pub mod host;
 pub mod srv;
-

--- a/src/resolv/lookup/srv.rs
+++ b/src/resolv/lookup/srv.rs
@@ -88,7 +88,9 @@ impl FoundSrvs {
         // that we can use as the base for the stream: We turn the result into
         // two options of the two cases and chain those up.
         let iter = match self.items {
-            Ok(vec) => Some(vec.into_iter()).into_iter().flatten().chain(None),
+            Ok(vec) => {
+                Some(vec.into_iter()).into_iter().flatten().chain(None)
+            }
             Err(one) => None.into_iter().flatten().chain(Some(one)),
         };
         stream::iter(iter).then(move |item| item.resolve(resolver))
@@ -99,7 +101,8 @@ impl FoundSrvs {
     /// Reorders merged results as if they were from a single query.
     pub fn merge(&mut self, other: &mut Self) {
         if self.items.is_err() {
-            let one = mem::replace(&mut self.items, Ok(Vec::new())).unwrap_err();
+            let one =
+                mem::replace(&mut self.items, Ok(Vec::new())).unwrap_err();
             self.items.as_mut().unwrap().push(one);
         }
         match self.items {
@@ -121,7 +124,8 @@ impl FoundSrvs {
         fallback_name: impl ToDname,
         fallback_port: u16,
     ) -> Result<Option<Self>, SrvError> {
-        let name = answer.canonical_name().ok_or(SrvError::MalformedAnswer)?;
+        let name =
+            answer.canonical_name().ok_or(SrvError::MalformedAnswer)?;
         let mut items = Self::process_records(answer, &name)?;
 
         if items.is_empty() {
@@ -156,7 +160,10 @@ impl FoundSrvs {
         Ok(res)
     }
 
-    fn process_additional(items: &mut [SrvItem], answer: &Message<&[u8]>) -> Result<(), SrvError> {
+    fn process_additional(
+        items: &mut [SrvItem],
+        answer: &Message<&[u8]>,
+    ) -> Result<(), SrvError> {
         let additional = answer.additional()?;
         for item in items {
             let mut addrs = Vec::new();
@@ -165,7 +172,9 @@ impl FoundSrvs {
                     Ok(record) => record,
                     Err(_) => continue,
                 };
-                if record.class() != Class::In || record.owner() != item.target() {
+                if record.class() != Class::In
+                    || record.owner() != item.target()
+                {
                     continue;
                 }
                 if let Ok(Some(record)) = record.to_record::<A>() {
@@ -195,7 +204,10 @@ impl FoundSrvs {
         for i in 0..items.len() {
             if current_prio != items[i].priority() {
                 current_prio = items[i].priority();
-                Self::reorder_by_weight(&mut items[first_index..i], weight_sum);
+                Self::reorder_by_weight(
+                    &mut items[first_index..i],
+                    weight_sum,
+                );
                 weight_sum = 0;
                 first_index = i;
             }
@@ -256,7 +268,10 @@ impl SrvItem {
     }
 
     // Resolves the target.
-    pub async fn resolve<R: Resolver>(self, resolver: &R) -> Result<ResolvedSrvItem, io::Error>
+    pub async fn resolve<R: Resolver>(
+        self,
+        resolver: &R,
+    ) -> Result<ResolvedSrvItem, io::Error>
     where
         for<'a> &'a R::Octets: OctetsRef,
     {

--- a/src/resolv/resolver.rs
+++ b/src/resolv/resolver.rs
@@ -1,11 +1,10 @@
 //! The trait defining an abstract resolver.
 
-use std::io;
-use futures::future::Future;
-use crate::base::name::ToDname;
 use crate::base::message::Message;
+use crate::base::name::ToDname;
 use crate::base::question::Question;
-
+use futures::future::Future;
+use std::io;
 
 //----------- Resolver -------------------------------------------------------
 
@@ -33,9 +32,10 @@ pub trait Resolver {
     /// The method takes anything that can be converted into a question and
     /// produces a future trying to answer the question.
     fn query<N, Q>(&self, question: Q) -> Self::Query
-    where N: ToDname, Q: Into<Question<N>>;
+    where
+        N: ToDname,
+        Q: Into<Question<N>>;
 }
-
 
 //------------ SearchNames ---------------------------------------------------
 
@@ -54,4 +54,3 @@ pub trait SearchNames {
     /// Returns an iterator over the search suffixes.
     fn search_iter(&self) -> Self::Iter;
 }
-

--- a/src/resolv/stub/conf.rs
+++ b/src/resolv/stub/conf.rs
@@ -349,7 +349,8 @@ impl ResolvConf {
         if self.servers.is_empty() {
             // glibc just simply uses 127.0.0.1:53. Let's do that, too,
             // and claim it is for compatibility.
-            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 53);
+            let addr =
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 53);
             self.servers.push(ServerConf::new(addr, Transport::Udp));
             self.servers.push(ServerConf::new(addr, Transport::Tcp));
         }
@@ -376,7 +377,10 @@ impl ResolvConf {
 ///
 impl ResolvConf {
     /// Parses the configuration from a file.
-    pub fn parse_file<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+    pub fn parse_file<P: AsRef<Path>>(
+        &mut self,
+        path: P,
+    ) -> Result<(), Error> {
         let mut file = fs::File::open(path)?;
         self.parse(&mut file)
     }
@@ -391,7 +395,10 @@ impl ResolvConf {
             let line = line?;
             let line = line.trim_end();
 
-            if line.is_empty() || line.starts_with(';') || line.starts_with('#') {
+            if line.is_empty()
+                || line.starts_with(';')
+                || line.starts_with('#')
+            {
                 continue;
             }
 
@@ -401,7 +408,8 @@ impl ResolvConf {
                 Some("nameserver") => self.parse_nameserver(words)?,
                 Some("domain") => self.parse_domain(words)?,
                 Some("search") => self.parse_search(words)?,
-                Some("sortlist") => { /* TODO: self.parse_sortlist(words)? */ }
+                Some("sortlist") => { /* TODO: self.parse_sortlist(words)? */
+                }
                 Some("options") => self.parse_options(words)?,
                 _ => return Err(Error::ParseError),
             }
@@ -409,7 +417,10 @@ impl ResolvConf {
         Ok(())
     }
 
-    fn parse_nameserver(&mut self, mut words: SplitWhitespace) -> Result<(), Error> {
+    fn parse_nameserver(
+        &mut self,
+        mut words: SplitWhitespace,
+    ) -> Result<(), Error> {
         use std::net::ToSocketAddrs;
 
         for addr in (next_word(&mut words)?, 53).to_socket_addrs()? {
@@ -419,7 +430,10 @@ impl ResolvConf {
         no_more_words(words)
     }
 
-    fn parse_domain(&mut self, mut words: SplitWhitespace) -> Result<(), Error> {
+    fn parse_domain(
+        &mut self,
+        mut words: SplitWhitespace,
+    ) -> Result<(), Error> {
         let domain = SearchSuffix::from_str(next_word(&mut words)?)?;
         self.options.search = domain.into();
         no_more_words(words)
@@ -457,7 +471,9 @@ impl ResolvConf {
             match split_arg(word)? {
                 ("debug", None) => {}
                 ("ndots", Some(n)) => self.options.ndots = n,
-                ("timeout", Some(n)) => self.options.timeout = Duration::new(n as u64, 0),
+                ("timeout", Some(n)) => {
+                    self.options.timeout = Duration::new(n as u64, 0)
+                }
                 ("attempts", Some(n)) => self.options.attempts = n,
                 ("rotate", None) => self.options.rotate = true,
                 ("no-check-names", None) => self.options.no_check_name = true,
@@ -466,8 +482,12 @@ impl ResolvConf {
                 ("ip6-dotint", None) => self.options.use_ip6dotint = true,
                 ("no-ip6-dotint", None) => self.options.use_ip6dotint = false,
                 ("edns0", None) => self.options.use_edns0 = true,
-                ("single-request", None) => self.options.single_request = true,
-                ("single-request-reopen", None) => self.options.single_request_reopen = true,
+                ("single-request", None) => {
+                    self.options.single_request = true
+                }
+                ("single-request-reopen", None) => {
+                    self.options.single_request_reopen = true
+                }
                 ("no-tld-query", None) => self.options.no_tld_query = true,
                 ("use-vc", None) => self.options.use_vc = true,
                 // Ignore unknown or misformated options.
@@ -524,7 +544,8 @@ impl fmt::Display for ResolvConf {
         }
         if self.options.timeout != Duration::new(5, 0) {
             // XXX This ignores fractional seconds.
-            options.push(format!("timeout:{}", self.options.timeout.as_secs()));
+            options
+                .push(format!("timeout:{}", self.options.timeout.as_secs()));
         }
         if self.options.attempts != 2 {
             options.push(format!("attempts:{}", self.options.attempts));
@@ -661,7 +682,9 @@ impl ops::Deref for SearchList {
 // These are here to wrap stuff into Results.
 
 /// Returns a reference to the next word or an error.
-fn next_word<'a>(words: &'a mut str::SplitWhitespace) -> Result<&'a str, Error> {
+fn next_word<'a>(
+    words: &'a mut str::SplitWhitespace,
+) -> Result<&'a str, Error> {
     match words.next() {
         Some(word) => Ok(word),
         None => Err(Error::ParseError),

--- a/src/sign/key.rs
+++ b/src/sign/key.rs
@@ -1,7 +1,6 @@
 use crate::base::iana::SecAlg;
 use crate::base::name::ToDname;
-use crate::rdata::{Ds, Dnskey};
-
+use crate::rdata::{Dnskey, Ds};
 
 pub trait SigningKey {
     type Octets: AsRef<[u8]>;
@@ -22,7 +21,6 @@ pub trait SigningKey {
     fn sign(&self, data: &[u8]) -> Result<Self::Signature, Self::Error>;
 }
 
-
 impl<'a, K: SigningKey> SigningKey for &'a K {
     type Octets = K::Octets;
     type Signature = K::Signature;
@@ -31,10 +29,7 @@ impl<'a, K: SigningKey> SigningKey for &'a K {
     fn dnskey(&self) -> Result<Dnskey<Self::Octets>, Self::Error> {
         (*self).dnskey()
     }
-    fn ds<N: ToDname>(
-        &self,
-        owner: N
-    ) -> Result<Ds<Self::Octets>, Self::Error> {
+    fn ds<N: ToDname>(&self, owner: N) -> Result<Ds<Self::Octets>, Self::Error> {
         (*self).ds(owner)
     }
 
@@ -50,4 +45,3 @@ impl<'a, K: SigningKey> SigningKey for &'a K {
         (*self).sign(data)
     }
 }
-

--- a/src/sign/key.rs
+++ b/src/sign/key.rs
@@ -8,7 +8,10 @@ pub trait SigningKey {
     type Error;
 
     fn dnskey(&self) -> Result<Dnskey<Self::Octets>, Self::Error>;
-    fn ds<N: ToDname>(&self, owner: N) -> Result<Ds<Self::Octets>, Self::Error>;
+    fn ds<N: ToDname>(
+        &self,
+        owner: N,
+    ) -> Result<Ds<Self::Octets>, Self::Error>;
 
     fn algorithm(&self) -> Result<SecAlg, Self::Error> {
         self.dnskey().map(|dnskey| dnskey.algorithm())
@@ -29,7 +32,10 @@ impl<'a, K: SigningKey> SigningKey for &'a K {
     fn dnskey(&self) -> Result<Dnskey<Self::Octets>, Self::Error> {
         (*self).dnskey()
     }
-    fn ds<N: ToDname>(&self, owner: N) -> Result<Ds<Self::Octets>, Self::Error> {
+    fn ds<N: ToDname>(
+        &self,
+        owner: N,
+    ) -> Result<Ds<Self::Octets>, Self::Error> {
         (*self).ds(owner)
     }
 

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -5,5 +5,5 @@
 
 pub mod key;
 //pub mod openssl;
-pub mod ring;
 pub mod records;
+pub mod ring;

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -125,7 +125,9 @@ impl<N, D> SortedRecords<N, D> {
                     // If we are at a zone cut, we only sign DS and NSEC
                     // records. NS records we must not sign and everything
                     // else shouldn’t be here, really.
-                    if rrset.rtype() != Rtype::Ds && rrset.rtype() != Rtype::Nsec {
+                    if rrset.rtype() != Rtype::Ds
+                        && rrset.rtype() != Rtype::Nsec
+                    {
                         continue;
                     }
                 } else {
@@ -221,7 +223,10 @@ impl<N, D> SortedRecords<N, D> {
             };
 
             if let Some((prev_name, bitmap)) = prev.take() {
-                res.push(prev_name.into_record(ttl, Nsec::new(name.owner().clone(), bitmap)));
+                res.push(prev_name.into_record(
+                    ttl,
+                    Nsec::new(name.owner().clone(), bitmap),
+                ));
             }
 
             let mut bitmap = RtypeBitmap::<Octets>::builder();
@@ -234,7 +239,9 @@ impl<N, D> SortedRecords<N, D> {
             prev = Some((name, bitmap.finalize()));
         }
         if let Some((prev_name, bitmap)) = prev {
-            res.push(prev_name.into_record(ttl, Nsec::new(apex_owner, bitmap)));
+            res.push(
+                prev_name.into_record(ttl, Nsec::new(apex_owner, bitmap)),
+            );
         }
         res
     }
@@ -333,7 +340,8 @@ impl<'a, N, D> Family<'a, N, D> {
         NN: ToDname,
         D: RecordData,
     {
-        self.family_name().ne(apex) && self.records().any(|record| record.rtype() == Rtype::Ns)
+        self.family_name().ne(apex)
+            && self.records().any(|record| record.rtype() == Rtype::Ns)
     }
 
     pub fn is_in_zone<NN: ToDname>(&self, apex: &FamilyName<NN>) -> bool
@@ -385,7 +393,11 @@ impl<N> FamilyName<N> {
             .map(|dnskey| self.clone().into_record(ttl, dnskey.convert()))
     }
 
-    pub fn ds<K: SigningKey>(&self, ttl: u32, key: K) -> Result<Record<N, Ds<K::Octets>>, K::Error>
+    pub fn ds<K: SigningKey>(
+        &self,
+        ttl: u32,
+        key: K,
+    ) -> Result<Record<N, Ds<K::Octets>>, K::Error>
     where
         N: ToDname + Clone,
     {
@@ -502,7 +514,9 @@ where
         };
         let mut end = 1;
         while let Some(record) = self.slice.get(end) {
-            if !record.owner().name_eq(first.owner()) || record.class() != first.class() {
+            if !record.owner().name_eq(first.owner())
+                || record.class() != first.class()
+            {
                 break;
             }
             end += 1;

--- a/src/test/cargo.rs
+++ b/src/test/cargo.rs
@@ -1,5 +1,3 @@
 //! Stuff from Cargo.
 
-
-pub struct Environ {
-}
+pub struct Environ {}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -13,4 +13,3 @@
 pub mod cargo;
 pub mod nsd;
 pub mod utils;
-

--- a/src/test/nsd.rs
+++ b/src/test/nsd.rs
@@ -1,21 +1,20 @@
 //! Configuring and running NSD.
 
-use std::{fmt, io};
+use crate::utils::base64;
+use bytes::Bytes;
 use std::fs::File;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::string::String;
 use std::vec::Vec;
-use bytes::Bytes;
-use crate::utils::base64;
-
+use std::{fmt, io};
 
 //------------ Config --------------------------------------------------------
 
 /// NSD configuration.
 ///
 /// This type contains a subset of the options available in NSD’s
-/// configuration file. In order to configure an NSD instance, you create and 
+/// configuration file. In order to configure an NSD instance, you create and
 /// manipulate a value of this type and, once you are happy with it, save if
 /// to disk via the `save` method.
 ///
@@ -63,10 +62,7 @@ impl Config {
     }
 
     /// Writes the configuration to something writable.
-    pub fn write<W: io::Write>(
-        &self,
-        target: &mut W
-    ) -> Result<(), io::Error> {
+    pub fn write<W: io::Write>(&self, target: &mut W) -> Result<(), io::Error> {
         // server: clause
         writeln!(target, "server:")?;
         for addr in &self.ip_address {
@@ -117,7 +113,6 @@ impl Config {
     }
 }
 
-
 //------------ KeyConfig -----------------------------------------------------
 
 /// A single `key:` clause fo the NSD configuration.
@@ -129,20 +124,15 @@ pub struct KeyConfig {
 }
 
 impl KeyConfig {
-    pub fn new<S: Into<String>, V: Into<Bytes>>(
-        name: S, algorithm: S, secret: V
-    ) -> Self {
+    pub fn new<S: Into<String>, V: Into<Bytes>>(name: S, algorithm: S, secret: V) -> Self {
         KeyConfig {
-            name: name.into(), 
+            name: name.into(),
             algorithm: algorithm.into(),
-            secret: secret.into()
+            secret: secret.into(),
         }
     }
 
-    pub fn write<W: io::Write>(
-        &self,
-        target: &mut W
-    ) -> Result<(), io::Error> {
+    pub fn write<W: io::Write>(&self, target: &mut W) -> Result<(), io::Error> {
         writeln!(target, "key:")?;
         writeln!(target, "    name: {}", self.name)?;
         writeln!(target, "    algorithm: {}", self.algorithm)?;
@@ -152,7 +142,6 @@ impl KeyConfig {
         Ok(())
     }
 }
-
 
 //------------ ZoneConfig ----------------------------------------------------
 
@@ -166,19 +155,18 @@ pub struct ZoneConfig {
 
 impl ZoneConfig {
     pub fn new<S: Into<String>, P: Into<PathBuf>>(
-        name: S, zonefile: P, provide_xfr: Vec<Acl>
+        name: S,
+        zonefile: P,
+        provide_xfr: Vec<Acl>,
     ) -> Self {
         ZoneConfig {
             name: name.into(),
             zonefile: zonefile.into(),
-            provide_xfr
+            provide_xfr,
         }
     }
 
-    pub fn write<W: io::Write>(
-        &self,
-        target: &mut W
-    ) -> Result<(), io::Error> {
+    pub fn write<W: io::Write>(&self, target: &mut W) -> Result<(), io::Error> {
         writeln!(target, "zone:")?;
         writeln!(target, "    name: {}", self.name)?;
         writeln!(target, "    zonefile: {}", self.zonefile.display())?;
@@ -189,7 +177,6 @@ impl ZoneConfig {
         Ok(())
     }
 }
-
 
 //------------ Acl -----------------------------------------------------------
 
@@ -205,7 +192,7 @@ pub struct Acl {
     pub ip_port: Option<u16>,
 
     /// Name of TSIG key.
-    key: Option<String>
+    key: Option<String>,
 }
 
 impl Acl {
@@ -213,9 +200,14 @@ impl Acl {
         ip_addr: IpAddr,
         ip_net: Option<u8>,
         ip_port: Option<u16>,
-        key: Option<String>
+        key: Option<String>,
     ) -> Self {
-        Acl { ip_addr, ip_net, ip_port, key }
+        Acl {
+            ip_addr,
+            ip_net,
+            ip_port,
+            key,
+        }
     }
 }
 
@@ -230,9 +222,8 @@ impl fmt::Display for Acl {
         }
         match self.key {
             Some(ref key) => write!(f, " {}", key)?,
-            None => write!(f, " NOKEY")?
+            None => write!(f, " NOKEY")?,
         }
         Ok(())
     }
 }
-        

--- a/src/test/nsd.rs
+++ b/src/test/nsd.rs
@@ -62,7 +62,10 @@ impl Config {
     }
 
     /// Writes the configuration to something writable.
-    pub fn write<W: io::Write>(&self, target: &mut W) -> Result<(), io::Error> {
+    pub fn write<W: io::Write>(
+        &self,
+        target: &mut W,
+    ) -> Result<(), io::Error> {
         // server: clause
         writeln!(target, "server:")?;
         for addr in &self.ip_address {
@@ -124,7 +127,11 @@ pub struct KeyConfig {
 }
 
 impl KeyConfig {
-    pub fn new<S: Into<String>, V: Into<Bytes>>(name: S, algorithm: S, secret: V) -> Self {
+    pub fn new<S: Into<String>, V: Into<Bytes>>(
+        name: S,
+        algorithm: S,
+        secret: V,
+    ) -> Self {
         KeyConfig {
             name: name.into(),
             algorithm: algorithm.into(),
@@ -132,7 +139,10 @@ impl KeyConfig {
         }
     }
 
-    pub fn write<W: io::Write>(&self, target: &mut W) -> Result<(), io::Error> {
+    pub fn write<W: io::Write>(
+        &self,
+        target: &mut W,
+    ) -> Result<(), io::Error> {
         writeln!(target, "key:")?;
         writeln!(target, "    name: {}", self.name)?;
         writeln!(target, "    algorithm: {}", self.algorithm)?;
@@ -166,7 +176,10 @@ impl ZoneConfig {
         }
     }
 
-    pub fn write<W: io::Write>(&self, target: &mut W) -> Result<(), io::Error> {
+    pub fn write<W: io::Write>(
+        &self,
+        target: &mut W,
+    ) -> Result<(), io::Error> {
         writeln!(target, "zone:")?;
         writeln!(target, "    name: {}", self.name)?;
         writeln!(target, "    zonefile: {}", self.zonefile.display())?;

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -1,9 +1,8 @@
 //! Various utility functions.
 
-use std::io;
 use std::fs::File;
+use std::io;
 use std::path::Path;
-
 
 //------------ Functions -----------------------------------------------------
 
@@ -11,4 +10,3 @@ pub fn save<P: AsRef<Path>>(path: P, content: &str) -> Result<(), io::Error> {
     let mut file = File::create(path)?;
     io::Write::write_all(&mut file, content.as_bytes())
 }
-

--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -1,30 +1,29 @@
 //! Tests the TSIG implementation.
 #![cfg(all(test, feature = "interop"))]
 
-use std::{env, fs, io, thread};
+use crate::base::iana::{Rcode, Rtype};
+use crate::base::message::Message;
+use crate::base::message_builder::{
+    AdditionalBuilder, AnswerBuilder, MessageBuilder, StreamTarget,
+};
+use crate::base::name::Dname;
+use crate::rdata::{Soa, A};
+use crate::test::nsd;
+use crate::tsig;
+use crate::utils::base64;
+use ring::rand::SystemRandom;
 use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream, UdpSocket};
 use std::process::Command;
 use std::str::FromStr;
 use std::time::Duration;
 use std::vec::Vec;
-use ring::rand::SystemRandom;
-use crate::test::nsd;
-use crate::base::message::Message;
-use crate::base::message_builder::{
-    AdditionalBuilder, AnswerBuilder, MessageBuilder, StreamTarget,
-};
-use crate::base::name::Dname;
-use crate::base::iana::{Rcode, Rtype};
-use crate::rdata::{A, Soa};
-use crate::tsig;
-use crate::utils::base64;
+use std::{env, fs, io, thread};
 
 type TestMessage = Message<Vec<u8>>;
 type TestBuilder = MessageBuilder<StreamTarget<Vec<u8>>>;
 type TestAnswer = AnswerBuilder<StreamTarget<Vec<u8>>>;
 type TestAdditional = AdditionalBuilder<StreamTarget<Vec<u8>>>;
-
 
 //------------ Tests --------------------------------------------------------
 
@@ -48,23 +47,31 @@ fn tsig_client_nsd() {
         &rng,
         Dname::from_str("test.key.").unwrap(),
         None,
-        None
-    ).unwrap();
+        None,
+    )
+    .unwrap();
 
     let mut conf = nsd::Config::all_in(&base_dir);
-    conf.ip_address.push(SocketAddr::from_str("127.0.0.1:54321").unwrap());
+    conf.ip_address
+        .push(SocketAddr::from_str("127.0.0.1:54321").unwrap());
     conf.verbosity = Some(3);
-    conf.keys.push(nsd::KeyConfig::new("test.key.", "hmac-sha1", secret));
+    conf.keys
+        .push(nsd::KeyConfig::new("test.key.", "hmac-sha1", secret));
     conf.zones.push(nsd::ZoneConfig::new(
-        "example.com", zonepath, vec![nsd::Acl::new(
-            IpAddr::from_str("127.0.0.1").unwrap(), None, None,
-            Some("test.key.".into())
-        )]
+        "example.com",
+        zonepath,
+        vec![nsd::Acl::new(
+            IpAddr::from_str("127.0.0.1").unwrap(),
+            None,
+            None,
+            Some("test.key.".into()),
+        )],
     ));
     conf.save(&nsdconfpath).unwrap();
     let mut nsd = Command::new("/usr/sbin/nsd")
         .args(&["-c", &format!("{}", nsdconfpath.display()), "-d"])
-        .spawn().unwrap();
+        .spawn()
+        .unwrap();
     thread::sleep(Duration::from_secs(1));
     if nsd.try_wait().unwrap().is_some() {
         panic!("NSD didn't start.");
@@ -73,17 +80,14 @@ fn tsig_client_nsd() {
     let res = thread::spawn(move || {
         // Create an AXFR request and send it to NSD.
         let request = TestBuilder::new_stream_vec();
-        let mut request = request.request_axfr(
-            Dname::<Vec<u8>>::from_str("example.com.").unwrap()
-        ).unwrap().additional();
-        let tran = tsig::ClientTransaction::request(
-            &key, &mut request
-        ).unwrap();
+        let mut request = request
+            .request_axfr(Dname::<Vec<u8>>::from_str("example.com.").unwrap())
+            .unwrap()
+            .additional();
+        let tran = tsig::ClientTransaction::request(&key, &mut request).unwrap();
         let sock = UdpSocket::bind("127.0.0.1:54320").unwrap();
-        sock.send_to(
-            request.as_target().as_dgram_slice(),
-            "127.0.0.1:54321"
-        ).unwrap();
+        sock.send_to(request.as_target().as_dgram_slice(), "127.0.0.1:54321")
+            .unwrap();
         let mut answer = loop {
             let mut buf = vec![0; 512];
             let (len, addr) = sock.recv_from(buf.as_mut()).unwrap();
@@ -99,7 +103,8 @@ fn tsig_client_nsd() {
         if let Err(err) = tran.answer(&mut answer) {
             panic!("{:?}", err);
         }
-    }).join();
+    })
+    .join();
 
     // Shut down NSD just to be sure.
     let _ = nsd.kill();
@@ -115,8 +120,9 @@ fn tsig_server_drill() {
         &rng,
         Dname::from_str("test.key.").unwrap(),
         None,
-        None
-    ).unwrap();
+        None,
+    )
+    .unwrap();
     let secret = base64::encode_string(&secret);
     let secret = format!("test.key:{}:hmac-sha1", secret);
 
@@ -131,22 +137,17 @@ fn tsig_server_drill() {
                 Err(_) => continue,
             };
             let answer = TestBuilder::new_stream_vec();
-            let answer = answer.start_answer(
-                &request, Rcode::NoError
-            ).unwrap();
-            let tran = match tsig::ServerTransaction::request(
-                &&key, &mut request
-            ) {
+            let answer = answer.start_answer(&request, Rcode::NoError).unwrap();
+            let tran = match tsig::ServerTransaction::request(&&key, &mut request) {
                 Ok(Some(tran)) => tran,
                 Ok(None) => {
                     sock.send_to(answer.as_slice(), addr).unwrap();
                     continue;
                 }
                 Err(error) => {
-                    let answer = error.build_message(
-                        &request,
-                        TestBuilder::new_stream_vec()
-                    ).unwrap();
+                    let answer = error
+                        .build_message(&request, TestBuilder::new_stream_vec())
+                        .unwrap();
                     sock.send_to(answer.as_slice(), addr).unwrap();
                     continue;
                 }
@@ -158,12 +159,9 @@ fn tsig_server_drill() {
     });
 
     let status = Command::new("/usr/bin/drill")
-        .args(&[
-            "-p", "54322",
-            "-y", &secret,
-            "example.com", "@127.0.0.1"
-        ])
-        .status().unwrap();
+        .args(&["-p", "54322", "-y", &secret, "example.com", "@127.0.0.1"])
+        .status()
+        .unwrap();
     drop(join);
     assert!(status.success());
 }
@@ -185,23 +183,31 @@ fn tsig_client_sequence_nsd() {
         &rng,
         Dname::from_str("test.key.").unwrap(),
         None,
-        None
-    ).unwrap();
+        None,
+    )
+    .unwrap();
 
     let mut conf = nsd::Config::all_in(&base_dir);
-    conf.ip_address.push(SocketAddr::from_str("127.0.0.1:54323").unwrap());
+    conf.ip_address
+        .push(SocketAddr::from_str("127.0.0.1:54323").unwrap());
     conf.verbosity = Some(3);
-    conf.keys.push(nsd::KeyConfig::new("test.key.", "hmac-sha1", secret));
+    conf.keys
+        .push(nsd::KeyConfig::new("test.key.", "hmac-sha1", secret));
     conf.zones.push(nsd::ZoneConfig::new(
-        "example.com", zonepath, vec![nsd::Acl::new(
-            IpAddr::from_str("127.0.0.1").unwrap(), None, None,
-            Some("test.key.".into())
-        )]
+        "example.com",
+        zonepath,
+        vec![nsd::Acl::new(
+            IpAddr::from_str("127.0.0.1").unwrap(),
+            None,
+            None,
+            Some("test.key.".into()),
+        )],
     ));
     conf.save(&nsdconfpath).unwrap();
     let mut nsd = Command::new("/usr/sbin/nsd")
         .args(&["-c", &format!("{}", nsdconfpath.display()), "-d"])
-        .spawn().unwrap();
+        .spawn()
+        .unwrap();
     thread::sleep(Duration::from_secs(1));
     if nsd.try_wait().unwrap().is_some() {
         panic!("NSD didn't start.");
@@ -210,13 +216,13 @@ fn tsig_client_sequence_nsd() {
     let res = thread::spawn(move || {
         let mut sock = TcpStream::connect("127.0.0.1:54323").unwrap();
         let request = TestBuilder::new_stream_vec();
-        let mut request = request.request_axfr(
-            Dname::<Vec<u8>>::from_str("example.com.").unwrap()
-        ).unwrap().additional();
-        let mut tran = tsig::ClientSequence::request(
-            &key, &mut request
-        ).unwrap();
-        sock.write_all(request.as_target().as_stream_slice()).unwrap();
+        let mut request = request
+            .request_axfr(Dname::<Vec<u8>>::from_str("example.com.").unwrap())
+            .unwrap()
+            .additional();
+        let mut tran = tsig::ClientSequence::request(&key, &mut request).unwrap();
+        sock.write_all(request.as_target().as_stream_slice())
+            .unwrap();
         loop {
             let mut len = [0u8; 2];
             sock.read_exact(&mut len).unwrap();
@@ -228,13 +234,13 @@ fn tsig_client_sequence_nsd() {
             tran.answer(&mut answer).unwrap();
             // Last message has SOA as last record in answer section.
             // We don’t care about details.
-            if answer.answer().unwrap().last().unwrap().unwrap().rtype()
-                        == Rtype::Soa {
-                break
+            if answer.answer().unwrap().last().unwrap().unwrap().rtype() == Rtype::Soa {
+                break;
             }
         }
         tran.done().unwrap()
-    }).join();
+    })
+    .join();
 
     // Shut down NSD just to be sure.
     let _ = nsd.kill();
@@ -250,8 +256,9 @@ fn tsig_server_sequence_drill() {
         &rng,
         Dname::from_str("test.key.").unwrap(),
         None,
-        None
-    ).unwrap();
+        None,
+    )
+    .unwrap();
     let secret = base64::encode_string(&secret);
     let secret = format!("test.key:{}:hmac-sha1", secret);
     let listener = TcpListener::bind("127.0.0.1:54324").unwrap();
@@ -267,44 +274,40 @@ fn tsig_server_sequence_drill() {
             sock.read_exact(&mut buf).unwrap();
             let mut request = Message::from_octets(buf).unwrap();
             let mut tran = tsig::ServerSequence::request(&&key, &mut request)
-                                                .unwrap().unwrap();
+                .unwrap()
+                .unwrap();
             let mut answer = make_first_axfr(&request);
             tran.answer(&mut answer).unwrap();
-            send_tcp(
-                &mut sock,
-                answer.as_target().as_stream_slice()
-            ).unwrap();
+            send_tcp(&mut sock, answer.as_target().as_stream_slice()).unwrap();
             for two in 0..10u8 {
                 for one in 0..10u8 {
                     let mut answer = make_middle_axfr(&request, one, two);
                     tran.answer(&mut answer).unwrap();
-                    send_tcp(
-                        &mut sock,
-                        answer.as_target().as_stream_slice()
-                    ).unwrap();
+                    send_tcp(&mut sock, answer.as_target().as_stream_slice()).unwrap();
                 }
             }
             let mut answer = make_last_axfr(&request);
             tran.answer(&mut answer).unwrap();
-            send_tcp(
-                &mut sock,
-                answer.as_target().as_stream_slice()
-            ).unwrap();
+            send_tcp(&mut sock, answer.as_target().as_stream_slice()).unwrap();
         }
     });
 
     let status = Command::new("/usr/bin/drill")
         .args(&[
-            "-p", &format!("{}", port),
-            "-y", &secret,
+            "-p",
+            &format!("{}", port),
+            "-y",
+            &secret,
             "-t",
-            "example.com", "AXFR", "@127.0.0.1"
+            "example.com",
+            "AXFR",
+            "@127.0.0.1",
         ])
-        .status().unwrap();
+        .status()
+        .unwrap();
     drop(join);
     assert!(status.success());
 }
-
 
 //------------ Helpers ------------------------------------------------------
 
@@ -321,11 +324,7 @@ fn make_first_axfr(request: &TestMessage) -> TestAdditional {
     msg.additional()
 }
 
-fn make_middle_axfr(
-    request: &TestMessage,
-    one: u8,
-    two: u8
-) -> TestAdditional {
+fn make_middle_axfr(request: &TestMessage, one: u8, two: u8) -> TestAdditional {
     let msg = TestBuilder::new_stream_vec();
     let mut msg = msg.start_answer(request, Rcode::NoError).unwrap();
     push_a(&mut msg, 1, one, two);
@@ -341,27 +340,29 @@ fn make_last_axfr(request: &TestMessage) -> TestAdditional {
 }
 
 fn push_soa(builder: &mut TestAnswer) {
-    builder.push(
-        (
+    builder
+        .push((
             Dname::<Vec<u8>>::from_str("example.com.").unwrap(),
             3600,
             Soa::new(
                 Dname::<Vec<u8>>::from_str("mname.example.com.").unwrap(),
                 Dname::<Vec<u8>>::from_str("rname.example.com.").unwrap(),
                 12.into(),
-                3600, 3600, 3600, 3600
-            )
-        )
-    ).unwrap()
+                3600,
+                3600,
+                3600,
+                3600,
+            ),
+        ))
+        .unwrap()
 }
 
 fn push_a(builder: &mut TestAnswer, zero: u8, one: u8, two: u8) {
-    builder.push(
-        (
+    builder
+        .push((
             Dname::<Vec<u8>>::from_str("example.com.").unwrap(),
             3600,
-            A::from_octets(10, zero, one, two)
-        )
-    ).unwrap()
+            A::from_octets(10, zero, one, two),
+        ))
+        .unwrap()
 }
-

--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -84,7 +84,8 @@ fn tsig_client_nsd() {
             .request_axfr(Dname::<Vec<u8>>::from_str("example.com.").unwrap())
             .unwrap()
             .additional();
-        let tran = tsig::ClientTransaction::request(&key, &mut request).unwrap();
+        let tran =
+            tsig::ClientTransaction::request(&key, &mut request).unwrap();
         let sock = UdpSocket::bind("127.0.0.1:54320").unwrap();
         sock.send_to(request.as_target().as_dgram_slice(), "127.0.0.1:54321")
             .unwrap();
@@ -137,21 +138,26 @@ fn tsig_server_drill() {
                 Err(_) => continue,
             };
             let answer = TestBuilder::new_stream_vec();
-            let answer = answer.start_answer(&request, Rcode::NoError).unwrap();
-            let tran = match tsig::ServerTransaction::request(&&key, &mut request) {
-                Ok(Some(tran)) => tran,
-                Ok(None) => {
-                    sock.send_to(answer.as_slice(), addr).unwrap();
-                    continue;
-                }
-                Err(error) => {
-                    let answer = error
-                        .build_message(&request, TestBuilder::new_stream_vec())
-                        .unwrap();
-                    sock.send_to(answer.as_slice(), addr).unwrap();
-                    continue;
-                }
-            };
+            let answer =
+                answer.start_answer(&request, Rcode::NoError).unwrap();
+            let tran =
+                match tsig::ServerTransaction::request(&&key, &mut request) {
+                    Ok(Some(tran)) => tran,
+                    Ok(None) => {
+                        sock.send_to(answer.as_slice(), addr).unwrap();
+                        continue;
+                    }
+                    Err(error) => {
+                        let answer = error
+                            .build_message(
+                                &request,
+                                TestBuilder::new_stream_vec(),
+                            )
+                            .unwrap();
+                        sock.send_to(answer.as_slice(), addr).unwrap();
+                        continue;
+                    }
+                };
             let mut answer = answer.additional();
             tran.answer(&mut answer).unwrap();
             sock.send_to(answer.as_slice(), addr).unwrap();
@@ -220,7 +226,8 @@ fn tsig_client_sequence_nsd() {
             .request_axfr(Dname::<Vec<u8>>::from_str("example.com.").unwrap())
             .unwrap()
             .additional();
-        let mut tran = tsig::ClientSequence::request(&key, &mut request).unwrap();
+        let mut tran =
+            tsig::ClientSequence::request(&key, &mut request).unwrap();
         sock.write_all(request.as_target().as_stream_slice())
             .unwrap();
         loop {
@@ -234,7 +241,9 @@ fn tsig_client_sequence_nsd() {
             tran.answer(&mut answer).unwrap();
             // Last message has SOA as last record in answer section.
             // We don’t care about details.
-            if answer.answer().unwrap().last().unwrap().unwrap().rtype() == Rtype::Soa {
+            if answer.answer().unwrap().last().unwrap().unwrap().rtype()
+                == Rtype::Soa
+            {
                 break;
             }
         }
@@ -278,17 +287,20 @@ fn tsig_server_sequence_drill() {
                 .unwrap();
             let mut answer = make_first_axfr(&request);
             tran.answer(&mut answer).unwrap();
-            send_tcp(&mut sock, answer.as_target().as_stream_slice()).unwrap();
+            send_tcp(&mut sock, answer.as_target().as_stream_slice())
+                .unwrap();
             for two in 0..10u8 {
                 for one in 0..10u8 {
                     let mut answer = make_middle_axfr(&request, one, two);
                     tran.answer(&mut answer).unwrap();
-                    send_tcp(&mut sock, answer.as_target().as_stream_slice()).unwrap();
+                    send_tcp(&mut sock, answer.as_target().as_stream_slice())
+                        .unwrap();
                 }
             }
             let mut answer = make_last_axfr(&request);
             tran.answer(&mut answer).unwrap();
-            send_tcp(&mut sock, answer.as_target().as_stream_slice()).unwrap();
+            send_tcp(&mut sock, answer.as_target().as_stream_slice())
+                .unwrap();
         }
     });
 
@@ -324,7 +336,11 @@ fn make_first_axfr(request: &TestMessage) -> TestAdditional {
     msg.additional()
 }
 
-fn make_middle_axfr(request: &TestMessage, one: u8, two: u8) -> TestAdditional {
+fn make_middle_axfr(
+    request: &TestMessage,
+    one: u8,
+    two: u8,
+) -> TestAdditional {
     let msg = TestBuilder::new_stream_vec();
     let mut msg = msg.start_answer(request, Rcode::NoError).unwrap();
     push_a(&mut msg, 1, one, two);

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! TSIG is intended to provide authentication for message exchanges. Messages
 //! are signed using a secret key shared between the two participants. The
-//! party sending the request – the client – generates a signature over the 
+//! party sending the request – the client – generates a signature over the
 //! message it is about to send using that key and adds it in a special record
 //! of record type [TSIG] to the additional section of the message. The
 //! receiver of the request – the server – verifies the signature using the
@@ -55,24 +55,18 @@
 
 mod interop;
 
-
-use std::{cmp, error, fmt, hash, mem, str};
-use std::collections::HashMap;
-use bytes::{Bytes, BytesMut};
-use ring::{constant_time, hmac, rand, hkdf::KeyType};
 use crate::base::header::HeaderSection;
 use crate::base::iana::{Class, Rcode, TsigRcode};
 use crate::base::message::Message;
 use crate::base::message_builder::{AdditionalBuilder, MessageBuilder};
-use crate::base::name::{
-    Dname, Label, ParsedDname, ToDname, ToLabelIter
-};
-use crate::base::octets::{
-    OctetsBuilder, OctetsRef, OctetsVec, ParseError, ShortBuf
-};
+use crate::base::name::{Dname, Label, ParsedDname, ToDname, ToLabelIter};
+use crate::base::octets::{OctetsBuilder, OctetsRef, OctetsVec, ParseError, ShortBuf};
 use crate::base::record::Record;
 use crate::rdata::rfc2845::{Time48, Tsig};
-
+use bytes::{Bytes, BytesMut};
+use ring::{constant_time, hkdf::KeyType, hmac, rand};
+use std::collections::HashMap;
+use std::{cmp, error, fmt, hash, mem, str};
 
 //------------ Key -----------------------------------------------------------
 
@@ -147,16 +141,15 @@ impl Key {
         key: &[u8],
         name: Dname<OctetsVec>,
         min_mac_len: Option<usize>,
-        signing_len: Option<usize>
+        signing_len: Option<usize>,
     ) -> Result<Self, NewKeyError> {
-        let (min_mac_len, signing_len) = Self::calculate_bounds(
-            algorithm, min_mac_len, signing_len
-        )?;
+        let (min_mac_len, signing_len) =
+            Self::calculate_bounds(algorithm, min_mac_len, signing_len)?;
         Ok(Key {
             key: hmac::Key::new(algorithm.into_hmac_algorithm(), key),
             name,
             min_mac_len,
-            signing_len
+            signing_len,
         })
     }
 
@@ -172,23 +165,20 @@ impl Key {
         rng: &dyn rand::SecureRandom,
         name: Dname<OctetsVec>,
         min_mac_len: Option<usize>,
-        signing_len: Option<usize>
+        signing_len: Option<usize>,
     ) -> Result<(Self, Bytes), GenerateKeyError> {
-        let (min_mac_len, signing_len) = Self::calculate_bounds(
-            algorithm, min_mac_len, signing_len
-        )?;
+        let (min_mac_len, signing_len) =
+            Self::calculate_bounds(algorithm, min_mac_len, signing_len)?;
         let algorithm = algorithm.into_hmac_algorithm();
         let key_len = algorithm.len();
         let mut bytes = BytesMut::with_capacity(key_len);
         bytes.resize(key_len, 0);
         rng.fill(&mut bytes)?;
         let key = Key {
-            key: hmac::Key::new(
-                algorithm, &bytes
-            ),
+            key: hmac::Key::new(algorithm, &bytes),
             name,
             min_mac_len,
-            signing_len
+            signing_len,
         };
         Ok((key, bytes.freeze()))
     }
@@ -200,25 +190,25 @@ impl Key {
     fn calculate_bounds(
         algorithm: Algorithm,
         min_mac_len: Option<usize>,
-        signing_len: Option<usize>
+        signing_len: Option<usize>,
     ) -> Result<(usize, usize), NewKeyError> {
         let min_mac_len = match min_mac_len {
             Some(len) => {
                 if !algorithm.within_len_bounds(len) {
-                    return Err(NewKeyError::BadMinMacLen)
+                    return Err(NewKeyError::BadMinMacLen);
                 }
                 len
             }
-            None => algorithm.native_len()
+            None => algorithm.native_len(),
         };
         let signing_len = match signing_len {
             Some(len) => {
                 if !algorithm.within_len_bounds(len) {
-                    return Err(NewKeyError::BadSigningLen)
+                    return Err(NewKeyError::BadSigningLen);
                 }
                 len
             }
-            None => algorithm.native_len()
+            None => algorithm.native_len(),
         };
         Ok((min_mac_len, signing_len))
     }
@@ -233,7 +223,6 @@ impl Key {
         &signature.as_ref()[..self.signing_len]
     }
 }
-
 
 /// # Access to Properties
 ///
@@ -264,17 +253,13 @@ impl Key {
     }
 
     /// Checks whether the key in the record is this key.
-    fn check_tsig<Octets>(
-        &self,
-        tsig: &MessageTsig<Octets>
-    ) -> Result<(), ValidationError>
-    where for<'o> &'o Octets: OctetsRef {
-        if *tsig.owner() != self.name
-            || *tsig.data().algorithm() != self.algorithm().to_dname() 
-        {
+    fn check_tsig<Octets>(&self, tsig: &MessageTsig<Octets>) -> Result<(), ValidationError>
+    where
+        for<'o> &'o Octets: OctetsRef,
+    {
+        if *tsig.owner() != self.name || *tsig.data().algorithm() != self.algorithm().to_dname() {
             Err(ValidationError::BadKey)
-        }
-        else {
+        } else {
             Ok(())
         }
     }
@@ -290,12 +275,11 @@ impl Key {
         provided: &[u8],
     ) -> Result<(), ValidationError> {
         if provided.len() < self.min_mac_len {
-            return Err(ValidationError::BadTrunc)
+            return Err(ValidationError::BadTrunc);
         }
         let expected = if provided.len() < expected.as_ref().len() {
             &expected.as_ref()[..provided.len()]
-        }
-        else {
+        } else {
             expected.as_ref()
         };
         constant_time::verify_slices_are_equal(expected, provided)
@@ -322,7 +306,6 @@ impl Key {
     }
 }
 
-
 //--- AsRef
 
 impl AsRef<Key> for Key {
@@ -330,7 +313,6 @@ impl AsRef<Key> for Key {
         self
     }
 }
-
 
 //------------ KeyStore ------------------------------------------------------
 
@@ -359,23 +341,16 @@ pub trait KeyStore {
     ///
     /// The method looks up a key based on a pair of name and algorithm. If
     /// the key can be found, it is returned. Otherwise, `None` is returned.
-    fn get_key<N: ToDname>(
-        &self, name: &N, algorithm: Algorithm
-    ) -> Option<Self::Key>;
+    fn get_key<N: ToDname>(&self, name: &N, algorithm: Algorithm) -> Option<Self::Key>;
 }
 
 impl<K: AsRef<Key> + Clone> KeyStore for K {
     type Key = Self;
 
-    fn get_key<N: ToDname>(
-        &self, name: &N, algorithm: Algorithm
-    ) -> Option<Self::Key> {
-        if self.as_ref().name() == name 
-            && self.as_ref().algorithm() == algorithm
-        {
+    fn get_key<N: ToDname>(&self, name: &N, algorithm: Algorithm) -> Option<Self::Key> {
+        if self.as_ref().name() == name && self.as_ref().algorithm() == algorithm {
             Some(self.clone())
-        }
-        else {
+        } else {
             None
         }
     }
@@ -384,19 +359,16 @@ impl<K: AsRef<Key> + Clone> KeyStore for K {
 impl<K, S> KeyStore for HashMap<(Dname<OctetsVec>, Algorithm), K, S>
 where
     K: AsRef<Key> + Clone,
-    S: hash::BuildHasher
+    S: hash::BuildHasher,
 {
     type Key = K;
 
-    fn get_key<N: ToDname>(
-        &self, name: &N, algorithm: Algorithm
-    ) -> Option<Self::Key> {
+    fn get_key<N: ToDname>(&self, name: &N, algorithm: Algorithm) -> Option<Self::Key> {
         // XXX This seems a bit wasteful.
         let name = name.to_dname::<OctetsVec>().unwrap();
         self.get(&(name, algorithm)).cloned()
     }
 }
-
 
 //------------ ClientTransaction ---------------------------------------------
 
@@ -439,7 +411,7 @@ impl<K: AsRef<Key>> ClientTransaction<K> {
     /// [`request_with_fudge`]: #method.request_with_fudge
     pub fn request<Target: OctetsBuilder>(
         key: K,
-        message: &mut AdditionalBuilder<Target>
+        message: &mut AdditionalBuilder<Target>,
     ) -> Result<Self, ShortBuf> {
         Self::request_with_fudge(key, message, 300)
     }
@@ -466,14 +438,10 @@ impl<K: AsRef<Key>> ClientTransaction<K> {
     pub fn request_with_fudge<Target: OctetsBuilder>(
         key: K,
         message: &mut AdditionalBuilder<Target>,
-        fudge: u16
+        fudge: u16,
     ) -> Result<Self, ShortBuf> {
-        let variables = Variables::new(
-            Time48::now(), fudge, TsigRcode::NoError, None
-        );
-        let (mut context, mac) = SigningContext::request(
-            key, message.as_slice(), None, &variables
-        );
+        let variables = Variables::new(Time48::now(), fudge, TsigRcode::NoError, None);
+        let (mut context, mac) = SigningContext::request(key, message.as_slice(), None, &variables);
         let mac = context.key().signature_slice(&mac);
         context.apply_signature(mac);
         context.key().complete_message(message, &variables, mac)?;
@@ -490,30 +458,26 @@ impl<K: AsRef<Key>> ClientTransaction<K> {
     /// whether this record is a correct record for this transaction and if
     /// it correctly signs the answer for this transaction. If any of this
     /// fails, returns an error.
-    pub fn answer<Octets>(
-        &self, message: &mut Message<Octets>
-    ) -> Result<(), ValidationError>
+    pub fn answer<Octets>(&self, message: &mut Message<Octets>) -> Result<(), ValidationError>
     where
         Octets: AsRef<[u8]> + AsMut<[u8]>,
-        for<'a> &'a Octets: OctetsRef
+        for<'a> &'a Octets: OctetsRef,
     {
         let tsig = match self.context.get_answer_tsig(message)? {
             Some(some) => some,
-            None => return Err(ValidationError::ServerUnsigned)
+            None => return Err(ValidationError::ServerUnsigned),
         };
         let mut header = message.header_section();
         header.header_mut().set_id(tsig.data().original_id());
         header.counts_mut().dec_arcount();
         let signature = self.context.answer(
             header.as_slice(),
-            Some(&message.as_slice()[
-                 mem::size_of::<HeaderSection>()..tsig.start
-            ]),
-            &tsig.variables()
+            Some(&message.as_slice()[mem::size_of::<HeaderSection>()..tsig.start]),
+            &tsig.variables(),
         );
-        self.context.key().compare_signatures(
-            &signature, tsig.data().mac().as_ref()
-        )?;
+        self.context
+            .key()
+            .compare_signatures(&signature, tsig.data().mac().as_ref())?;
         self.context.check_answer_time(message, &tsig)?;
         remove_tsig(tsig.into_original_id(), message);
         Ok(())
@@ -524,7 +488,6 @@ impl<K: AsRef<Key>> ClientTransaction<K> {
         self.context.key()
     }
 }
-
 
 //------------ ServerTransaction ---------------------------------------------
 
@@ -562,16 +525,15 @@ impl<K: AsRef<Key>> ServerTransaction<K> {
     /// client as the error case of the result.
     pub fn request<Store, Octets>(
         store: &Store,
-        message: &mut Message<Octets>
+        message: &mut Message<Octets>,
     ) -> Result<Option<Self>, ServerError<K>>
     where
-        Store: KeyStore<Key=K>,
+        Store: KeyStore<Key = K>,
         Octets: AsRef<[u8]> + AsMut<[u8]>,
-        for<'o> &'o Octets: OctetsRef
+        for<'o> &'o Octets: OctetsRef,
     {
-        SigningContext::server_request(
-            store, message
-        ).map(|context| context.map(|context| ServerTransaction { context }))
+        SigningContext::server_request(store, message)
+            .map(|context| context.map(|context| ServerTransaction { context }))
     }
 
     /// Produces a signed answer.
@@ -587,7 +549,8 @@ impl<K: AsRef<Key>> ServerTransaction<K> {
     /// isn’t enough space left, it returns the builder unchanged as the
     /// error case.
     pub fn answer<Target: OctetsBuilder>(
-        self, message: &mut AdditionalBuilder<Target>
+        self,
+        message: &mut AdditionalBuilder<Target>,
     ) -> Result<(), ShortBuf> {
         self.answer_with_fudge(message, 300)
     }
@@ -603,14 +566,12 @@ impl<K: AsRef<Key>> ServerTransaction<K> {
     pub fn answer_with_fudge<Target: OctetsBuilder>(
         self,
         message: &mut AdditionalBuilder<Target>,
-        fudge: u16
+        fudge: u16,
     ) -> Result<(), ShortBuf> {
-        let variables = Variables::new(
-            Time48::now(), fudge, TsigRcode::NoError, None
-        );
-        let (mac, key) = self.context.final_answer(
-            message.as_slice(), None, &variables
-        );
+        let variables = Variables::new(Time48::now(), fudge, TsigRcode::NoError, None);
+        let (mac, key) = self
+            .context
+            .final_answer(message.as_slice(), None, &variables);
         let mac = key.as_ref().signature_slice(&mac);
         key.as_ref().complete_message(message, &variables, mac)
     }
@@ -620,7 +581,6 @@ impl<K: AsRef<Key>> ServerTransaction<K> {
         self.context.key()
     }
 }
-
 
 //------------ ClientSequence ------------------------------------------------
 
@@ -668,7 +628,8 @@ impl<K: AsRef<Key>> ClientSequence<K> {
     /// freeze the message and return both it and a new value of a client
     /// sequence.
     pub fn request<Target: OctetsBuilder>(
-        key: K, message: &mut AdditionalBuilder<Target>
+        key: K,
+        message: &mut AdditionalBuilder<Target>,
     ) -> Result<Self, ShortBuf> {
         Self::request_with_fudge(key, message, 300)
     }
@@ -683,18 +644,20 @@ impl<K: AsRef<Key>> ClientSequence<K> {
     ///
     /// [`request`]: #method.request
     pub fn request_with_fudge<Target: OctetsBuilder>(
-        key: K, message: &mut AdditionalBuilder<Target>, fudge: u16
+        key: K,
+        message: &mut AdditionalBuilder<Target>,
+        fudge: u16,
     ) -> Result<Self, ShortBuf> {
-        let variables = Variables::new(
-            Time48::now(), fudge, TsigRcode::NoError, None
-        );
-        let (mut context, mac) = SigningContext::request(
-            key, message.as_slice(), None, &variables
-        );
+        let variables = Variables::new(Time48::now(), fudge, TsigRcode::NoError, None);
+        let (mut context, mac) = SigningContext::request(key, message.as_slice(), None, &variables);
         let mac = context.key().signature_slice(&mac);
         context.apply_signature(mac);
         context.key().complete_message(message, &variables, mac)?;
-        Ok(ClientSequence { context, first: true, unsigned: 0 })
+        Ok(ClientSequence {
+            context,
+            first: true,
+            unsigned: 0,
+        })
     }
 
     /// Validates an answer.
@@ -705,18 +668,14 @@ impl<K: AsRef<Key>> ClientSequence<K> {
     ///
     /// If it doesn’t or if there had been more than 99 unsigned messages in
     /// the sequence since the last signed one, returns an error.
-    pub fn answer<Octets>(
-        &mut self,
-        message: &mut Message<Octets>
-    ) -> Result<(), ValidationError>
+    pub fn answer<Octets>(&mut self, message: &mut Message<Octets>) -> Result<(), ValidationError>
     where
         Octets: AsRef<[u8]> + AsMut<[u8]>,
-        for<'a> &'a Octets: OctetsRef
+        for<'a> &'a Octets: OctetsRef,
     {
         if self.first {
             self.answer_first(message)
-        }
-        else {
+        } else {
             self.answer_subsequent(message)
         }
     }
@@ -731,38 +690,32 @@ impl<K: AsRef<Key>> ClientSequence<K> {
         // The last message must be signed, so the counter must be 0 here.
         if self.unsigned != 0 {
             Err(ValidationError::TooManyUnsigned)
-        }
-        else {
+        } else {
             Ok(())
         }
     }
 
     /// Checks the first answer in the sequence.
-    fn answer_first<Octets>(
-        &mut self,
-        message: &mut Message<Octets>
-    ) -> Result<(), ValidationError>
+    fn answer_first<Octets>(&mut self, message: &mut Message<Octets>) -> Result<(), ValidationError>
     where
         Octets: AsRef<[u8]> + AsMut<[u8]>,
-        for<'a> &'a Octets: OctetsRef
+        for<'a> &'a Octets: OctetsRef,
     {
         let tsig = match self.context.get_answer_tsig(message)? {
             Some(some) => some,
-            None => return Err(ValidationError::ServerUnsigned)
+            None => return Err(ValidationError::ServerUnsigned),
         };
         let mut header = message.header_section();
         header.header_mut().set_id(tsig.data().original_id());
         header.counts_mut().dec_arcount();
         let signature = self.context.first_answer(
             header.as_slice(),
-            Some(&message.as_slice()[
-                 mem::size_of::<HeaderSection>()..tsig.start
-            ]),
-            &tsig.variables()
+            Some(&message.as_slice()[mem::size_of::<HeaderSection>()..tsig.start]),
+            &tsig.variables(),
         );
-        self.context.key().compare_signatures(
-            &signature, tsig.data().mac().as_ref()
-        )?;
+        self.context
+            .key()
+            .compare_signatures(&signature, tsig.data().mac().as_ref())?;
         self.context.apply_signature(tsig.data().mac().as_ref());
         self.context.check_answer_time(message, &tsig)?;
         self.first = false;
@@ -774,10 +727,10 @@ impl<K: AsRef<Key>> ClientSequence<K> {
     fn answer_subsequent<Octets>(
         &mut self,
         message: &mut Message<Octets>,
-    ) -> Result<(), ValidationError> 
+    ) -> Result<(), ValidationError>
     where
         Octets: AsRef<[u8]> + AsMut<[u8]>,
-        for<'a> &'a Octets: OctetsRef
+        for<'a> &'a Octets: OctetsRef,
     {
         let tsig = match self.context.get_answer_tsig(message)? {
             Some(tsig) => tsig,
@@ -785,10 +738,9 @@ impl<K: AsRef<Key>> ClientSequence<K> {
                 if self.unsigned < 99 {
                     self.context.unsigned_subsequent(message.as_slice());
                     self.unsigned += 1;
-                    return Ok(())
-                }
-                else {
-                    return Err(ValidationError::TooManyUnsigned)
+                    return Ok(());
+                } else {
+                    return Err(ValidationError::TooManyUnsigned);
                 }
             }
         };
@@ -799,14 +751,12 @@ impl<K: AsRef<Key>> ClientSequence<K> {
         header.counts_mut().dec_arcount();
         let signature = self.context.signed_subsequent(
             header.as_slice(),
-            Some(&message.as_slice()[
-                 mem::size_of::<HeaderSection>()..tsig.start
-            ]),
-            &tsig.variables()
+            Some(&message.as_slice()[mem::size_of::<HeaderSection>()..tsig.start]),
+            &tsig.variables(),
         );
-        self.context.key().compare_signatures(
-            &signature, tsig.data().mac().as_ref()
-        )?;
+        self.context
+            .key()
+            .compare_signatures(&signature, tsig.data().mac().as_ref())?;
         self.context.apply_signature(tsig.data().mac().as_ref());
         self.context.check_answer_time(message, &tsig)?;
         self.unsigned = 0;
@@ -819,7 +769,6 @@ impl<K: AsRef<Key>> ClientSequence<K> {
         self.context.key()
     }
 }
-
 
 //------------ ServerSequence ------------------------------------------------
 
@@ -864,18 +813,19 @@ impl<K: AsRef<Key>> ServerSequence<K> {
     /// client as the error case of the result.
     pub fn request<Store, Octets>(
         store: &Store,
-        message: &mut Message<Octets>
+        message: &mut Message<Octets>,
     ) -> Result<Option<Self>, ServerError<K>>
     where
-        Store: KeyStore<Key=K>,
+        Store: KeyStore<Key = K>,
         Octets: AsRef<[u8]> + AsMut<[u8]>,
-        for<'o> &'o Octets: OctetsRef
+        for<'o> &'o Octets: OctetsRef,
     {
-        SigningContext::server_request(
-            store, message
-        ).map(|context| context.map(|context| {
-            ServerSequence { context, first: false }
-        }))
+        SigningContext::server_request(store, message).map(|context| {
+            context.map(|context| ServerSequence {
+                context,
+                first: false,
+            })
+        })
     }
 
     /// Produces a signed answer.
@@ -886,7 +836,8 @@ impl<K: AsRef<Key>> ServerSequence<K> {
     /// fails because there wasn’t enough space in the builder, returns the
     /// unchanged builder as an error.
     pub fn answer<Target: OctetsBuilder>(
-        &mut self, message: &mut AdditionalBuilder<Target>
+        &mut self,
+        message: &mut AdditionalBuilder<Target>,
     ) -> Result<(), ShortBuf> {
         self.answer_with_fudge(message, 300)
     }
@@ -899,19 +850,16 @@ impl<K: AsRef<Key>> ServerSequence<K> {
     pub fn answer_with_fudge<Target: OctetsBuilder>(
         &mut self,
         message: &mut AdditionalBuilder<Target>,
-        fudge: u16
+        fudge: u16,
     ) -> Result<(), ShortBuf> {
-        let variables = Variables::new(
-            Time48::now(), fudge, TsigRcode::NoError, None
-        );
+        let variables = Variables::new(Time48::now(), fudge, TsigRcode::NoError, None);
         let mac = if self.first {
             self.first = false;
-            self.context.first_answer(message.as_slice(), None, &variables)
-        }
-        else {
-            self.context.signed_subsequent(
-                message.as_slice(), None, &variables
-            )
+            self.context
+                .first_answer(message.as_slice(), None, &variables)
+        } else {
+            self.context
+                .signed_subsequent(message.as_slice(), None, &variables)
         };
         let mac = self.key().signature_slice(&mac);
         self.key().complete_message(message, &variables, mac)
@@ -922,7 +870,6 @@ impl<K: AsRef<Key>> ServerSequence<K> {
         self.context.key()
     }
 }
-
 
 //------------ SigningContext ------------------------------------------------
 
@@ -964,19 +911,19 @@ impl<K: AsRef<Key>> SigningContext<K> {
     /// to the client otherwise.
     fn server_request<Store, Octets>(
         store: &Store,
-        message: &mut Message<Octets>
+        message: &mut Message<Octets>,
     ) -> Result<Option<Self>, ServerError<Store::Key>>
     where
         Store: KeyStore<Key = K>,
         Octets: AsRef<[u8]> + AsMut<[u8]>,
-        for<'a> &'a Octets: OctetsRef
+        for<'a> &'a Octets: OctetsRef,
     {
         // 4.5 Server TSIG checks
         //
         // First, do we have a valid TSIG?
         let tsig = match MessageTsig::from_message(message) {
             Some(tsig) => tsig,
-            None => return Ok(None)
+            None => return Ok(None),
         };
 
         // 4.5.1. KEY check and error handling
@@ -997,22 +944,21 @@ impl<K: AsRef<Key>> SigningContext<K> {
         header.header_mut().set_id(tsig.data().original_id());
         header.counts_mut().dec_arcount();
         let (mut context, signature) = Self::request(
-            key, header.as_slice(),
-            Some(&message.as_slice()[
-                 mem::size_of::<HeaderSection>()..tsig.start
-            ]),
-            &variables
+            key,
+            header.as_slice(),
+            Some(&message.as_slice()[mem::size_of::<HeaderSection>()..tsig.start]),
+            &variables,
         );
-        let res = context.key.as_ref().compare_signatures(
-            &signature,
-            tsig.data().mac().as_ref()
-        );
+        let res = context
+            .key
+            .as_ref()
+            .compare_signatures(&signature, tsig.data().mac().as_ref());
         if let Err(err) = res {
             return Err(ServerError::unsigned(match err {
                 ValidationError::BadTrunc => TsigRcode::BadTrunc,
                 ValidationError::BadKey => TsigRcode::BadKey,
                 _ => TsigRcode::FormErr,
-            }))
+            }));
         }
 
         // The signature is fine. Add it to the context for later.
@@ -1029,9 +975,9 @@ impl<K: AsRef<Key>> SigningContext<K> {
                     variables.time_signed,
                     variables.fudge,
                     TsigRcode::BadTime,
-                    Some(Time48::now())
-                )
-            ))
+                    Some(Time48::now()),
+                ),
+            ));
         }
         remove_tsig(tsig.into_original_id(), message);
         Ok(Some(context))
@@ -1054,22 +1000,25 @@ impl<K: AsRef<Key>> SigningContext<K> {
     /// later have to have the TSIG record stripped off and the ID updated.
     fn get_answer_tsig<'a, Octets>(
         &self,
-        message: &'a Message<Octets>
+        message: &'a Message<Octets>,
     ) -> Result<Option<MessageTsig<'a, Octets>>, ValidationError>
-    where Octets: AsRef<[u8]>, for<'o> &'o Octets: OctetsRef {
+    where
+        Octets: AsRef<[u8]>,
+        for<'o> &'o Octets: OctetsRef,
+    {
         // Extract TSIG or bail out.
         let tsig = match MessageTsig::from_message(message) {
             Some(tsig) => tsig,
-            None => return Ok(None)
+            None => return Ok(None),
         };
 
         // Check for unsigned errors.
         if message.header().rcode() == Rcode::NotAuth {
             if tsig.data().error() == TsigRcode::BadKey {
-                return Err(ValidationError::ServerBadKey)
+                return Err(ValidationError::ServerBadKey);
             }
             if tsig.data().error() == TsigRcode::BadSig {
-                return Err(ValidationError::ServerBadSig)
+                return Err(ValidationError::ServerBadSig);
             }
         }
 
@@ -1081,7 +1030,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
 
     /// Checks the timing values of an answer TSIG.
     ///
-    /// This is the second part of the code shared between the various 
+    /// This is the second part of the code shared between the various
     /// answer methods of `ClientTransaction` and `ClientSequence`. It
     /// checks for timing errors reported by the server as well as the
     /// time signed in the signature.
@@ -1090,22 +1039,24 @@ impl<K: AsRef<Key>> SigningContext<K> {
         message: &'a Message<Octets>,
         tsig: &MessageTsig<'a, Octets>,
     ) -> Result<(), ValidationError>
-    where Octets: AsRef<[u8]>, for<'o> &'o Octets: OctetsRef {
-        if message.header().rcode() == Rcode::NotAuth
-            && tsig.data().error() == TsigRcode::BadTime
-        {
+    where
+        Octets: AsRef<[u8]>,
+        for<'o> &'o Octets: OctetsRef,
+    {
+        if message.header().rcode() == Rcode::NotAuth && tsig.data().error() == TsigRcode::BadTime {
             let server = match tsig.data().other_time() {
                 Some(time) => time,
-                None => return Err(ValidationError::FormErr)
+                None => return Err(ValidationError::FormErr),
             };
             return Err(ValidationError::ServerBadTime {
-                client: tsig.data().time_signed(), server
-            })
+                client: tsig.data().time_signed(),
+                server,
+            });
         }
 
         // Check the time.
         if !tsig.data().is_valid_now() {
-            return Err(ValidationError::BadTime)
+            return Err(ValidationError::BadTime);
         }
 
         Ok(())
@@ -1117,7 +1068,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
     fn new(key: K) -> Self {
         SigningContext {
             context: key.as_ref().signing_context(),
-            key
+            key,
         }
     }
 
@@ -1150,7 +1101,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
         key: K,
         first: &[u8],
         second: Option<&[u8]>,
-        variables: &Variables
+        variables: &Variables,
     ) -> (Self, hmac::Tag) {
         let mut context = key.as_ref().signing_context();
         context.update(first);
@@ -1169,12 +1120,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
     ///
     /// This happens on a clone of the original signing context. The context
     /// itself will _not_ change.
-    fn answer(
-        &self,
-        first: &[u8],
-        second: Option<&[u8]>,
-        variables: &Variables
-    ) -> hmac::Tag {
+    fn answer(&self, first: &[u8], second: Option<&[u8]>, variables: &Variables) -> hmac::Tag {
         let mut context = self.context.clone();
         context.update(first);
         if let Some(second) = second {
@@ -1191,7 +1137,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
         mut self,
         first: &[u8],
         second: Option<&[u8]>,
-        variables: &Variables
+        variables: &Variables,
     ) -> (hmac::Tag, K) {
         self.context.update(first);
         if let Some(second) = second {
@@ -1208,7 +1154,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
         &mut self,
         first: &[u8],
         second: Option<&[u8]>,
-        variables: &Variables
+        variables: &Variables,
     ) -> hmac::Tag {
         // Replace current context with new context.
         let mut context = self.key().signing_context();
@@ -1224,10 +1170,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
     }
 
     /// Applies the content of an unsigned message to the context.
-    fn unsigned_subsequent(
-        &mut self,
-        message: &[u8]
-    ) {
+    fn unsigned_subsequent(&mut self, message: &[u8]) {
         self.context.update(message)
     }
 
@@ -1238,7 +1181,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
         &mut self,
         first: &[u8],
         second: Option<&[u8]>,
-        variables: &Variables
+        variables: &Variables,
     ) -> hmac::Tag {
         // Replace current context with new context.
         let mut context = self.key().signing_context();
@@ -1254,16 +1197,17 @@ impl<K: AsRef<Key>> SigningContext<K> {
     }
 }
 
-
 //------------ MessageTsig ---------------------------------------------------
 
 /// The TSIG record of a message.
 struct MessageTsig<'a, Octets>
-where for<'o> &'o Octets: OctetsRef {
+where
+    for<'o> &'o Octets: OctetsRef,
+{
     /// The actual record.
     record: Record<
         ParsedDname<&'a Octets>,
-        Tsig<<&'a Octets as OctetsRef>::Range, ParsedDname<&'a Octets>>
+        Tsig<<&'a Octets as OctetsRef>::Range, ParsedDname<&'a Octets>>,
     >,
 
     /// The index of the start of the record.
@@ -1271,27 +1215,34 @@ where for<'o> &'o Octets: OctetsRef {
 }
 
 impl<'a, Octets> MessageTsig<'a, Octets>
-where for<'o> &'o Octets: OctetsRef {
+where
+    for<'o> &'o Octets: OctetsRef,
+{
     /// Get the TSIG record from a message.
     ///
     /// Checks that there is exactly one TSIG record in the additional
     /// section, that it is the last record in this section. If that is true,
     /// returns the parsed TSIG records.
     fn from_message(msg: &'a Message<Octets>) -> Option<Self>
-    where Octets: AsRef<[u8]>, for<'o> &'o Octets: OctetsRef {
+    where
+        Octets: AsRef<[u8]>,
+        for<'o> &'o Octets: OctetsRef,
+    {
         let mut section = msg.additional().ok()?;
         let mut start = section.pos();
         let mut record = section.next()?;
         loop {
             record = match section.next() {
                 Some(record) => record,
-                None => break
+                None => break,
             };
             start = section.pos();
         }
-        record.ok()?.into_record::<Tsig<_, _>>().ok()?.map(|record| {
-            MessageTsig { record, start }
-        })
+        record
+            .ok()?
+            .into_record::<Tsig<_, _>>()
+            .ok()?
+            .map(|record| MessageTsig { record, start })
     }
 
     fn variables(&self) -> Variables {
@@ -1309,17 +1260,18 @@ where for<'o> &'o Octets: OctetsRef {
 }
 
 impl<'a, Octets> std::ops::Deref for MessageTsig<'a, Octets>
-where for<'o> &'o Octets: OctetsRef {
+where
+    for<'o> &'o Octets: OctetsRef,
+{
     type Target = Record<
         ParsedDname<&'a Octets>,
-        Tsig<<&'a Octets as OctetsRef>::Range, ParsedDname<&'a Octets>>
+        Tsig<<&'a Octets as OctetsRef>::Range, ParsedDname<&'a Octets>>,
     >;
 
     fn deref(&self) -> &Self::Target {
         &self.record
     }
 }
-
 
 //------------ Variables -----------------------------------------------------
 
@@ -1348,14 +1300,12 @@ struct Variables {
 
 impl Variables {
     /// Creates a new value from the parts.
-    fn new(
-        time_signed: Time48,
-        fudge: u16,
-        error: TsigRcode,
-        other: Option<Time48>
-    ) -> Self {
+    fn new(time_signed: Time48, fudge: u16, error: TsigRcode, other: Option<Time48>) -> Self {
         Variables {
-            time_signed, fudge, error, other
+            time_signed,
+            fudge,
+            error,
+            other,
         }
     }
 
@@ -1370,7 +1320,7 @@ impl Variables {
         let other = self.other.map(Time48::into_octets);
         let other = match other {
             Some(ref time) => time.as_ref(),
-            None => b""
+            None => b"",
         };
         builder.push((
             key.name.clone(),
@@ -1384,7 +1334,7 @@ impl Variables {
                 original_id,
                 self.error,
                 other,
-            )
+            ),
         ))
     }
 
@@ -1411,8 +1361,7 @@ impl Variables {
         // Other Len
         if self.other.is_some() {
             context.update(&6u16.to_be_bytes());
-        }
-        else {
+        } else {
             context.update(&0u16.to_be_bytes());
         }
         // Other
@@ -1431,7 +1380,6 @@ impl Variables {
     }
 }
 
-
 //------------ Algorithm -----------------------------------------------------
 
 /// The supported TSIG algorithms.
@@ -1440,7 +1388,7 @@ pub enum Algorithm {
     Sha1,
     Sha256,
     Sha384,
-    Sha512
+    Sha512,
 }
 
 impl Algorithm {
@@ -1451,18 +1399,18 @@ impl Algorithm {
         let mut labels = name.iter_labels();
         let first = match labels.next() {
             Some(label) => label,
-            None => return None
+            None => return None,
         };
         match labels.next() {
-            Some(label) if label.is_root() => {},
-            _ => return None
+            Some(label) if label.is_root() => {}
+            _ => return None,
         }
         match first.as_slice() {
             b"hmac-sha1" => Some(Algorithm::Sha1),
             b"hmac-sha256" => Some(Algorithm::Sha256),
             b"hmac-sha384" => Some(Algorithm::Sha384),
             b"hmac-sha512" => Some(Algorithm::Sha512),
-            _ => None
+            _ => None,
         }
     }
 
@@ -1479,7 +1427,7 @@ impl Algorithm {
         } else if alg == hmac::HMAC_SHA512 {
             Algorithm::Sha512
         } else {
-           panic!("Unknown TSIG key algorithm.") 
+            panic!("Unknown TSIG key algorithm.")
         }
     }
 
@@ -1505,11 +1453,7 @@ impl Algorithm {
 
     /// Returns a domain name for this value.
     pub fn to_dname(self) -> Dname<&'static [u8]> {
-        unsafe {
-            Dname::from_octets_unchecked(
-                self.into_wire_slice()
-            )
-        }
+        unsafe { Dname::from_octets_unchecked(self.into_wire_slice()) }
     }
 
     /// Returns the native length of a signature created with this algorithm.
@@ -1519,11 +1463,9 @@ impl Algorithm {
 
     /// Returns the bounds for the allowed signature size.
     pub fn within_len_bounds(self, len: usize) -> bool {
-        len >= cmp::max(10, self.native_len() / 2)
-        && len <= self.native_len()
+        len >= cmp::max(10, self.native_len() / 2) && len <= self.native_len()
     }
 }
-
 
 //--- FromStr
 
@@ -1541,32 +1483,33 @@ impl str::FromStr for Algorithm {
     }
 }
 
-
 //--- Display
 
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match *self {
-            Algorithm::Sha1 => "hmac-sha1",
-            Algorithm::Sha256 => "hmac-sha256",
-            Algorithm::Sha384 => "hmac-sha384",
-            Algorithm::Sha512 => "hmac-sha512",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                Algorithm::Sha1 => "hmac-sha1",
+                Algorithm::Sha256 => "hmac-sha256",
+                Algorithm::Sha384 => "hmac-sha384",
+                Algorithm::Sha512 => "hmac-sha512",
+            }
+        )
     }
 }
-
 
 //------------ Helper Functions ----------------------------------------------
 
 fn remove_tsig<Octets>(original_id: u16, message: &mut Message<Octets>)
 where
     Octets: AsRef<[u8]> + AsMut<[u8]>,
-    for<'o> &'o Octets: OctetsRef
+    for<'o> &'o Octets: OctetsRef,
 {
     message.header_mut().set_id(original_id);
     message.remove_last_additional();
 }
-
 
 //============ Error Types ===================================================
 
@@ -1585,15 +1528,13 @@ enum ServerErrorInner<K> {
     ///
     /// To crate the actual message, we need the original message with the
     /// TSIG intact as the last additional record.
-    Unsigned {
-        error: TsigRcode,
-    },
+    Unsigned { error: TsigRcode },
 
     /// Return a signed error message.
     Signed {
         context: SigningContext<K>,
         variables: Variables,
-    }
+    },
 }
 
 impl<K> ServerError<K> {
@@ -1619,18 +1560,19 @@ impl<K: AsRef<Key>> ServerError<K> {
         msg: &Message<Octets>,
         builder: MessageBuilder<Target>,
     ) -> Result<AdditionalBuilder<Target>, ShortBuf>
-    where for<'a> &'a Octets: OctetsRef {
+    where
+        for<'a> &'a Octets: OctetsRef,
+    {
         let builder = builder.start_answer(msg, Rcode::NotAuth)?;
         let mut builder = builder.additional();
         match self.0 {
             ServerErrorInner::Unsigned { error } => {
-                let tsig = {
-                    MessageTsig::from_message(
-                        msg
-                    ).expect("missing or malformed TSIG record")
-                };
+                let tsig =
+                    { MessageTsig::from_message(msg).expect("missing or malformed TSIG record") };
                 builder.push((
-                    tsig.owner(), tsig.class(), tsig.ttl(),
+                    tsig.owner(),
+                    tsig.class(),
+                    tsig.ttl(),
                     Tsig::new(
                         tsig.data().algorithm(),
                         tsig.data().time_signed(),
@@ -1639,21 +1581,19 @@ impl<K: AsRef<Key>> ServerError<K> {
                         msg.header().id(),
                         error,
                         b"",
-                    )
+                    ),
                 ))?;
             }
             ServerErrorInner::Signed { context, variables } => {
-                let (mac, key) = context.final_answer(
-                    builder.as_slice(), None, &variables
-                );
+                let (mac, key) = context.final_answer(builder.as_slice(), None, &variables);
                 let mac = key.as_ref().signature_slice(&mac);
-                key.as_ref().complete_message(&mut builder, &variables, mac)?;
+                key.as_ref()
+                    .complete_message(&mut builder, &variables, mac)?;
             }
         }
         Ok(builder)
     }
 }
-
 
 //--- Debug, Display, and Error
 
@@ -1669,11 +1609,10 @@ impl<K> fmt::Debug for ServerErrorInner<K> {
             ServerErrorInner::Unsigned { error } => {
                 f.debug_struct("Unsigned").field("error", &error).finish()
             }
-            ServerErrorInner::Signed { ref variables, .. } => {
-                f.debug_struct("Signed")
-                    .field("variables", variables)
-                    .finish()
-            }
+            ServerErrorInner::Signed { ref variables, .. } => f
+                .debug_struct("Signed")
+                .field("variables", variables)
+                .finish(),
         }
     }
 }
@@ -1684,7 +1623,7 @@ impl<K> fmt::Display for ServerError<K> {
     }
 }
 
-impl<K> error::Error for ServerError<K> { }
+impl<K> error::Error for ServerError<K> {}
 
 //------------ NewKeyError ---------------------------------------------------
 
@@ -1695,22 +1634,18 @@ pub enum NewKeyError {
     BadSigningLen,
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for NewKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            NewKeyError::BadMinMacLen
-                => f.write_str("minimum signature length out of bounds"),
-            NewKeyError::BadSigningLen
-                => f.write_str("created signature length out of bounds"),
+            NewKeyError::BadMinMacLen => f.write_str("minimum signature length out of bounds"),
+            NewKeyError::BadSigningLen => f.write_str("created signature length out of bounds"),
         }
     }
 }
 
-impl error::Error for NewKeyError { }
-
+impl error::Error for NewKeyError {}
 
 //------------ GenerateKeyError ----------------------------------------------
 
@@ -1722,14 +1657,13 @@ pub enum GenerateKeyError {
     GenerationFailed,
 }
 
-
 //--- From
 
 impl From<NewKeyError> for GenerateKeyError {
     fn from(err: NewKeyError) -> Self {
         match err {
             NewKeyError::BadMinMacLen => GenerateKeyError::BadMinMacLen,
-            NewKeyError::BadSigningLen => GenerateKeyError::BadSigningLen
+            NewKeyError::BadSigningLen => GenerateKeyError::BadSigningLen,
         }
     }
 }
@@ -1740,31 +1674,27 @@ impl From<ring::error::Unspecified> for GenerateKeyError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for GenerateKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            GenerateKeyError::BadMinMacLen
-                => f.write_str("minimum signature length out of bounds"),
-            GenerateKeyError::BadSigningLen
-                => f.write_str("created signature length out of bounds"),
-            GenerateKeyError::GenerationFailed
-                => f.write_str("generating key failed"),
+            GenerateKeyError::BadMinMacLen => f.write_str("minimum signature length out of bounds"),
+            GenerateKeyError::BadSigningLen => {
+                f.write_str("created signature length out of bounds")
+            }
+            GenerateKeyError::GenerationFailed => f.write_str("generating key failed"),
         }
     }
 }
 
-impl error::Error for GenerateKeyError { }
-
+impl error::Error for GenerateKeyError {}
 
 //------------ AlgorithmError ------------------------------------------------
 
 /// An invalid algorithm was provided.
 #[derive(Clone, Copy, Debug)]
 pub struct AlgorithmError;
-
 
 //--- Display and Error
 
@@ -1774,8 +1704,7 @@ impl fmt::Display for AlgorithmError {
     }
 }
 
-impl error::Error for AlgorithmError { }
-
+impl error::Error for AlgorithmError {}
 
 //------------ ValidationError -----------------------------------------------
 
@@ -1792,13 +1721,9 @@ pub enum ValidationError {
     ServerUnsigned,
     ServerBadKey,
     ServerBadSig,
-    ServerBadTime {
-        client: Time48,
-        server: Time48
-    },
+    ServerBadTime { client: Time48, server: Time48 },
     TooManyUnsigned,
 }
-
 
 //--- From
 
@@ -1808,39 +1733,25 @@ impl From<ParseError> for ValidationError {
     }
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ValidationError::BadAlg
-                => f.write_str("unknown algorithm"),
-            ValidationError::BadOther
-                => f.write_str("bad content of 'other' field"),
-            ValidationError::BadSig
-                => f.write_str("bad signature"),
-            ValidationError::BadTrunc
-                => f.write_str("short signature"),
-            ValidationError::BadKey
-                => f.write_str("unknown key"),
-            ValidationError::BadTime
-                => f.write_str("bad time"),
-            ValidationError::FormErr
-                => f.write_str("format error"),
-            ValidationError::ServerUnsigned
-                => f.write_str("unsigned answer"),
-            ValidationError::ServerBadKey
-                => f.write_str("unknown key on server"),
-            ValidationError::ServerBadSig
-                => f.write_str("server failed to verify MAC"),
-            ValidationError::ServerBadTime { .. }
-                => f.write_str("server reported bad time"),
-            ValidationError::TooManyUnsigned
-                => f.write_str("too many unsigned messages"),
+            ValidationError::BadAlg => f.write_str("unknown algorithm"),
+            ValidationError::BadOther => f.write_str("bad content of 'other' field"),
+            ValidationError::BadSig => f.write_str("bad signature"),
+            ValidationError::BadTrunc => f.write_str("short signature"),
+            ValidationError::BadKey => f.write_str("unknown key"),
+            ValidationError::BadTime => f.write_str("bad time"),
+            ValidationError::FormErr => f.write_str("format error"),
+            ValidationError::ServerUnsigned => f.write_str("unsigned answer"),
+            ValidationError::ServerBadKey => f.write_str("unknown key on server"),
+            ValidationError::ServerBadSig => f.write_str("server failed to verify MAC"),
+            ValidationError::ServerBadTime { .. } => f.write_str("server reported bad time"),
+            ValidationError::TooManyUnsigned => f.write_str("too many unsigned messages"),
         }
     }
 }
 
-impl error::Error for ValidationError { }
-
+impl error::Error for ValidationError {}

--- a/src/utils/base64.rs
+++ b/src/utils/base64.rs
@@ -233,7 +233,9 @@ impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             DecodeError::TrailingInput => f.write_str("trailing input"),
-            DecodeError::IllegalChar(ch) => write!(f, "illegal character '{}'", ch),
+            DecodeError::IllegalChar(ch) => {
+                write!(f, "illegal character '{}'", ch)
+            }
             DecodeError::ShortInput => f.write_str("incomplete input"),
         }
     }
@@ -302,10 +304,19 @@ mod test {
         assert_eq!(decode("Zm9vYmFy").unwrap().as_ref(), b"foobar");
 
         assert_eq!(decode("FPucA").unwrap_err(), DecodeError::ShortInput);
-        assert_eq!(decode("FPucA=").unwrap_err(), DecodeError::IllegalChar('='));
+        assert_eq!(
+            decode("FPucA=").unwrap_err(),
+            DecodeError::IllegalChar('=')
+        );
         assert_eq!(decode("FPucAw=").unwrap_err(), DecodeError::ShortInput);
-        assert_eq!(decode("FPucAw=a").unwrap_err(), DecodeError::TrailingInput);
-        assert_eq!(decode("FPucAw==a").unwrap_err(), DecodeError::TrailingInput);
+        assert_eq!(
+            decode("FPucAw=a").unwrap_err(),
+            DecodeError::TrailingInput
+        );
+        assert_eq!(
+            decode("FPucAw==a").unwrap_err(),
+            DecodeError::TrailingInput
+        );
     }
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,4 +4,3 @@
 
 pub mod base32;
 pub mod base64;
-

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -3,17 +3,16 @@
 //! **This module is experimental and likely to change significantly.**
 #![cfg(feature = "validate")]
 
-use std::{error, fmt};
-use std::vec::Vec;
-use ring::{digest, signature};
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, SecAlg};
-use crate::base::octets::{Compose, OctetsBuilder, ShortBuf};
 use crate::base::name::ToDname;
+use crate::base::octets::{Compose, OctetsBuilder, ShortBuf};
 use crate::base::rdata::RecordData;
 use crate::base::record::Record;
 use crate::rdata::{Dnskey, Rrsig};
-
+use ring::{digest, signature};
+use std::vec::Vec;
+use std::{error, fmt};
 
 //------------ Dnskey --------------------------------------------------------
 
@@ -45,7 +44,9 @@ pub trait DnskeyExt: Compose {
 }
 
 impl<Octets> DnskeyExt for Dnskey<Octets>
-where Octets: AsRef<[u8]> {
+where
+    Octets: AsRef<[u8]>,
+{
     /// Calculates a digest from DNSKEY.
     ///
     /// See [RFC 4034, Section 5.1.4]:
@@ -74,9 +75,7 @@ where Octets: AsRef<[u8]> {
         self.compose_canonical(&mut buf).unwrap();
 
         let mut ctx = match algorithm {
-            DigestAlg::Sha1 => {
-                digest::Context::new(&digest::SHA1_FOR_LEGACY_USE_ONLY)
-            },
+            DigestAlg::Sha1 => digest::Context::new(&digest::SHA1_FOR_LEGACY_USE_ONLY),
             DigestAlg::Sha256 => digest::Context::new(&digest::SHA256),
             DigestAlg::Sha384 => digest::Context::new(&digest::SHA384),
             _ => {
@@ -88,7 +87,6 @@ where Octets: AsRef<[u8]> {
         Ok(ctx.finish())
     }
 }
-
 
 //------------ Rrsig ---------------------------------------------------------
 
@@ -109,7 +107,9 @@ pub trait RrsigExt: Compose {
         &self,
         buf: &mut B,
         records: &mut [Record<N, D>],
-    ) -> Result<(), ShortBuf> where D: CanonicalOrd + Compose + Sized;
+    ) -> Result<(), ShortBuf>
+    where
+        D: CanonicalOrd + Compose + Sized;
 
     /// Attempt to use the cryptographic signature to authenticate the signed data, and thus authenticate the RRSET.
     /// The signed data is expected to be calculated as per [RFC4035, Section 5.3.2](https://tools.ietf.org/html/rfc4035#section-5.3.2).
@@ -145,7 +145,9 @@ impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
         buf: &mut B,
         records: &mut [Record<N, D>],
     ) -> Result<(), ShortBuf>
-    where D: CanonicalOrd + Compose + Sized {
+    where
+        D: CanonicalOrd + Compose + Sized,
+    {
         // signed_data = RRSIG_RDATA | RR(1) | RR(2)...  where
         //    "|" denotes concatenation
         // RRSIG_RDATA is the wire format of the RRSIG RDATA fields
@@ -176,7 +178,11 @@ impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
             if rrsig_labels < fqdn_labels {
                 // name = "*." | the rightmost rrsig_label labels of the fqdn
                 buf.append_slice(b"\x01*")?;
-                match fqdn.to_cow().iter_suffixes().nth(fqdn_labels - rrsig_labels) {
+                match fqdn
+                    .to_cow()
+                    .iter_suffixes()
+                    .nth(fqdn_labels - rrsig_labels)
+                {
                     Some(name) => name.compose_canonical(buf),
                     None => fqdn.compose_canonical(buf),
                 }?;
@@ -187,9 +193,7 @@ impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
             rr.rtype().compose(buf)?;
             rr.class().compose(buf)?;
             self.original_ttl().compose(buf)?;
-            buf.u16_len_prefixed(|buf| {
-                rr.data().compose_canonical(buf)
-            })?;
+            buf.u16_len_prefixed(|buf| rr.data().compose_canonical(buf))?;
         }
         Ok(())
     }
@@ -203,30 +207,20 @@ impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
         let signed_data = signed_data.as_ref();
 
         match self.algorithm() {
-            SecAlg::RsaSha1 | SecAlg::RsaSha1Nsec3Sha1 | SecAlg::RsaSha256 |
-            SecAlg::RsaSha512 => {
+            SecAlg::RsaSha1 | SecAlg::RsaSha1Nsec3Sha1 | SecAlg::RsaSha256 | SecAlg::RsaSha512 => {
                 let (algorithm, min_bytes) = match self.algorithm() {
-                    SecAlg::RsaSha1 | SecAlg::RsaSha1Nsec3Sha1 => {
-                        (
-                            &signature::
-                                RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,
-                            1024 / 8
-                        )
-                    }
-                    SecAlg::RsaSha256 => {
-                        (
-                            &signature::
-                                RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
-                            1024 / 8
-                        )
-                    }
-                    SecAlg::RsaSha512 => {
-                        (
-                            &signature::
-                                RSA_PKCS1_1024_8192_SHA512_FOR_LEGACY_USE_ONLY,
-                            1024 / 8
-                        )
-                    }
+                    SecAlg::RsaSha1 | SecAlg::RsaSha1Nsec3Sha1 => (
+                        &signature::RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,
+                        1024 / 8,
+                    ),
+                    SecAlg::RsaSha256 => (
+                        &signature::RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
+                        1024 / 8,
+                    ),
+                    SecAlg::RsaSha512 => (
+                        &signature::RSA_PKCS1_1024_8192_SHA512_FOR_LEGACY_USE_ONLY,
+                        1024 / 8,
+                    ),
                     _ => unreachable!(),
                 };
 
@@ -238,18 +232,15 @@ impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
                 // The key isn't available in either PEM or DER, so use the
                 // direct RSA verifier.
                 let (e, n) = rsa_exponent_modulus(dnskey)?;
-                let public_key = signature::RsaPublicKeyComponents {
-                    n: &n, e: &e
-                };
-                public_key.verify(algorithm, signed_data, &signature)
-                .map_err(|_| AlgorithmError::BadSig)
+                let public_key = signature::RsaPublicKeyComponents { n: &n, e: &e };
+                public_key
+                    .verify(algorithm, signed_data, &signature)
+                    .map_err(|_| AlgorithmError::BadSig)
             }
             SecAlg::EcdsaP256Sha256 | SecAlg::EcdsaP384Sha384 => {
                 let algorithm = match self.algorithm() {
-                    SecAlg::EcdsaP256Sha256 =>
-                        &signature::ECDSA_P256_SHA256_FIXED,
-                    SecAlg::EcdsaP384Sha384 =>
-                        &signature::ECDSA_P384_SHA384_FIXED,
+                    SecAlg::EcdsaP256Sha256 => &signature::ECDSA_P256_SHA256_FIXED,
+                    SecAlg::EcdsaP384Sha384 => &signature::ECDSA_P384_SHA384_FIXED,
                     _ => unreachable!(),
                 };
 
@@ -259,29 +250,24 @@ impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
                 key.push(0x4);
                 key.extend_from_slice(&public_key);
 
-                signature::UnparsedPublicKey::new(
-                    algorithm, &key
-                ).verify(&signed_data, &signature).map_err(|_|
-                    AlgorithmError::BadSig
-                )
+                signature::UnparsedPublicKey::new(algorithm, &key)
+                    .verify(&signed_data, &signature)
+                    .map_err(|_| AlgorithmError::BadSig)
             }
             SecAlg::Ed25519 => {
                 let key = dnskey.public_key();
-                signature::UnparsedPublicKey::new(
-                    &signature::ED25519, &key
-                ).verify(&signed_data, &signature).map_err(|_|
-                    AlgorithmError::BadSig
-                )
+                signature::UnparsedPublicKey::new(&signature::ED25519, &key)
+                    .verify(&signed_data, &signature)
+                    .map_err(|_| AlgorithmError::BadSig)
             }
             _ => Err(AlgorithmError::Unsupported),
         }
     }
 }
 
-
 /// Return the RSA exponent and modulus components from DNSKEY record data.
 fn rsa_exponent_modulus(
-    dnskey: &Dnskey<impl AsRef<[u8]>>
+    dnskey: &Dnskey<impl AsRef<[u8]>>,
 ) -> Result<(&[u8], &[u8]), AlgorithmError> {
     let public_key = dnskey.public_key().as_ref();
     if public_key.len() <= 3 {
@@ -304,7 +290,6 @@ fn rsa_exponent_modulus(
     Ok(public_key[pos..].split_at(exp_len))
 }
 
-
 //============ Error Types ===================================================
 
 //------------ AlgorithmError ------------------------------------------------
@@ -317,38 +302,32 @@ pub enum AlgorithmError {
     InvalidData,
 }
 
-
 //--- Display and Error
 
 impl fmt::Display for AlgorithmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            AlgorithmError::Unsupported
-                => f.write_str("unsupported algorithm"),
-            AlgorithmError::BadSig
-                => f.write_str("bad signature"),
-            AlgorithmError::InvalidData
-                => f.write_str("invalid data"),
+            AlgorithmError::Unsupported => f.write_str("unsupported algorithm"),
+            AlgorithmError::BadSig => f.write_str("bad signature"),
+            AlgorithmError::InvalidData => f.write_str("invalid data"),
         }
     }
 }
 
 impl error::Error for AlgorithmError {}
 
-
-
 //============ Test ==========================================================
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
-    use bytes::Bytes;
+    use super::*;
     use crate::base::iana::{Class, Rtype, SecAlg};
     use crate::base::serial::Serial;
     use crate::master::scan::Scanner;
     use crate::rdata::{MasterRecordData, Mx};
     use crate::utils::base64;
-    use super::*;
+    use bytes::Bytes;
+    use std::str::FromStr;
 
     type Dname = crate::base::name::Dname<Bytes>;
     type Ds = crate::rdata::Ds<Bytes>;
@@ -357,22 +336,28 @@ mod test {
 
     // Returns current root KSK/ZSK for testing.
     fn root_pubkey() -> (Dnskey, Dnskey) {
-        let ksk = base64::decode("\
+        let ksk = base64::decode(
+            "\
             AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/\
             4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMt\
             NROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwV\
             N8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK\
             6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+c\
-            n8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU="
-        ).unwrap().into();
-        let zsk = base64::decode("\
+            n8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU=",
+        )
+        .unwrap()
+        .into();
+        let zsk = base64::decode(
+            "\
             AwEAAeVDC34GZILwsQJy97K2Fst4P3XYZrXLyrkausYzSqEjSUulgh+iLgH\
             g0y7FIF890+sIjXsk7KLJUmCOWfYWPorNKEOKLk5Zx/4M6D3IHZE3O3m/Ea\
             hrc28qQzmTLxiMZAW65MvR2UO3LxVtYOPBEBiDgAQD47x2JLsJYtavCzNL5\
             WiUk59OgvHmDqmcC7VXYBhK8V8Tic089XJgExGeplKWUt9yyc31ra1swJX5\
             1XsOaQz17+vyLVH8AZP26KvKFiZeoRbaq6vl+hc8HQnI2ug5rA2zoz3MsSQ\
-            BvP1f/HvqsWxLqwXXKyDD1QM639U+XzVB8CYigyscRP22QCnwKIU="
-        ).unwrap().into();
+            BvP1f/HvqsWxLqwXXKyDD1QM639U+XzVB8CYigyscRP22QCnwKIU=",
+        )
+        .unwrap()
+        .into();
         (
             Dnskey::new(257, 3, SecAlg::RsaSha256, ksk),
             Dnskey::new(256, 3, SecAlg::RsaSha256, zsk),
@@ -429,16 +414,24 @@ mod test {
     fn rrsig_verify_rsa_sha256() {
         let (ksk, zsk) = root_pubkey();
         let rrsig = Rrsig::new(
-            Rtype::Dnskey, SecAlg::RsaSha256, 0, 172800, 1560211200.into(),
-            1558396800.into(), 20326, Dname::root(),
+            Rtype::Dnskey,
+            SecAlg::RsaSha256,
+            0,
+            172800,
+            1560211200.into(),
+            1558396800.into(),
+            20326,
+            Dname::root(),
             base64::decode(
                 "otBkINZAQu7AvPKjr/xWIEE7+SoZtKgF8bzVynX6bfJMJuPay8jPvNmwXk\
                 ZOdSoYlvFp0bk9JWJKCh8y5uoNfMFkN6OSrDkr3t0E+c8c0Mnmwkk5CETH3\
                 Gqxthi0yyRX5T4VlHU06/Ks4zI+XAgl3FBpOc554ivdzez8YCjAIGx7Xgzz\
                 ooEb7heMSlLc7S7/HNjw51TPRs4RxrAVcezieKCzPPpeWBhjE6R3oiSwrl0\
                 SBD4/yplrDlr7UHs/Atcm3MSgemdyr2sOoOUkVQCVpcj3SQQezoD2tCM786\
-                1CXEQdg5fjeHDtz285xHt5HJpA5cOcctRo4ihybfow/+V7AQ=="
-            ).unwrap().into()
+                1CXEQdg5fjeHDtz285xHt5HJpA5cOcctRo4ihybfow/+V7AQ==",
+            )
+            .unwrap()
+            .into(),
         );
         rrsig_verify_dnskey(ksk, zsk, rrsig);
     }
@@ -447,29 +440,45 @@ mod test {
     fn rrsig_verify_ecdsap256_sha256() {
         let (ksk, zsk) = (
             Dnskey::new(
-                257, 3, SecAlg::EcdsaP256Sha256,
+                257,
+                3,
+                SecAlg::EcdsaP256Sha256,
                 base64::decode(
                     "mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAe\
-                    F+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ=="
-                ).unwrap().into()
+                    F+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+                )
+                .unwrap()
+                .into(),
             ),
             Dnskey::new(
-                256, 3, SecAlg::EcdsaP256Sha256,
+                256,
+                3,
+                SecAlg::EcdsaP256Sha256,
                 base64::decode(
                     "oJMRESz5E4gYzS/q6XDrvU1qMPYIjCWzJaOau8XNEZeqCYKD5ar0IR\
-                    d8KqXXFJkqmVfRvMGPmM1x8fGAa2XhSA=="
-                ).unwrap().into()
+                    d8KqXXFJkqmVfRvMGPmM1x8fGAa2XhSA==",
+                )
+                .unwrap()
+                .into(),
             ),
         );
 
         let owner = Dname::from_str("cloudflare.com.").unwrap();
         let rrsig = Rrsig::new(
-            Rtype::Dnskey, SecAlg::EcdsaP256Sha256, 2, 3600,
-            1560314494.into(), 1555130494.into(), 2371, owner.clone(),
+            Rtype::Dnskey,
+            SecAlg::EcdsaP256Sha256,
+            2,
+            3600,
+            1560314494.into(),
+            1555130494.into(),
+            2371,
+            owner.clone(),
             base64::decode(
                 "8jnAGhG7O52wmL065je10XQztRX1vK8P8KBSyo71Z6h5wAT9+GFxKBaE\
-                zcJBLvRmofYFDAhju21p1uTfLaYHrg=="
-            ).unwrap().into()
+                zcJBLvRmofYFDAhju21p1uTfLaYHrg==",
+            )
+            .unwrap()
+            .into(),
         );
         rrsig_verify_dnskey(ksk, zsk, rrsig);
     }
@@ -495,16 +504,22 @@ mod test {
             ),
         );
 
-        let owner = Dname::from_octets(
-            Bytes::from(b"\x07ED25519\x02nl\x00".as_ref())
-        ).unwrap();
+        let owner = Dname::from_octets(Bytes::from(b"\x07ED25519\x02nl\x00".as_ref())).unwrap();
         let rrsig = Rrsig::new(
-            Rtype::Dnskey, SecAlg::Ed25519, 2, 3600, 1559174400.into(),
-            1557360000.into(), 45515, owner.clone(),
+            Rtype::Dnskey,
+            SecAlg::Ed25519,
+            2,
+            3600,
+            1559174400.into(),
+            1557360000.into(),
+            45515,
+            owner.clone(),
             base64::decode(
                 "hvPSS3E9Mx7lMARqtv6IGiw0NE0uz0mZewndJCHTkhwSYqlasUq7KfO5\
-                QdtgPXja7YkTaqzrYUbYk01J8ICsAA=="
-            ).unwrap().into()
+                QdtgPXja7YkTaqzrYUbYk01J8ICsAA==",
+            )
+            .unwrap()
+            .into(),
         );
         rrsig_verify_dnskey(ksk, zsk, rrsig);
     }
@@ -513,21 +528,27 @@ mod test {
     fn rrsig_verify_generic_type() {
         let (ksk, zsk) = root_pubkey();
         let rrsig = Rrsig::new(
-            Rtype::Dnskey, SecAlg::RsaSha256, 0, 172800, 1560211200.into(),
-            1558396800.into(), 20326, Dname::root(),
+            Rtype::Dnskey,
+            SecAlg::RsaSha256,
+            0,
+            172800,
+            1560211200.into(),
+            1558396800.into(),
+            20326,
+            Dname::root(),
             base64::decode(
                 "otBkINZAQu7AvPKjr/xWIEE7+SoZtKgF8bzVynX6bfJMJuPay8jPvNmwXkZ\
                 OdSoYlvFp0bk9JWJKCh8y5uoNfMFkN6OSrDkr3t0E+c8c0Mnmwkk5CETH3Gq\
                 xthi0yyRX5T4VlHU06/Ks4zI+XAgl3FBpOc554ivdzez8YCjAIGx7XgzzooE\
                 b7heMSlLc7S7/HNjw51TPRs4RxrAVcezieKCzPPpeWBhjE6R3oiSwrl0SBD4\
                 /yplrDlr7UHs/Atcm3MSgemdyr2sOoOUkVQCVpcj3SQQezoD2tCM7861CXEQ\
-                dg5fjeHDtz285xHt5HJpA5cOcctRo4ihybfow/+V7AQ=="
-            ).unwrap().into()
+                dg5fjeHDtz285xHt5HJpA5cOcctRo4ihybfow/+V7AQ==",
+            )
+            .unwrap()
+            .into(),
         );
 
-        let mut records: Vec<
-            Record<Dname, MasterRecordData<Bytes, Dname>>
-        > = [&ksk, &zsk]
+        let mut records: Vec<Record<Dname, MasterRecordData<Bytes, Dname>>> = [&ksk, &zsk]
             .iter()
             .cloned()
             .map(|x| {
@@ -554,27 +575,41 @@ mod test {
     #[test]
     fn rrsig_verify_wildcard() {
         let key = Dnskey::new(
-            256, 3, SecAlg::RsaSha1,
+            256,
+            3,
+            SecAlg::RsaSha1,
             base64::decode(
                 "AQOy1bZVvpPqhg4j7EJoM9rI3ZmyEx2OzDBVrZy/lvI5CQePxX\
                 HZS4i8dANH4DX3tbHol61ek8EFMcsGXxKciJFHyhl94C+NwILQd\
                 zsUlSFovBZsyl/NX6yEbtw/xN9ZNcrbYvgjjZ/UVPZIySFNsgEY\
-                vh0z2542lzMKR4Dh8uZffQ=="
-        ).unwrap().into());
+                vh0z2542lzMKR4Dh8uZffQ==",
+            )
+            .unwrap()
+            .into(),
+        );
         let rrsig = Rrsig::new(
-            Rtype::Mx, SecAlg::RsaSha1, 2, 3600,
-            rrsig_serial("20040509183619"), rrsig_serial("20040409183619"),
-            38519, Dname::from_str("example.").unwrap(),
+            Rtype::Mx,
+            SecAlg::RsaSha1,
+            2,
+            3600,
+            rrsig_serial("20040509183619"),
+            rrsig_serial("20040409183619"),
+            38519,
+            Dname::from_str("example.").unwrap(),
             base64::decode(
-                 "OMK8rAZlepfzLWW75Dxd63jy2wswESzxDKG2f9AMN1CytCd10cYI\
+                "OMK8rAZlepfzLWW75Dxd63jy2wswESzxDKG2f9AMN1CytCd10cYI\
                  SAxfAdvXSZ7xujKAtPbctvOQ2ofO7AZJ+d01EeeQTVBPq4/6KCWhq\
                  e2XTjnkVLNvvhnc0u28aoSsG0+4InvkkOHknKxw4kX18MMR34i8lC\
-                 36SR5xBni8vHI="
-            ).unwrap().into()
+                 36SR5xBni8vHI=",
+            )
+            .unwrap()
+            .into(),
         );
         let record = Record::new(
-            Dname::from_str("a.z.w.example.").unwrap(), Class::In, 3600,
-            Mx::new(1, Dname::from_str("ai.example.").unwrap())
+            Dname::from_str("a.z.w.example.").unwrap(),
+            Class::In,
+            3600,
+            Mx::new(1, Dname::from_str("ai.example.").unwrap()),
         );
         let signed_data = {
             let mut buf = Vec::new();

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -75,7 +75,9 @@ where
         self.compose_canonical(&mut buf).unwrap();
 
         let mut ctx = match algorithm {
-            DigestAlg::Sha1 => digest::Context::new(&digest::SHA1_FOR_LEGACY_USE_ONLY),
+            DigestAlg::Sha1 => {
+                digest::Context::new(&digest::SHA1_FOR_LEGACY_USE_ONLY)
+            }
             DigestAlg::Sha256 => digest::Context::new(&digest::SHA256),
             DigestAlg::Sha384 => digest::Context::new(&digest::SHA384),
             _ => {
@@ -207,7 +209,10 @@ impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
         let signed_data = signed_data.as_ref();
 
         match self.algorithm() {
-            SecAlg::RsaSha1 | SecAlg::RsaSha1Nsec3Sha1 | SecAlg::RsaSha256 | SecAlg::RsaSha512 => {
+            SecAlg::RsaSha1
+            | SecAlg::RsaSha1Nsec3Sha1
+            | SecAlg::RsaSha256
+            | SecAlg::RsaSha512 => {
                 let (algorithm, min_bytes) = match self.algorithm() {
                     SecAlg::RsaSha1 | SecAlg::RsaSha1Nsec3Sha1 => (
                         &signature::RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,
@@ -232,15 +237,20 @@ impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
                 // The key isn't available in either PEM or DER, so use the
                 // direct RSA verifier.
                 let (e, n) = rsa_exponent_modulus(dnskey)?;
-                let public_key = signature::RsaPublicKeyComponents { n: &n, e: &e };
+                let public_key =
+                    signature::RsaPublicKeyComponents { n: &n, e: &e };
                 public_key
                     .verify(algorithm, signed_data, &signature)
                     .map_err(|_| AlgorithmError::BadSig)
             }
             SecAlg::EcdsaP256Sha256 | SecAlg::EcdsaP384Sha384 => {
                 let algorithm = match self.algorithm() {
-                    SecAlg::EcdsaP256Sha256 => &signature::ECDSA_P256_SHA256_FIXED,
-                    SecAlg::EcdsaP384Sha384 => &signature::ECDSA_P384_SHA384_FIXED,
+                    SecAlg::EcdsaP256Sha256 => {
+                        &signature::ECDSA_P256_SHA256_FIXED
+                    }
+                    SecAlg::EcdsaP384Sha384 => {
+                        &signature::ECDSA_P384_SHA384_FIXED
+                    }
                     _ => unreachable!(),
                 };
 
@@ -307,7 +317,9 @@ pub enum AlgorithmError {
 impl fmt::Display for AlgorithmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            AlgorithmError::Unsupported => f.write_str("unsupported algorithm"),
+            AlgorithmError::Unsupported => {
+                f.write_str("unsupported algorithm")
+            }
             AlgorithmError::BadSig => f.write_str("bad signature"),
             AlgorithmError::InvalidData => f.write_str("invalid data"),
         }
@@ -393,7 +405,14 @@ mod test {
         let mut records: Vec<_> = [&ksk, &zsk]
             .iter()
             .cloned()
-            .map(|x| Record::new(rrsig.signer_name().clone(), Class::In, 0, x.clone()))
+            .map(|x| {
+                Record::new(
+                    rrsig.signer_name().clone(),
+                    Class::In,
+                    0,
+                    x.clone(),
+                )
+            })
             .collect();
         let signed_data = {
             let mut buf = Vec::new();
@@ -490,21 +509,28 @@ mod test {
                 257,
                 3,
                 SecAlg::Ed25519,
-                base64::decode("m1NELLVVQKl4fHVn/KKdeNO0PrYKGT3IGbYseT8XcKo=")
-                    .unwrap()
-                    .into(),
+                base64::decode(
+                    "m1NELLVVQKl4fHVn/KKdeNO0PrYKGT3IGbYseT8XcKo=",
+                )
+                .unwrap()
+                .into(),
             ),
             Dnskey::new(
                 256,
                 3,
                 SecAlg::Ed25519,
-                base64::decode("2tstZAjgmlDTePn0NVXrAHBJmg84LoaFVxzLl1anjGI=")
-                    .unwrap()
-                    .into(),
+                base64::decode(
+                    "2tstZAjgmlDTePn0NVXrAHBJmg84LoaFVxzLl1anjGI=",
+                )
+                .unwrap()
+                .into(),
             ),
         );
 
-        let owner = Dname::from_octets(Bytes::from(b"\x07ED25519\x02nl\x00".as_ref())).unwrap();
+        let owner = Dname::from_octets(Bytes::from(
+            b"\x07ED25519\x02nl\x00".as_ref(),
+        ))
+        .unwrap();
         let rrsig = Rrsig::new(
             Rtype::Dnskey,
             SecAlg::Ed25519,
@@ -548,14 +574,20 @@ mod test {
             .into(),
         );
 
-        let mut records: Vec<Record<Dname, MasterRecordData<Bytes, Dname>>> = [&ksk, &zsk]
-            .iter()
-            .cloned()
-            .map(|x| {
-                let data = MasterRecordData::from(x.clone());
-                Record::new(rrsig.signer_name().clone(), Class::In, 0, data)
-            })
-            .collect();
+        let mut records: Vec<Record<Dname, MasterRecordData<Bytes, Dname>>> =
+            [&ksk, &zsk]
+                .iter()
+                .cloned()
+                .map(|x| {
+                    let data = MasterRecordData::from(x.clone());
+                    Record::new(
+                        rrsig.signer_name().clone(),
+                        Class::In,
+                        0,
+                        data,
+                    )
+                })
+                .collect();
 
         let signed_data = {
             let mut buf = Vec::new();


### PR DESCRIPTION
This PR adds a ci step to check that everything is formatted, followed up by formatting of all files. 

Rationale for using rustfmt: This helps folks (including myself) who have rustmt by default run on every save to avoid some work of undoing the formatting. It'll take care of other whitespace errors (as reported by git) I believe as well.

Rationale for using the `stable` as formatter: I'd assume most devs looking to make changes in future will be using the latest stable locally. While there have been minor regressions in the past for rustfmt releases, I've found it to be quite stable, most likely just reformatting previously bad looking sections.

I do not really recommend merging this now, since it might make it quite difficult for anyone with open changes to merge/rebase them in. Feel free to just take the ci check, modify it to be based on other version and/or close this at any time :)