### PR TITLE
Require Resolver::Query to be Send.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain"
-version = "0.6.2-dev"
+version = "0.7.0-dev"
 edition = "2018"
 authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]
 description = "A DNS library for Rust."

--- a/src/resolv/resolver.rs
+++ b/src/resolv/resolver.rs
@@ -25,7 +25,7 @@ pub trait Resolver {
     type Answer: AsRef<Message<Self::Octets>>;
 
     /// The future resolving into an answer.
-    type Query: Future<Output = Result<Self::Answer, io::Error>>;
+    type Query: Future<Output = Result<Self::Answer, io::Error>> + Send;
 
     /// Returns a future answering a question.
     ///

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -204,7 +204,7 @@ impl<'a> Resolver for &'a StubResolver {
     type Octets = Bytes;
     type Answer = Answer;
     type Query =
-        Pin<Box<dyn Future<Output = Result<Answer, io::Error>> + 'a>>;
+        Pin<Box<dyn Future<Output = Result<Answer, io::Error>> + Send + 'a>>;
 
     fn query<N, Q>(&self, question: Q) -> Self::Query
     where


### PR DESCRIPTION
This will allow the resolver to be used in async functions spawned onto a Tokio runtime.

The stub resolver’s query struct is already `Send`, so no actual changes are necessary. However, because this changes the definition of the `Resolver` trait, this is a breaking change, anyway.

Fixes #96. 