### PR TITLE
Drop AsRef<[u8]> and AsMut<[u8]> from OctetsBuilder trait bounds.

### DIFF
--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -105,7 +105,7 @@ macro_rules! int_enum {
         }
 
         impl $crate::base::octets::Compose for $ianatype {
-            fn compose<T: $crate::base::octets::OctetsBuilder>(
+            fn compose<T: $crate::base::octets::OctetsBuilder + AsMut<[u8]>>(
                 &self,
                 target: &mut T
             ) -> Result<(), $crate::base::octets::ShortBuf> {

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -561,7 +561,7 @@ where
         R: AsRecord + 's,
         F: FnMut(ParsedRecord<&'s Octets>) -> Option<R>,
         T: Into<AnswerBuilder<O>>,
-        O: OctetsBuilder,
+        O: OctetsBuilder + AsMut<[u8]>,
     {
         let mut source = self.answer()?;
         let mut target = target.into();

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -217,7 +217,7 @@ impl MessageBuilder<StreamTarget<BytesMut>> {
     }
 }
 
-impl<Target: OctetsBuilder> MessageBuilder<Target> {
+impl<Target: OctetsBuilder + AsMut<[u8]>> MessageBuilder<Target> {
     /// Starts creating an answer for the given message.
     ///
     /// Specifically, this sets the ID, QR, OPCODE, RD, and RCODE fields
@@ -268,20 +268,22 @@ impl<Target: OctetsBuilder> MessageBuilder<Target> {
 
 /// # Access to the Message Header
 ///
-impl<Target: OctetsBuilder> MessageBuilder<Target> {
+impl<Target: OctetsBuilder + AsRef<[u8]>> MessageBuilder<Target> {
     /// Return the current value of the message header.
     pub fn header(&self) -> Header {
         *Header::for_message_slice(self.target.as_ref())
     }
 
-    /// Returns a mutable reference to the message header for manipulations.
-    pub fn header_mut(&mut self) -> &mut Header {
-        Header::for_message_slice_mut(self.target.as_mut())
-    }
-
     /// Return the current value of the message header counts.
     pub fn counts(&self) -> HeaderCounts {
         *HeaderCounts::for_message_slice(self.target.as_ref())
+    }
+}
+
+impl<Target: OctetsBuilder + AsMut<[u8]>> MessageBuilder<Target> {
+    /// Returns a mutable reference to the message header for manipulations.
+    pub fn header_mut(&mut self) -> &mut Header {
+        Header::for_message_slice_mut(self.target.as_mut())
     }
 
     /// Returns a mutable reference to the message header counts.
@@ -380,7 +382,7 @@ impl<Target> MessageBuilder<Target> {
 
 impl<Target> From<QuestionBuilder<Target>> for MessageBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: QuestionBuilder<Target>) -> Self {
         src.builder()
@@ -389,7 +391,7 @@ where
 
 impl<Target> From<AnswerBuilder<Target>> for MessageBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AnswerBuilder<Target>) -> Self {
         src.builder()
@@ -398,7 +400,7 @@ where
 
 impl<Target> From<AuthorityBuilder<Target>> for MessageBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AuthorityBuilder<Target>) -> Self {
         src.builder()
@@ -407,7 +409,7 @@ where
 
 impl<Target> From<AdditionalBuilder<Target>> for MessageBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AdditionalBuilder<Target>) -> Self {
         src.builder()
@@ -463,7 +465,9 @@ impl<Target: OctetsBuilder> QuestionBuilder<Target> {
     fn new(builder: MessageBuilder<Target>) -> Self {
         Self { builder }
     }
+}
 
+impl<Target: OctetsBuilder + AsMut<[u8]>> QuestionBuilder<Target> {
     /// Appends a question to the question section.
     ///
     /// This method accepts anything that implements the [`AsQuestion`]
@@ -502,7 +506,7 @@ impl<Target: OctetsBuilder> QuestionBuilder<Target> {
 /// # Conversions
 ///
 /// Additional conversion are available via the `Deref` implementation.
-impl<Target: OctetsBuilder> QuestionBuilder<Target> {
+impl<Target: OctetsBuilder + AsMut<[u8]>> QuestionBuilder<Target> {
     /// Rewinds to an empty question section.
     ///
     /// All previously added questions will be lost.
@@ -519,7 +523,9 @@ impl<Target: OctetsBuilder> QuestionBuilder<Target> {
         self.rewind();
         self.builder
     }
+}
 
+impl<Target: OctetsBuilder> QuestionBuilder<Target> {
     /// Converts the question builder into a question builder.
     ///
     /// In other words, doesn’t do anything.
@@ -587,7 +593,7 @@ where
 
 impl<Target> From<AnswerBuilder<Target>> for QuestionBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AnswerBuilder<Target>) -> Self {
         src.question()
@@ -596,7 +602,7 @@ where
 
 impl<Target> From<AuthorityBuilder<Target>> for QuestionBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AuthorityBuilder<Target>) -> Self {
         src.question()
@@ -605,7 +611,7 @@ where
 
 impl<Target> From<AdditionalBuilder<Target>> for QuestionBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AdditionalBuilder<Target>) -> Self {
         src.question()
@@ -690,11 +696,13 @@ impl<Target: OctetsBuilder> AnswerBuilder<Target> {
     /// Assumes that all three record sections are empty.
     fn new(builder: MessageBuilder<Target>) -> Self {
         AnswerBuilder {
-            start: builder.target.as_ref().len(),
+            start: builder.target.len(),
             builder,
         }
     }
+}
 
+impl<Target: OctetsBuilder + AsMut<[u8]>> AnswerBuilder<Target> {
     /// Appends a record to the answer section.
     ///
     /// This methods accepts anything that implements the [`AsRecord`] trait.
@@ -736,7 +744,7 @@ impl<Target: OctetsBuilder> AnswerBuilder<Target> {
 /// # Conversions
 ///
 /// Additional conversion are available via the `Deref` implementation.
-impl<Target: OctetsBuilder> AnswerBuilder<Target> {
+impl<Target: OctetsBuilder + AsMut<[u8]>> AnswerBuilder<Target> {
     /// Rewinds to an empty answer section.
     ///
     /// All previously added answers will be lost.
@@ -761,7 +769,9 @@ impl<Target: OctetsBuilder> AnswerBuilder<Target> {
         self.rewind();
         QuestionBuilder::new(self.builder)
     }
+}
 
+impl<Target: OctetsBuilder> AnswerBuilder<Target> {
     /// Converts the answer builder into an answer builder.
     ///
     /// This doesn’t do anything, really.
@@ -831,7 +841,7 @@ where
 
 impl<Target> From<AuthorityBuilder<Target>> for AnswerBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AuthorityBuilder<Target>) -> Self {
         src.answer()
@@ -840,7 +850,7 @@ where
 
 impl<Target> From<AdditionalBuilder<Target>> for AnswerBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AdditionalBuilder<Target>) -> Self {
         src.answer()
@@ -925,11 +935,13 @@ impl<Target: OctetsBuilder> AuthorityBuilder<Target> {
     /// Assumes that the authority and additional sections are empty.
     fn new(answer: AnswerBuilder<Target>) -> Self {
         AuthorityBuilder {
-            start: answer.as_target().as_ref().len(),
+            start: answer.as_target().len(),
             answer,
         }
     }
+}
 
+impl<Target: OctetsBuilder + AsMut<[u8]>> AuthorityBuilder<Target> {
     /// Appends a record to the authority section.
     ///
     /// This methods accepts anything that implements the [`AsRecord`] trait.
@@ -971,7 +983,7 @@ impl<Target: OctetsBuilder> AuthorityBuilder<Target> {
 ///
 /// Additional conversion methods are available via the `Deref`
 /// implementation.
-impl<Target: OctetsBuilder> AuthorityBuilder<Target> {
+impl<Target: OctetsBuilder + AsMut<[u8]>> AuthorityBuilder<Target> {
     /// Rewinds to an empty authority section.
     ///
     /// All previously added authority records will be lost.
@@ -1004,7 +1016,9 @@ impl<Target: OctetsBuilder> AuthorityBuilder<Target> {
         self.rewind();
         self.answer
     }
+}
 
+impl<Target: OctetsBuilder> AuthorityBuilder<Target> {
     /// Converts the authority builder into an authority builder.
     ///
     /// This is identical to the identity function.
@@ -1076,7 +1090,7 @@ where
 
 impl<Target> From<AdditionalBuilder<Target>> for AuthorityBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn from(src: AdditionalBuilder<Target>) -> Self {
         src.authority()
@@ -1166,11 +1180,13 @@ impl<Target: OctetsBuilder> AdditionalBuilder<Target> {
     /// Assumes that the additional section is currently empty.
     fn new(authority: AuthorityBuilder<Target>) -> Self {
         AdditionalBuilder {
-            start: authority.as_target().as_ref().len(),
+            start: authority.as_target().len(),
             authority,
         }
     }
+}
 
+impl<Target: OctetsBuilder + AsMut<[u8]>> AdditionalBuilder<Target> {
     /// Appends a record to the additional section.
     ///
     /// This methods accepts anything that implements the [`AsRecord`] trait.
@@ -1206,7 +1222,12 @@ impl<Target: OctetsBuilder> AdditionalBuilder<Target> {
             err
         })
     }
+}
 
+impl<Target> AdditionalBuilder<Target>
+where
+    Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
+{
     /// Appends and builds an OPT record.
     ///
     /// The actual building of the record is handled by a closure that
@@ -1229,7 +1250,7 @@ impl<Target: OctetsBuilder> AdditionalBuilder<Target> {
 ///
 /// Additional conversion methods are available via the `Deref`
 /// implementation.
-impl<Target: OctetsBuilder> AdditionalBuilder<Target> {
+impl<Target: OctetsBuilder + AsMut<[u8]>> AdditionalBuilder<Target> {
     /// Rewinds to an empty additional section.
     ///
     /// All previously added additional records will be lost.
@@ -1270,7 +1291,9 @@ impl<Target: OctetsBuilder> AdditionalBuilder<Target> {
         self.rewind();
         self.authority
     }
+}
 
+impl<Target: OctetsBuilder> AdditionalBuilder<Target> {
     /// Converts the additional builder into an additional builder.
     ///
     /// In other words, does absolutely nothing.
@@ -1404,14 +1427,14 @@ pub trait RecordSectionBuilder {
 
 impl<Target> RecordSectionBuilder for AnswerBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn push(&mut self, record: impl AsRecord) -> Result<(), ShortBuf> {
         Self::push(self, record)
     }
 }
 
-impl<Target: OctetsBuilder> RecordSectionBuilder
+impl<Target: OctetsBuilder + AsMut<[u8]>> RecordSectionBuilder
     for AuthorityBuilder<Target>
 {
     fn push(&mut self, record: impl AsRecord) -> Result<(), ShortBuf> {
@@ -1421,7 +1444,7 @@ impl<Target: OctetsBuilder> RecordSectionBuilder
 
 impl<Target> RecordSectionBuilder for AdditionalBuilder<Target>
 where
-    Target: OctetsBuilder,
+    Target: OctetsBuilder + AsMut<[u8]>,
 {
     fn push(&mut self, record: impl AsRecord) -> Result<(), ShortBuf> {
         Self::push(self, record)
@@ -1450,12 +1473,15 @@ pub struct OptBuilder<'a, Target> {
     arcount: u16,
 }
 
-impl<'a, Target: OctetsBuilder> OptBuilder<'a, Target> {
+impl<'a, Target> OptBuilder<'a, Target>
+where
+    Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
+{
     /// Creates a new opt builder atop an additional builder.
     fn new(
         additional: &'a mut AdditionalBuilder<Target>,
     ) -> Result<Self, ShortBuf> {
-        let start = additional.as_target().as_ref().len();
+        let start = additional.as_target().len();
         let arcount = additional.counts().arcount();
 
         let err = additional
@@ -1622,7 +1648,7 @@ pub struct StreamTarget<Target> {
     target: Target,
 }
 
-impl<Target: OctetsBuilder> StreamTarget<Target> {
+impl<Target: OctetsBuilder + AsMut<[u8]>> StreamTarget<Target> {
     /// Creates a new stream target wrapping an octets builder.
     ///
     /// The function will truncate the builder back to empty and appends the
@@ -1658,11 +1684,16 @@ impl<Target: OctetsBuilder> StreamTarget<Target> {
     }
 
     /// Updates the length value to the current length of the target.
-    fn update_shim(&mut self) {
+    fn update_shim(&mut self)
+    where
+        Target: AsMut<[u8]>,
+    {
         let len = (self.target.len() - 2) as u16;
         self.target.as_mut()[..2].copy_from_slice(&len.to_be_bytes())
     }
+}
 
+impl<Target: OctetsBuilder + AsRef<[u8]>> StreamTarget<Target> {
     /// Returns an octets slice of the message for stream transports.
     ///
     /// The slice will start with the length octets and can be send as is
@@ -1697,7 +1728,10 @@ impl<Target: AsMut<[u8]>> AsMut<[u8]> for StreamTarget<Target> {
 
 //--- OctetsBuilder
 
-impl<Target: OctetsBuilder> OctetsBuilder for StreamTarget<Target> {
+impl<Target> OctetsBuilder for StreamTarget<Target>
+where
+    Target: OctetsBuilder + AsMut<[u8]>,
+{
     type Octets = Target::Octets;
 
     fn append_slice(&mut self, slice: &[u8]) -> Result<(), ShortBuf> {
@@ -1717,6 +1751,14 @@ impl<Target: OctetsBuilder> OctetsBuilder for StreamTarget<Target> {
 
     fn freeze(self) -> Self::Octets {
         self.target.freeze()
+    }
+
+    fn len(&self) -> usize {
+        self.target.len() - 2
+    }
+
+    fn is_empty(&self) -> bool {
+        self.target.len() > 2
     }
 }
 
@@ -1833,7 +1875,10 @@ impl<Target: AsMut<[u8]>> AsMut<[u8]> for StaticCompressor<Target> {
 
 //--- OctetsBuilder
 
-impl<Target: OctetsBuilder> OctetsBuilder for StaticCompressor<Target> {
+impl<Target> OctetsBuilder for StaticCompressor<Target>
+where
+    Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
+{
     type Octets = Target::Octets;
 
     fn append_slice(&mut self, slice: &[u8]) -> Result<(), ShortBuf> {
@@ -1892,6 +1937,14 @@ impl<Target: OctetsBuilder> OctetsBuilder for StaticCompressor<Target> {
 
     fn freeze(self) -> Self::Octets {
         self.target.freeze()
+    }
+
+    fn len(&self) -> usize {
+        self.target.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.target.is_empty()
     }
 }
 
@@ -2042,7 +2095,10 @@ impl<Target: AsMut<[u8]>> AsMut<[u8]> for TreeCompressor<Target> {
 }
 
 #[cfg(feature = "std")]
-impl<Target: OctetsBuilder> OctetsBuilder for TreeCompressor<Target> {
+impl<Target> OctetsBuilder for TreeCompressor<Target>
+where
+    Target: OctetsBuilder + AsMut<[u8]>,
+{
     type Octets = Target::Octets;
 
     fn append_slice(&mut self, slice: &[u8]) -> Result<(), ShortBuf> {
@@ -2098,6 +2154,14 @@ impl<Target: OctetsBuilder> OctetsBuilder for TreeCompressor<Target> {
     fn freeze(self) -> Self::Octets {
         self.target.freeze()
     }
+
+    fn len(&self) -> usize {
+        self.target.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.target.is_empty()
+    }
 }
 
 //============ Testing =======================================================
@@ -2149,6 +2213,8 @@ mod test {
 
         // Convert the builder into the actual message.
         let target = msg.finish().into_target();
+
+        eprintln!("target {}", target.len());
 
         // Reparse message and check contents
         let msg = Message::from_octets(target.as_dgram_slice()).unwrap();
@@ -2202,7 +2268,10 @@ mod test {
         assert_eq!(opts.next(), Some(Ok(nsid)));
     }
 
-    fn create_compressed<T: OctetsBuilder + AsRef<[u8]>>(target: T) -> T {
+    fn create_compressed<T>(target: T) -> T
+    where
+        T: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
+    {
         let mut msg = MessageBuilder::from_target(target).unwrap().question();
         msg.header_mut().set_rcode(Rcode::NXDomain);
         msg.header_mut().set_rd(true);

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -70,7 +70,7 @@ impl<Builder> DnameBuilder<Builder> {
     /// consititutes a correctly encoded relative domain name.
     pub fn from_builder(builder: Builder) -> Result<Self, RelativeDnameError>
     where
-        Builder: OctetsBuilder,
+        Builder: OctetsBuilder + AsRef<[u8]>,
     {
         RelativeDname::check_slice(builder.as_ref())?;
         Ok(unsafe { DnameBuilder::from_builder_unchecked(builder) })
@@ -110,6 +110,18 @@ impl DnameBuilder<BytesMut> {
 }
 
 impl<Builder: OctetsBuilder> DnameBuilder<Builder> {
+    /// Returns the length of the already assembled domain name.
+    pub fn len(&self) -> usize {
+        self.builder.len()
+    }
+
+    /// Returns whether the name is still empty.
+    pub fn is_empty(&self) -> bool {
+        self.builder.is_empty()
+    }
+}
+
+impl<Builder: OctetsBuilder + AsMut<[u8]>> DnameBuilder<Builder> {
     /// Returns whether there currently is a label under construction.
     ///
     /// This returns `false` if the name is still empty or if the last thing
@@ -322,7 +334,7 @@ impl<Builder: EmptyBuilder> Default for DnameBuilder<Builder> {
 
 //--- Deref and AsRef
 
-impl<Builder: OctetsBuilder> ops::Deref for DnameBuilder<Builder> {
+impl<Builder: AsRef<[u8]>> ops::Deref for DnameBuilder<Builder> {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
@@ -330,7 +342,7 @@ impl<Builder: OctetsBuilder> ops::Deref for DnameBuilder<Builder> {
     }
 }
 
-impl<Builder: OctetsBuilder> AsRef<[u8]> for DnameBuilder<Builder> {
+impl<Builder: AsRef<[u8]>> AsRef<[u8]> for DnameBuilder<Builder> {
     fn as_ref(&self) -> &[u8] {
         self.builder.as_ref()
     }

--- a/src/base/name/chain.rs
+++ b/src/base/name/chain.rs
@@ -100,7 +100,7 @@ impl<L, R> Chain<L, R> {
 //--- Compose
 
 impl<L: ToRelativeDname, R: ToEitherDname> Compose for Chain<L, R> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -110,7 +110,7 @@ impl<L: ToRelativeDname, R: ToEitherDname> Compose for Chain<L, R> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -126,7 +126,7 @@ where
     Octets: AsRef<[u8]>,
     R: ToDname,
 {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -141,7 +141,7 @@ where
         }
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -95,7 +95,7 @@ impl<Octets> Dname<Octets> {
     pub fn from_chars<C>(chars: C) -> Result<Self, FromStrError>
     where
         Octets: FromBuilder,
-        <Octets as FromBuilder>::Builder: EmptyBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
         C: IntoIterator<Item = char>,
     {
         let mut builder = DnameBuilder::<Octets::Builder>::new();
@@ -629,7 +629,7 @@ where
 impl<Octets> FromStr for Dname<Octets>
 where
     Octets: FromBuilder,
-    <Octets as FromBuilder>::Builder: EmptyBuilder,
+    <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
 {
     type Err = FromStrError;
 
@@ -785,14 +785,14 @@ fn name_len<Source: AsRef<[u8]>>(
 }
 
 impl<Octets: AsRef<[u8]> + ?Sized> Compose for Dname<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
         target.append_slice(self.0.as_ref())
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -879,7 +879,7 @@ where
 impl<'de, Octets> serde::Deserialize<'de> for Dname<Octets>
 where
     Octets: FromBuilder + DeserializeOctets<'de>,
-    <Octets as FromBuilder>::Builder: EmptyBuilder,
+    <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
 {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
@@ -892,7 +892,7 @@ where
         where
             Octets: FromBuilder + DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets> + EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder + AsMut<[u8]>,
         {
             type Value = Dname<Octets>;
 
@@ -933,7 +933,7 @@ where
         where
             Octets: FromBuilder + DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets> + EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder + AsMut<[u8]>,
         {
             type Value = Dname<Octets>;
 

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -247,7 +247,7 @@ impl Label {
 //--- Compose
 
 impl Compose for Label {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -257,7 +257,7 @@ impl Compose for Label {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/base/name/parsed.rs
+++ b/src/base/name/parsed.rs
@@ -399,7 +399,7 @@ where
 }
 
 impl<Ref: AsRef<[u8]>> Compose for ParsedDname<Ref> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -415,7 +415,7 @@ impl<Ref: AsRef<[u8]>> Compose for ParsedDname<Ref> {
         }
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -3,7 +3,9 @@ use super::super::octets::{
     ParseError, ShortBuf,
 };
 #[cfg(feature = "serde")]
-use super::super::octets::{DeserializeOctets, FromBuilder, SerializeOctets};
+use super::super::octets::{
+    DeserializeOctets, EmptyBuilder, FromBuilder, SerializeOctets,
+};
 use super::builder::{DnameBuilder, PushError};
 use super::chain::{Chain, LongChainError};
 use super::dname::Dname;
@@ -240,6 +242,7 @@ impl<Octets> RelativeDname<Octets> {
     >
     where
         Octets: IntoBuilder,
+        <Octets as IntoBuilder>::Builder: AsMut<[u8]>,
     {
         self.into_builder().into_dname()
     }
@@ -657,14 +660,14 @@ impl<Octets: AsRef<[u8]> + ?Sized> ToRelativeDname for RelativeDname<Octets> {
 //--- Compose
 
 impl<Octets: AsRef<[u8]> + ?Sized> Compose for RelativeDname<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
         target.append_slice(self.0.as_ref())
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -785,7 +788,7 @@ where
 impl<'de, Octets> serde::Deserialize<'de> for RelativeDname<Octets>
 where
     Octets: FromBuilder + DeserializeOctets<'de>,
-    <Octets as FromBuilder>::Builder: crate::base::octets::EmptyBuilder,
+    <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
 {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
@@ -798,8 +801,7 @@ where
         where
             Octets: FromBuilder + DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets>
-                    + crate::base::octets::EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder + AsMut<[u8]>,
         {
             type Value = RelativeDname<Octets>;
 
@@ -842,8 +844,7 @@ where
         where
             Octets: FromBuilder + DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets>
-                    + crate::base::octets::EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder + AsMut<[u8]>,
         {
             type Value = RelativeDname<Octets>;
 

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -124,7 +124,7 @@ impl<Octets> UncertainDname<Octets> {
     pub fn from_chars<C>(chars: C) -> Result<Self, FromStrError>
     where
         Octets: FromBuilder,
-        <Octets as FromBuilder>::Builder: EmptyBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
         C: IntoIterator<Item = char>,
     {
         let mut builder =
@@ -221,7 +221,8 @@ impl<Octets> UncertainDname<Octets> {
     >
     where
         Octets: AsRef<[u8]> + IntoBuilder,
-        <Octets as IntoBuilder>::Builder: OctetsBuilder<Octets = Octets>,
+        <Octets as IntoBuilder>::Builder:
+            OctetsBuilder<Octets = Octets> + AsMut<[u8]>,
     {
         match self {
             UncertainDname::Absolute(name) => Ok(name),
@@ -306,7 +307,7 @@ impl<Octets> From<RelativeDname<Octets>> for UncertainDname<Octets> {
 impl<Octets> str::FromStr for UncertainDname<Octets>
 where
     Octets: FromBuilder,
-    <Octets as FromBuilder>::Builder: EmptyBuilder,
+    <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
 {
     type Err = FromStrError;
 
@@ -384,7 +385,7 @@ impl<'a, Octets: AsRef<[u8]>> IntoIterator for &'a UncertainDname<Octets> {
 //--- Compose
 
 impl<Octets: AsRef<[u8]>> Compose for UncertainDname<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -394,7 +395,7 @@ impl<Octets: AsRef<[u8]>> Compose for UncertainDname<Octets> {
         }
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -515,7 +516,7 @@ where
 impl<'de, Octets> serde::Deserialize<'de> for UncertainDname<Octets>
 where
     Octets: FromBuilder + DeserializeOctets<'de>,
-    <Octets as FromBuilder>::Builder: EmptyBuilder,
+    <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
 {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
@@ -528,7 +529,7 @@ where
         where
             Octets: FromBuilder + DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets> + EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder + AsMut<[u8]>,
         {
             type Value = UncertainDname<Octets>;
 
@@ -571,7 +572,7 @@ where
         where
             Octets: FromBuilder + DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets> + EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder + AsMut<[u8]>,
         {
             type Value = UncertainDname<Octets>;
 

--- a/src/base/opt/macros.rs
+++ b/src/base/opt/macros.rs
@@ -40,7 +40,7 @@ macro_rules! opt_types {
         //--- Compose
 
         impl<Octets: AsRef<[u8]>> Compose for AllOptData<Octets> {
-            fn compose<T: $crate::base::octets::OctetsBuilder>(
+            fn compose<T: $crate::base::octets::OctetsBuilder + AsMut<[u8]>>(
                 &self, target: &mut T
             ) -> Result<(), ShortBuf> {
                 match *self {

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -169,7 +169,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Opt<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Opt<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -314,7 +314,7 @@ impl Default for OptHeader {
 }
 
 impl Compose for OptHeader {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -498,7 +498,7 @@ impl<Octets: AsRef<[u8]>> Parse<Octets> for OptionHeader {
 }
 
 impl Compose for OptionHeader {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -748,7 +748,7 @@ impl<Octets: AsMut<[u8]>> AsMut<[u8]> for UnknownOptData<Octets> {
 //--- Compose
 
 impl<Octets: AsRef<[u8]>> Compose for UnknownOptData<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc5001.rs
+++ b/src/base/opt/rfc5001.rs
@@ -26,10 +26,14 @@ impl<Octets> Nsid<Octets> {
 }
 
 impl Nsid<()> {
-    pub fn push<Target: OctetsBuilder, Data: AsRef<[u8]>>(
+    pub fn push<Target, Data>(
         builder: &mut OptBuilder<Target>,
         data: &Data
-    ) -> Result<(), ShortBuf> {
+    ) -> Result<(), ShortBuf>
+    where
+        Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
+        Data: AsRef<[u8]>,
+    {
         let data = data.as_ref();
         assert!(data.len() <= core::u16::MAX as usize);
         builder.push_raw_option(OptionCode::Nsid, |target| {
@@ -56,7 +60,7 @@ impl<Octets> CodeOptData for Nsid<Octets> {
 
 
 impl<Octets: AsRef<[u8]>> Compose for Nsid<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T
     ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc6975.rs
+++ b/src/base/opt/rfc6975.rs
@@ -30,7 +30,7 @@ macro_rules! option_type {
         }
 
         impl $name<()> {
-            pub fn push<Target: OctetsBuilder>(
+            pub fn push<Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>>(
                 builder: &mut OptBuilder<Target>,
                 algs: &[SecAlg]
             ) -> Result<(), ShortBuf> {
@@ -61,7 +61,7 @@ macro_rules! option_type {
         }
 
         impl<Octets: AsRef<[u8]>> Compose for $name<Octets> {
-            fn compose<T: OctetsBuilder>(
+            fn compose<T: OctetsBuilder + AsMut<[u8]>>(
                 &self,
                 target: &mut T
             ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc7314.rs
+++ b/src/base/opt/rfc7314.rs
@@ -18,7 +18,7 @@ impl Expire {
         Expire(expire)
     }
 
-    pub fn push<Target: OctetsBuilder>(
+    pub fn push<Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>>(
         builder: &mut OptBuilder<Target>,
         expire: Option<u32>
     ) -> Result<(), ShortBuf> {
@@ -54,7 +54,7 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for Expire {
 }
 
 impl Compose for Expire {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T
     ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc7828.rs
+++ b/src/base/opt/rfc7828.rs
@@ -18,7 +18,7 @@ impl TcpKeepalive {
         TcpKeepalive(timeout)
     }
 
-    pub fn push<Target: OctetsBuilder>(
+    pub fn push<Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>>(
         builder: &mut OptBuilder<Target>,
         timeout: u16
     ) -> Result<(), ShortBuf> {
@@ -44,7 +44,7 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for TcpKeepalive {
 }
 
 impl Compose for TcpKeepalive {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T
     ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc7830.rs
+++ b/src/base/opt/rfc7830.rs
@@ -35,14 +35,14 @@ impl Padding {
         Padding { len, mode }
     }
 
-    pub fn push<Target: OctetsBuilder>(
+    pub fn push<Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>>(
         builder: &mut OptBuilder<Target>,
         len: u16,
     ) -> Result<(), ShortBuf> {
         Self::push_with_mode(builder, len, PaddingMode::Zero)
     }
 
-    pub fn push_with_mode<Target: OctetsBuilder>(
+    pub fn push_with_mode<Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>>(
         builder: &mut OptBuilder<Target>,
         len: u16,
         mode: PaddingMode
@@ -81,7 +81,7 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for Padding {
 }
 
 impl Compose for Padding {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T
     ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc7871.rs
+++ b/src/base/opt/rfc7871.rs
@@ -36,7 +36,7 @@ impl ClientSubnet {
         }
     }
 
-    pub fn push<Target: OctetsBuilder>(
+    pub fn push<Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>>(
         builder: &mut OptBuilder<Target>,
         source_prefix_len: u8,
         scope_prefix_len: u8,
@@ -134,7 +134,7 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for ClientSubnet {
 }
 
 impl Compose for ClientSubnet {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc7873.rs
+++ b/src/base/opt/rfc7873.rs
@@ -18,7 +18,7 @@ impl Cookie {
         Cookie(cookie)
     }
 
-    pub fn push<Target: OctetsBuilder>(
+    pub fn push<Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>>(
         builder: &mut OptBuilder<Target>,
         cookie: [u8; 8]
     ) -> Result<(), ShortBuf> {
@@ -47,7 +47,7 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for Cookie {
 
 
 impl Compose for Cookie {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T
     ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc7901.rs
+++ b/src/base/opt/rfc7901.rs
@@ -23,10 +23,14 @@ impl<Octets> Chain<Octets> {
         Chain { start }
     }
 
-    pub fn push<Target: OctetsBuilder, N: ToDname>(
+    pub fn push<Target, N>(
         builder: &mut OptBuilder<Target>,
         start: &N
-    ) -> Result<(), ShortBuf> {
+    ) -> Result<(), ShortBuf>
+    where
+        Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
+        N: ToDname,
+    {
         builder.push_raw_option(OptionCode::Chain, |target| {
             target.append_all(|target| {
                 for label in start.iter_labels() {
@@ -56,7 +60,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Chain<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Chain<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T
     ) -> Result<(), ShortBuf> {

--- a/src/base/opt/rfc8145.rs
+++ b/src/base/opt/rfc8145.rs
@@ -22,7 +22,7 @@ impl<Octets> KeyTag<Octets> {
         KeyTag { octets }
     }
 
-    pub fn push<Target: OctetsBuilder>(
+    pub fn push<Target: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>>(
         builder: &mut OptBuilder<Target>,
         tags: &[u16]
     ) -> Result<(), ShortBuf> {
@@ -70,7 +70,7 @@ impl<Ref: OctetsRef> Parse<Ref> for KeyTag<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for KeyTag<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T
     ) -> Result<(), ShortBuf> {

--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -214,7 +214,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Question<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Question<N> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -225,7 +225,7 @@ impl<N: ToDname> Compose for Question<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -287,7 +287,7 @@ pub trait AsQuestion {
     fn qclass(&self) -> Class;
 
     /// Produces the encoding of the question.
-    fn compose_question<T: OctetsBuilder>(
+    fn compose_question<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf>
@@ -302,7 +302,7 @@ pub trait AsQuestion {
     }
 
     /// Produces the canoncial encoding of the question.
-    fn compose_question_canonical<T: OctetsBuilder>(
+    fn compose_question_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf>

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -334,7 +334,7 @@ where
 }
 
 impl<N: ToDname, D: RecordData> Compose for Record<N, D> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -347,7 +347,7 @@ impl<N: ToDname, D: RecordData> Compose for Record<N, D> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -434,7 +434,7 @@ pub trait AsRecord {
     fn data(&self) -> &Self::Data;
 
     /// Produces the encoded record.
-    fn compose_record<T: OctetsBuilder>(
+    fn compose_record<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -448,7 +448,7 @@ pub trait AsRecord {
     }
 
     /// Produces the canonically encoded record.
-    fn compose_record_canonical<T: OctetsBuilder>(
+    fn compose_record_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -775,7 +775,7 @@ impl<Ref: OctetsRef> Parse<Ref> for RecordHeader<ParsedDname<Ref>> {
 }
 
 impl<Name: Compose> Compose for RecordHeader<Name> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -788,7 +788,7 @@ impl<Name: Compose> Compose for RecordHeader<Name> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/base/serial.rs
+++ b/src/base/serial.rs
@@ -207,7 +207,7 @@ impl<T: AsRef<[u8]>> Parse<T> for Serial {
 }
 
 impl Compose for Serial {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -241,7 +241,7 @@ macro_rules! rdata_types {
 
         impl<O, N> $crate::base::octets::Compose for ZoneRecordData<O, N>
         where O: AsRef<[u8]>, N: $crate::base::name::ToDname {
-            fn compose<T: $crate::base::octets::OctetsBuilder>(
+            fn compose<T: $crate::base::octets::OctetsBuilder + AsMut<[u8]>>(
                 &self,
                 target: &mut T
             ) -> Result<(), $crate::base::octets::ShortBuf> {
@@ -257,10 +257,11 @@ macro_rules! rdata_types {
                 }
             }
 
-            fn compose_canonical<T: $crate::base::octets::OctetsBuilder>(
+            fn compose_canonical<T>(
                 &self,
                 target: &mut T
-            ) -> Result<(), $crate::base::octets::ShortBuf> {
+            ) -> Result<(), $crate::base::octets::ShortBuf>
+            where T: $crate::base::octets::OctetsBuilder + AsMut<[u8]> {
                 match *self {
                     $( $( $(
                         ZoneRecordData::$mtype(ref inner) => {
@@ -664,7 +665,7 @@ macro_rules! rdata_types {
         impl<O, N> $crate::base::octets::Compose for AllRecordData<O, N>
         where O: AsRef<[u8]>, N: $crate::base::name::ToDname
         {
-            fn compose<T: $crate::base::octets::OctetsBuilder>(
+            fn compose<T: $crate::base::octets::OctetsBuilder + AsMut<[u8]>>(
                 &self,
                 buf: &mut T
             ) -> Result<(), $crate::base::octets::ShortBuf> {
@@ -684,10 +685,11 @@ macro_rules! rdata_types {
                 }
             }
 
-            fn compose_canonical<T: $crate::base::octets::OctetsBuilder>(
+            fn compose_canonical<T>(
                 &self,
                 buf: &mut T
-            ) -> Result<(), $crate::base::octets::ShortBuf> {
+            ) -> Result<(), $crate::base::octets::ShortBuf>
+            where T: $crate::base::octets::OctetsBuilder + AsMut<[u8]> {
                 match *self {
                     $( $( $(
                         AllRecordData::$mtype(ref inner) => {
@@ -967,14 +969,14 @@ macro_rules! dname_type {
         }
 
         impl<N: ToDname> Compose for $target<N> {
-            fn compose<T: OctetsBuilder>(
+            fn compose<T: OctetsBuilder + AsMut<[u8]>>(
                 &self,
                 target: &mut T
             ) -> Result<(), ShortBuf> {
                 target.append_compressed_dname(&self.$field)
             }
 
-            fn compose_canonical<T: OctetsBuilder>(
+            fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
                 &self,
                 target: &mut T
             ) -> Result<(), ShortBuf> {

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -116,7 +116,7 @@ impl<Octets: AsRef<[u8]>> Parse<Octets> for A {
 }
 
 impl Compose for A {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -324,7 +324,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Hinfo<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Hinfo<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -551,7 +551,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Minfo<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Minfo<N> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -561,7 +561,7 @@ impl<N: ToDname> Compose for Minfo<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -726,7 +726,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Mx<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Mx<N> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -736,7 +736,7 @@ impl<N: ToDname> Compose for Mx<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -912,7 +912,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Null<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Null<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -1223,7 +1223,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Soa<ParsedDname<Ref>> {
 }
 
 impl<N: ToDname> Compose for Soa<N> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -1238,7 +1238,7 @@ impl<N: ToDname> Compose for Soa<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -1309,7 +1309,7 @@ impl<Octets: FromBuilder> Txt<Octets> {
     /// Creates a new Txt record from a single character string.
     pub fn from_slice(text: &[u8]) -> Result<Self, ShortBuf>
     where
-        <Octets as FromBuilder>::Builder: EmptyBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
     {
         let mut builder = TxtBuilder::<Octets::Builder>::new();
         builder.append_slice(text)?;
@@ -1489,7 +1489,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Txt<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Txt<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -1589,7 +1589,7 @@ where
 impl<'de, Octets> serde::Deserialize<'de> for Txt<Octets>
 where
     Octets: FromBuilder + DeserializeOctets<'de>,
-    <Octets as FromBuilder>::Builder: EmptyBuilder,
+    <Octets as FromBuilder>::Builder: EmptyBuilder + AsMut<[u8]>,
 {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
@@ -1602,7 +1602,7 @@ where
         where
             Octets: FromBuilder + DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets> + EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder + AsMut<[u8]>,
         {
             type Value = Txt<Octets>;
 
@@ -1667,7 +1667,7 @@ where
         where
             Octets: FromBuilder + DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets> + EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder + AsMut<[u8]>,
         {
             type Value = Txt<Octets>;
 
@@ -1756,7 +1756,7 @@ impl TxtBuilder<BytesMut> {
     }
 }
 
-impl<Builder: OctetsBuilder> TxtBuilder<Builder> {
+impl<Builder: OctetsBuilder + AsMut<[u8]>> TxtBuilder<Builder> {
     pub fn append_slice(&mut self, mut slice: &[u8]) -> Result<(), ShortBuf> {
         if let Some(start) = self.start {
             let left = 255 - (self.builder.len() - (start + 1));

--- a/src/rdata/rfc2782.rs
+++ b/src/rdata/rfc2782.rs
@@ -175,7 +175,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Srv<ParsedDname<Ref>> {
 }
 
 impl<N: Compose> Compose for Srv<N> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -187,7 +187,7 @@ impl<N: Compose> Compose for Srv<N> {
         })
     }
 
-    fn compose_canonical<T: OctetsBuilder>(
+    fn compose_canonical<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/rdata/rfc2845.rs
+++ b/src/rdata/rfc2845.rs
@@ -407,7 +407,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Tsig<Ref::Range, ParsedDname<Ref>> {
 }
 
 impl<O: AsRef<[u8]>, N: Compose> Compose for Tsig<O, N> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -559,7 +559,7 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for Time48 {
 }
 
 impl Compose for Time48 {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/rdata/rfc3596.rs
+++ b/src/rdata/rfc3596.rs
@@ -89,7 +89,7 @@ impl<Ref: AsRef<[u8]>> Parse<Ref> for Aaaa {
 }
 
 impl Compose for Aaaa {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/rdata/rfc5155.rs
+++ b/src/rdata/rfc5155.rs
@@ -35,7 +35,8 @@ use core::{fmt, hash, ops, str};
         deserialize = "
             Octets: FromBuilder + crate::base::octets::DeserializeOctets<'de>,
             <Octets as FromBuilder>::Builder:
-                OctetsBuilder<Octets = Octets> + EmptyBuilder,
+                OctetsBuilder<Octets = Octets> + EmptyBuilder
+                + AsRef<[u8]> + AsMut<[u8]>,
         ",
     ))
 )]
@@ -246,7 +247,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec3<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Nsec3<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -494,7 +495,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec3param<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Nsec3param<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -752,7 +753,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Nsec3Salt<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]> + ?Sized> Compose for Nsec3Salt<Octets> {
-    fn compose<Target: OctetsBuilder>(
+    fn compose<Target: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut Target,
     ) -> Result<(), ShortBuf> {
@@ -1097,7 +1098,7 @@ impl<Ref: OctetsRef> Parse<Ref> for OwnerHash<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]> + ?Sized> Compose for OwnerHash<Octets> {
-    fn compose<Target: OctetsBuilder>(
+    fn compose<Target: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut Target,
     ) -> Result<(), ShortBuf> {

--- a/src/rdata/rfc7344.rs
+++ b/src/rdata/rfc7344.rs
@@ -189,7 +189,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Cdnskey<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Cdnskey<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -433,7 +433,7 @@ impl<Ref: OctetsRef> Parse<Ref> for Cds<Ref::Range> {
 }
 
 impl<Octets: AsRef<[u8]>> Compose for Cds<Octets> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {

--- a/src/rdata/svcb.rs
+++ b/src/rdata/svcb.rs
@@ -89,7 +89,9 @@ impl<OB: OctetsBuilder, N> $name<OB, N> {
             sorter: self.sorter,
         }
     }
+}
 
+impl<OB: OctetsBuilder + AsMut<[u8]>, N> $name<OB, N> {
     /// Push a parameter into the builder.
     pub fn push<O: AsRef<[u8]>>(
         &mut self,
@@ -123,7 +125,7 @@ impl<Ref: OctetsRef> Parse<Ref> for $name<Ref::Range, ParsedDname<Ref>> {
 }
 
 impl<O: AsRef<[u8]>, N: Compose> Compose for $name<O, N> {
-    fn compose<T: OctetsBuilder>(
+    fn compose<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -151,7 +153,7 @@ impl<O: AsRef<[u8]>, N: Compose> Compose for $name<O, N> {
 
 impl<O: AsRef<[u8]>, N: Compose> $name<O, N> {
     /// Compose without checking for the order of parameters.
-    pub fn compose_unchecked<T: OctetsBuilder>(
+    pub fn compose_unchecked<T: OctetsBuilder + AsMut<[u8]>>(
         &self,
         target: &mut T,
     ) -> Result<(), ShortBuf> {
@@ -355,7 +357,7 @@ pub mod param {
             }
 
             impl<O: AsRef<[u8]>> Compose for AllParams<O> {
-                fn compose<T: OctetsBuilder>(
+                fn compose<T: OctetsBuilder + AsMut<[u8]>>(
                     &self,
                     target: &mut T,
                 ) -> Result<(), ShortBuf> {
@@ -452,7 +454,7 @@ pub mod param {
             }
 
             impl<O: AsRef<[u8]>> Compose for $name<O> {
-                fn compose<T: OctetsBuilder>(
+                fn compose<T: OctetsBuilder + AsMut<[u8]>>(
                     &self,
                     target: &mut T,
                 ) -> Result<(), ShortBuf> {
@@ -535,7 +537,7 @@ pub mod param {
 
     octets_wrapper!(Mandatory, MandatoryIter);
 
-    impl<OB: OctetsBuilder> Mandatory<OB> {
+    impl<OB: OctetsBuilder + AsMut<[u8]>> Mandatory<OB> {
         pub fn push(&mut self, key: SvcbParamKey) -> Result<(), ShortBuf> {
             u16::from(key).compose(&mut self.0)
         }
@@ -572,7 +574,7 @@ pub mod param {
 
     octets_wrapper!(Alpn, AlpnIter);
 
-    impl<OB: OctetsBuilder> Alpn<OB> {
+    impl<OB: OctetsBuilder + AsMut<[u8]>> Alpn<OB> {
         pub fn push<O: AsRef<[u8]>>(
             &mut self,
             name: O,
@@ -636,7 +638,7 @@ pub mod param {
     }
 
     impl Compose for NoDefaultAlpn {
-        fn compose<T: OctetsBuilder>(
+        fn compose<T: OctetsBuilder + AsMut<[u8]>>(
             &self,
             _target: &mut T,
         ) -> Result<(), ShortBuf> {
@@ -676,7 +678,7 @@ pub mod param {
     }
 
     impl Compose for Port {
-        fn compose<T: OctetsBuilder>(
+        fn compose<T: OctetsBuilder + AsMut<[u8]>>(
             &self,
             target: &mut T,
         ) -> Result<(), ShortBuf> {
@@ -827,7 +829,7 @@ pub mod param {
     }
 
     impl<O: AsRef<[u8]>> Compose for Unknown<O> {
-        fn compose<T: OctetsBuilder>(
+        fn compose<T: OctetsBuilder + AsMut<[u8]>>(
             &self,
             target: &mut T,
         ) -> Result<(), ShortBuf> {

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -175,7 +175,7 @@ impl<N, D> SortedRecords<N, D> {
         N: ToDname + Clone,
         D: RecordData,
         Octets: FromBuilder,
-        Octets::Builder: EmptyBuilder,
+        Octets::Builder: EmptyBuilder + AsRef<[u8]> + AsMut<[u8]>,
         ApexName: ToDname,
     {
         let mut res = Vec::new();

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -106,7 +106,11 @@ pub trait RrsigExt: Compose {
     ///    the received RRset due to DNS name compression, decremented TTLs, or
     ///    wildcard expansion.
     /// ```
-    fn signed_data<N: ToDname, D: RecordData, B: OctetsBuilder>(
+    fn signed_data<
+        N: ToDname,
+        D: RecordData,
+        B: OctetsBuilder + AsMut<[u8]>,
+    >(
         &self,
         buf: &mut B,
         records: &mut [Record<N, D>],
@@ -143,7 +147,11 @@ pub trait RrsigExt: Compose {
 }
 
 impl<Octets: AsRef<[u8]>, Name: Compose> RrsigExt for Rrsig<Octets, Name> {
-    fn signed_data<N: ToDname, D: RecordData, B: OctetsBuilder>(
+    fn signed_data<
+        N: ToDname,
+        D: RecordData,
+        B: OctetsBuilder + AsMut<[u8]>,
+    >(
         &self,
         buf: &mut B,
         records: &mut [Record<N, D>],


### PR DESCRIPTION
This makes it possible to impl `OctetsBuilder` for `Cow<[u8]>` and other
types that can only append at the price of explicitly requiring `AsRef<[u8]>`
and `AsMut<[u8]>` where needed. Unfortunately, this means lots of code
changes but hopefully, these should not cause too much havoc with code
using the crate.