### PR TITLE
Add a blanket impl of OctetsBuilder for &mut T.

### DIFF
--- a/src/base/octets.rs
+++ b/src/base/octets.rs
@@ -543,6 +543,22 @@ pub trait OctetsBuilder: AsRef<[u8]> + AsMut<[u8]> + Sized {
     }
 }
 
+impl<'a, T: OctetsBuilder<Octets = T>> OctetsBuilder for &'a mut T {
+    type Octets = &'a mut T;
+
+    fn append_slice(&mut self, slice: &[u8]) -> Result<(), ShortBuf> {
+        (*self).append_slice(slice)
+    }
+
+    fn truncate(&mut self, len: usize) {
+        (*self).truncate(len)
+    }
+
+    fn freeze(self) -> Self::Octets {
+        self
+    }
+}
+
 #[cfg(feature = "std")]
 impl OctetsBuilder for Vec<u8> {
     type Octets = Self;


### PR DESCRIPTION
This PR adds a blanket impl for any `&mut T` if `T` is an octets builder that uses itself as the frozen octets sequence.