### PR TITLE
add OctetsFrom implementations for common octet types

### DIFF
--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -7,6 +7,7 @@ use super::super::octets::{
 use super::super::octets::{DeserializeOctets, SerializeOctets};
 use super::builder::{DnameBuilder, FromStrError};
 use super::label::{Label, LabelTypeError, SplitLabelError};
+use super::parsed::ParsedDname;
 use super::relative::{DnameIter, RelativeDname};
 use super::traits::{ToDname, ToLabelIter};
 #[cfg(feature = "master")]
@@ -621,6 +622,17 @@ where
     fn octets_from(source: Dname<SrcOctets>) -> Result<Self, ShortBuf> {
         Octets::octets_from(source.0)
             .map(|octets| unsafe { Self::from_octets_unchecked(octets) })
+    }
+}
+
+impl<SrcOctets, Octets> OctetsFrom<ParsedDname<SrcOctets>> for Dname<Octets>
+where
+    SrcOctets: AsRef<[u8]>,
+    Octets: FromBuilder,
+    <Octets as FromBuilder>::Builder: EmptyBuilder,
+{
+    fn octets_from(source: ParsedDname<SrcOctets>) -> Result<Self, ShortBuf> {
+        source.to_dname().map_err(|_| ShortBuf)
     }
 }
 

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -1007,22 +1007,24 @@ impl<N, D> From<ShortBuf> for RecordParseError<N, D> {
 mod test {
 
     #[test]
-    #[cfg(features = "bytes")]
+    #[cfg(feature = "bytes")]
     fn ds_octets_into() {
-        use crate::base::iana::{DigestAlg, Rtype, SecAlg};
-        use crate::name::Dname;
-        use crate::octets::OctetsInto;
+        use crate::base::iana::{Class, DigestAlg, SecAlg};
+        use crate::base::octets::OctetsInto;
+        use crate::base::{Dname, Record};
         use crate::rdata::Ds;
+        use bytes::Bytes;
 
+        let owner = "a.example".parse::<Dname<Bytes>>().unwrap();
         let ds: Record<Dname<&[u8]>, Ds<&[u8]>> = Record::new(
-            "a.example".parse().unwrap(),
+            owner.for_slice(),
             Class::In,
             86400,
-            Ds::new(12, SecAlg::RsaSha256, b"something"),
+            Ds::new(12, SecAlg::RsaSha256, DigestAlg::Sha256, b"something"),
         );
         let ds_bytes: Record<Dname<Bytes>, Ds<Bytes>> =
-            ds.octets_into().unwrap();
+            ds.clone().octets_into().unwrap();
         assert_eq!(ds.owner(), ds_bytes.owner());
-        asswer_eq!(ds.data().digest(), ds_bytes.data().digest());
+        assert_eq!(ds.data().digest(), ds_bytes.data().digest());
     }
 }

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -1841,29 +1841,30 @@ mod test {
     use std::vec::Vec;
 
     #[test]
-    #[cfg(features = "bytes")]
+    #[cfg(feature = "bytes")]
     fn hinfo_octets_into() {
-        use crate::octets::OctetsInto;
+        use crate::base::octets::OctetsInto;
 
         let hinfo: Hinfo<Vec<u8>> =
             Hinfo::new("1234".parse().unwrap(), "abcd".parse().unwrap());
-        let hinfo_bytes: Hinfo<bytes::Bytes> = hinfo.octets_into().unwrap();
+        let hinfo_bytes: Hinfo<bytes::Bytes> =
+            hinfo.clone().octets_into().unwrap();
         assert_eq!(hinfo.cpu(), hinfo_bytes.cpu());
         assert_eq!(hinfo.os(), hinfo_bytes.os());
     }
 
     #[test]
-    #[cfg(features = "bytes")]
+    #[cfg(feature = "bytes")]
     fn minfo_octets_into() {
+        use crate::base::octets::OctetsInto;
         use crate::base::Dname;
-        use crate::octets::OctetsInto;
 
         let minfo: Minfo<Dname<Vec<u8>>> = Minfo::new(
             "a.example".parse().unwrap(),
             "b.example".parse().unwrap(),
         );
         let minfo_bytes: Minfo<Dname<bytes::Bytes>> =
-            minfo.octets_into().unwrap();
+            minfo.clone().octets_into().unwrap();
         assert_eq!(minfo.rmailbx(), minfo_bytes.rmailbx());
         assert_eq!(minfo.emailbx(), minfo_bytes.emailbx());
     }


### PR DESCRIPTION
Hi! 👋 This implements OctetsFrom trait for most common octet type conversions instead of providing a blanket implementation as a followup for https://github.com/NLnetLabs/domain/pull/89