### PR TITLE
Also declare MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "domain"
 version = "0.7.0-dev"
 edition = "2018"
+rust-version = "1.56.1"
 authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]
 description = "A DNS library for Rust."
 documentation = "https://docs.rs/domain"


### PR DESCRIPTION
Follow-up to #128: Also declare the MSRV in Cargo.toml, for the benefit of dependent apps and libraries.

See https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field.

Thank you