### PR TITLE
Fix typos in docstrings

### DIFF
--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -775,19 +775,17 @@ impl HeaderSection {
     ///
     /// # Panics
     ///
-    /// This function panics if the the octets slice is shorter than 24
-    /// octets.
+    /// This function panics if the octets slice is shorter than 12 octets.
     pub fn for_message_slice(s: &[u8]) -> &HeaderSection {
         assert!(s.len() >= mem::size_of::<HeaderSection>());
         unsafe { &*(s.as_ptr() as *const HeaderSection) }
     }
 
-    /// Creates a mutable reference from the ocetets slice of a message.
+    /// Creates a mutable reference from the octets slice of a message.
     ///
     /// # Panics
     ///
-    /// This function panics if the the octets slice is shorter than 24
-    /// octets.
+    /// This function panics if the octets slice is shorter than 12 octets.
     pub fn for_message_slice_mut(s: &mut [u8]) -> &mut HeaderSection {
         assert!(s.len() >= mem::size_of::<HeaderSection>());
         unsafe { &mut *(s.as_ptr() as *mut HeaderSection) }

--- a/src/base/octets.rs
+++ b/src/base/octets.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides the basic traits that allow defining types that are
 //! generic over a variable length sequence of octets. It implements these
-//! traits for most comonly used types of such sequences and provides a few
+//! traits for most commonly used types of such sequences and provides a few
 //! additional types for use in a no-std environment. In addition, it provides
 //! a few types and traits that make it easier to access data contained in
 //! such sequences.
@@ -18,7 +18,7 @@
 //! ## Octets and Octets References
 //!
 //! There is no special trait for octets, we simply use `AsRef<[u8]>` for
-//! imutable octets or `AsMut<[u8]>` if the octets of the sequence can be
+//! immutable octets or `AsMut<[u8]>` if the octets of the sequence can be
 //! manipulated (but the length is still fixed). This way, any type
 //! implementing these traits can be used already. The trait [`OctetsExt`]
 //! has been defined to collect additional methods that aren’t available via
@@ -1415,7 +1415,7 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
 impl<Ref: AsRef<[u8]>> Parser<Ref> {
     /// Takes and returns the next `len` octets.
     ///
-    /// Advances the parser by `len` octets. If there aren’t enough octats
+    /// Advances the parser by `len` octets. If there aren’t enough octets
     /// left, leaves the parser untouched and returns an error instead.
     pub fn parse_octets(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A DNS library for Rust.
 //!
-//! This crates provides a number of bulding blocks for developing
+//! This crates provides a number of building blocks for developing
 //! functionality related to the DNS. It provides fundamental types, traits,
 //! and code as well as a wide range of optional features. The intent is to
 //! eventually cover all aspects of modern DNS.
@@ -42,7 +42,7 @@
 //!
 //! The following is the complete list of the feature flags available.
 //!
-//! * `bytes`: Rnables using the types `Bytes` and `BytesMut` from the
+//! * `bytes`: Enables using the types `Bytes` and `BytesMut` from the
 //!    [bytes](https://github.com/tokio-rs/bytes) crate as octet sequences.
 //! * `chrono`: Adds the [chrono](https://github.com/chronotope/chrono)
 //!   crate as a dependency. This adds support for generating serial numbers


### PR DESCRIPTION
This is by no means a complete check of all the docstrings/comments, just a couple that caught my eye.