### PR TITLE
doc: document feature flags on docs.rs with doc_cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tokio              = { version = "1", features = ["rt-multi-thread", "io-util", 
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "readzone"

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,9 +13,14 @@ Bug Fixes
 
 Other Changes
 
+* Enable `doc_cfg` feature flag documentation for docs.rs.
+  ([#104] by [Martin Fischer])
+
 [#101]: https://github.com/NLnetLabs/domain/pull/101
 [#102]: https://github.com/NLnetLabs/domain/pull/102
 [@xofyarg]: https://github.com/xofyarg
+[#104]: https://github.com/NLnetLabs/domain/pull/104
+[Martin Fischer]: https://push-f.com/
 
 
 ## 0.6.1

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -152,6 +152,7 @@ impl<Octets: ?Sized> CharStr<Octets> {
 }
 
 #[cfg(feature = "bytes")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 impl CharStr<Bytes> {
     /// Creates a new character string from a bytes value.
     ///
@@ -167,6 +168,7 @@ impl CharStr<Bytes> {
 
     /// Scans a character string given as a word of hexadecimal digits.
     #[cfg(feature = "master")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "master")))]
     pub fn scan_hex<C: CharSource>(
         scanner: &mut Scanner<C>,
     ) -> Result<Self, ScanError> {

--- a/src/base/serial.rs
+++ b/src/base/serial.rs
@@ -178,6 +178,7 @@ impl From<Serial> for u32 {
 }
 
 #[cfg(feature = "chrono")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 impl<T: TimeZone> From<DateTime<T>> for Serial {
     fn from(value: DateTime<T>) -> Self {
         Self(value.timestamp() as u32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@
 #![no_std]
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::unknown_clippy_lints)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(any(feature = "std"))]
 #[allow(unused_imports)] // Import macros even if unused.

--- a/src/master/mod.rs
+++ b/src/master/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! **This module is experimental and likely to change.**
 #![cfg(feature = "master")]
+#![cfg_attr(docsrs, doc(cfg(feature = "master")))]
 
 pub mod entry;
 pub mod reader;

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -321,6 +321,7 @@ macro_rules! rdata_types {
         //--- (Scan) and Display
 
         #[cfg(feature="master")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "master")))]
         impl MasterRecordData<
             bytes::Bytes, $crate::base::name::Dname<bytes::Bytes>
         > {

--- a/src/resolv/mod.rs
+++ b/src/resolv/mod.rs
@@ -31,6 +31,7 @@
 //! [`Resolver`]: resolver/trait.Resolver.html
 //! [`StubResolver`]: stub/struct.StubResolver.html
 #![cfg(feature = "resolv")]
+#![cfg_attr(docsrs, doc(cfg(feature = "resolv")))]
 
 pub use self::resolver::Resolver;
 pub use self::stub::StubResolver;

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -152,6 +152,7 @@ impl StubResolver {
 }
 
 #[cfg(feature = "resolv-sync")]
+#[cfg_attr(docsrs, doc(cfg(feature = "resolv-sync")))]
 impl StubResolver {
     /// Synchronously perform a DNS operation atop a standard resolver.
     ///

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! **This module is experimental and likely to change significantly.**
 #![cfg(feature = "sign")]
+#![cfg_attr(docsrs, doc(cfg(feature = "sign")))]
 
 pub mod key;
 //pub mod openssl;

--- a/src/sign/openssl.rs
+++ b/src/sign/openssl.rs
@@ -1,5 +1,6 @@
 //! Key and Signer using OpenSSL.
 #![cfg(feature = "openssl")]
+#![cfg_attr(docsrs, doc(cfg(feature = "openssl")))]
 
 use std::vec::Vec;
 use openssl::error::ErrorStack;

--- a/src/sign/ring.rs
+++ b/src/sign/ring.rs
@@ -1,5 +1,6 @@
 //! Key and Signer using ring.
 #![cfg(feature = "ring")]
+#![cfg_attr(docsrs, doc(cfg(feature = "ring")))]
 
 use super::key::SigningKey;
 use crate::base::iana::{DigestAlg, SecAlg};

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -52,6 +52,7 @@
 //! [`ClientSequence`]: struct.ClientSequence.html
 //! [`ServerSequence`]: struct.ServerSequence.html
 #![cfg(feature = "tsig")]
+#![cfg_attr(docsrs, doc(cfg(feature = "tsig")))]
 
 mod interop;
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2,6 +2,7 @@
 //!
 //! **This module is experimental and likely to change significantly.**
 #![cfg(feature = "validate")]
+#![cfg_attr(docsrs, doc(cfg(feature = "validate")))]
 
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, SecAlg};


### PR DESCRIPTION
The unstable doc_cfg feature[0] makes rustdoc generate pretty notes for
APIs that are annotated to require a certain feature flag.

This commit adds these annotations and enables the unstable feature
for docs.rs builds (which already use nightly[1]).

To build the documentation locally with this feature use:

RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --no-deps --all-features

Screenshots:

![image](https://user-images.githubusercontent.com/73739153/126062812-1df79800-1e3b-43f9-a012-768169f59298.png)
![image](https://user-images.githubusercontent.com/73739153/126062821-d91e2165-46d0-4dcb-b4e6-cae5d3868da1.png)


[0]: https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html
[1]: https://docs.rs/about/builds