### PR TITLE
Enable no_std support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-rand           = "0.8"
-
+rand           = { version = "0.8", optional = true }
 bytes          = { version = "1.0", optional = true }
 chrono         = { version = "0.4.6", optional = true }
 futures        = { version = "0.3", optional = true }
@@ -32,13 +31,14 @@ tokio          = { version = "1.0", optional = true, features = ["io-util", "mac
 libc = { version = "0.2.71", default-features = false, optional = true }
 
 [features]
-default     = ["std"]
+default     = ["std", "random"]
 interop     = ["bytes", "ring"]
 master      = ["std", "bytes", "chrono"]
-resolv      = ["bytes", "futures", "smallvec", "std", "tokio", "libc"]
+resolv      = ["bytes", "futures", "smallvec", "std", "tokio", "libc", "random"]
 resolv-sync = ["resolv", "tokio/rt"]
 sign        = ["std"]
 std         = []
+random      = ["rand"]
 tsig        = ["bytes", "ring", "smallvec"]
 validate    = ["std", "ring"]
 

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -126,6 +126,7 @@ impl Header {
     }
 
     /// Sets the value of the ID field to a randomly chosen number.
+    #[cfg(feature = "random")]
     pub fn set_random_id(&mut self) {
         self.set_id(::rand::random())
     }
@@ -407,15 +408,15 @@ impl FromStr for Flags {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut flags = Flags::new();
-        for token in s.to_uppercase().split(' ') {
+        for token in s.split(' ') {
             match token {
-                "QR" => flags.qr = true,
-                "AA" => flags.aa = true,
-                "TC" => flags.tc = true,
-                "RD" => flags.rd = true,
-                "RA" => flags.ra = true,
-                "AD" => flags.ad = true,
-                "CD" => flags.cd = true,
+                "QR" | "Qr" | "qR" | "qr" => flags.qr = true,
+                "AA" | "Aa" | "aA" | "aa" => flags.aa = true,
+                "TC" | "Tc" | "tC" | "tc" => flags.tc = true,
+                "RD" | "Rd" | "rD" | "rd" => flags.rd = true,
+                "RA" | "Ra" | "rA" | "ra" => flags.ra = true,
+                "AD" | "Ad" | "aD" | "ad" => flags.ad = true,
+                "CD" | "Cd" | "cD" | "cd" => flags.cd = true,
                 "" => {}
                 _ => return Err(FlagsFromStrError),
             }

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -254,6 +254,7 @@ impl<Target: OctetsBuilder> MessageBuilder<Target> {
     ///
     /// Sets a random ID, pushes the domain and the AXFR record type into
     /// the question section, and converts the builder into an answer builder.
+    #[cfg(feature = "random")]
     pub fn request_axfr<N: ToDname>(
         mut self,
         apex: N,


### PR DESCRIPTION
`domain`, while offering a std feature, doesn't compile without std, regardless of the feature.

I've marked this PR as a WIP, as there's still some open questions.

We do seemingly need rng in a couple of places.
There is some support for non-os based rng in `rand`, but we'll probably need to use some static variable to hold the value.
There's also the question of seeding the thing.