### PR TITLE
More lenient dependency requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,9 @@ jobs:
       run: cargo clippy --all-features -- -D warnings
     - run: cargo build --no-default-features --verbose
     - run: cargo test --features="master resolv resolv-sync sign tsig validate" --verbose
-
+    - if: matrix.rust == 'nightly'
+      run: |
+        cargo +nightly update -Z minimal-versions
+        cargo check --features="master resolv resolv-sync sign tsig validate" --verbose --all-targets
+        cargo test --features="master resolv resolv-sync sign tsig validate"
+      name: Check and test with minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 rand           = "0.7"
 
 bytes          = { version = "1.0", optional = true }
-chrono         = { version = "0.4", optional = true }
+chrono         = { version = "0.4.1", optional = true }
 futures        = { version = "0.3", optional = true }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.16.14", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 rand           = "0.7"
 
 bytes          = { version = "1", optional = true }
-chrono         = { version = "0.4.1", optional = true }
+chrono         = { version = "0.4.6", optional = true }
 futures        = { version = "0.3", optional = true }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.16.14", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rand           = "0.7"
 
 bytes          = { version = "1.0", optional = true }
 chrono         = { version = "0.4", optional = true }
-futures        = { version = "0.3.9", optional = true }
+futures        = { version = "0.3", optional = true }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.16.14", optional = true }
 smallvec       = { version = "1.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,17 @@ ring           = { version = "0.16.14", optional = true }
 smallvec       = { version = "1", optional = true }
 tokio          = { version = "1", optional = true, features = ["io-util", "macros", "net", "time"] }
 
+[target.'cfg(macos)'.dependencies]
+# specifying this overrides minimum-version mio's 0.2.69 libc dependency, which allows the build to work
+libc = { version = "0.2.71", default-features = false, optional = true }
+
 [features]
 # If you add a feature here, also add it to .github/workflows/ci.yml for the
 # cargo test run. Only interop must not be present.
 default     = ["std"]
 interop     = ["bytes", "ring"]
 master      = ["std", "bytes", "chrono"]
-resolv      = ["bytes", "futures", "smallvec", "std", "tokio"]
+resolv      = ["bytes", "futures", "smallvec", "std", "tokio", "libc"]
 resolv-sync = ["resolv", "tokio/rt"]
 sign        = ["std"]
 std         = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ path = "src/lib.rs"
 [dependencies]
 rand           = "0.7"
 
-bytes          = { version = "1.0", optional = true }
+bytes          = { version = "1", optional = true }
 chrono         = { version = "0.4.1", optional = true }
 futures        = { version = "0.3", optional = true }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.16.14", optional = true }
 smallvec       = { version = "1", optional = true }
-tokio          = { version = "1.0", optional = true, features = ["io-util", "macros", "net", "time"] }
+tokio          = { version = "1", optional = true, features = ["io-util", "macros", "net", "time"] }
 
 [features]
 # If you add a feature here, also add it to .github/workflows/ci.yml for the
@@ -41,7 +41,7 @@ validate    = ["std", "ring"]
 
 [dev-dependencies]
 tokio-native-tls   = "0.3"
-tokio              = { version = "1.0", features = ["rt-multi-thread", "io-util", "net"] }
+tokio              = { version = "1", features = ["rt-multi-thread", "io-util", "net"] }
 
 [[example]]
 name = "readzone"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono         = { version = "0.4", optional = true }
 futures        = { version = "0.3", optional = true }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.16.14", optional = true }
-smallvec       = { version = "1.6", optional = true }
+smallvec       = { version = "1", optional = true }
 tokio          = { version = "1.0", optional = true, features = ["io-util", "macros", "net", "time"] }
 
 [features]


### PR DESCRIPTION
This fixes my over-eager minimum version raising for smallvec. Since the earliest of 1.0.0 seems to work, it should be required, and the same logic is followed for other deps. I found this by trying to update the crate as the rust-ipfs dep and there was at least one conflict with a smallvec 1.4.2 requirement coming from libp2p-core. With "1" domain is compatible with that as well.

In addition to tweaking the versions, this adds a `cargo +nightly update -Z minimal-versions` following https://github.com/rust-lang/cargo/issues/5657. This is how I found that `chrono 0.4.0` was not good, but `0.4.6` was. Later on the dependency minimal versions should be raised if the last test starts to fail.