### PR TITLE
add trait FlattenInto

### DIFF
--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -7,11 +7,11 @@
 use crate::base::charstr::{CharStr, CharStrError};
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
-use crate::base::name::{ParsedDname, ToDname};
+use crate::base::name::{Dname, ParsedDname, PushError, ToDname};
 use crate::base::net::Ipv4Addr;
 use crate::base::octets::{
-    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef,
-    Parse, ParseError, Parser, ShortBuf,
+    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom,
+    OctetsInto, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 #[cfg(feature = "serde")]
 use crate::base::octets::{DeserializeOctets, SerializeOctets};
@@ -61,6 +61,10 @@ impl A {
     }
     pub fn set_addr(&mut self, addr: Ipv4Addr) {
         self.addr = addr
+    }
+
+    pub fn flatten_into(self) -> Result<A, PushError> {
+        Ok(self)
     }
 }
 
@@ -229,6 +233,16 @@ impl<Octets> Hinfo<Octets> {
     /// The operating system type of the host.
     pub fn os(&self) -> &CharStr<Octets> {
         &self.os
+    }
+}
+
+impl<SrcOctets> Hinfo<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Hinfo<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        let Self { cpu, os } = self;
+        Ok(Hinfo::new(cpu.octets_into()?, os.octets_into()?))
     }
 }
 
@@ -468,6 +482,22 @@ impl<N> Minfo<N> {
     }
 }
 
+impl<Ref> Minfo<ParsedDname<Ref>>
+where
+    Ref: OctetsRef,
+{
+    pub fn flatten_into<Octets>(
+        self,
+    ) -> Result<Minfo<Dname<Octets>>, PushError>
+    where
+        Octets: OctetsFrom<Ref::Range> + FromBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        let Self { rmailbx, emailbx } = self;
+        Ok(Minfo::new(rmailbx.flatten_into()?, emailbx.flatten_into()?))
+    }
+}
+
 //--- OctetsFrom
 
 impl<Name, SrcName> OctetsFrom<Minfo<SrcName>> for Minfo<Name>
@@ -644,6 +674,23 @@ impl<N> Mx<N> {
     /// The name of the host that is the exchange.
     pub fn exchange(&self) -> &N {
         &self.exchange
+    }
+}
+
+impl<Ref> Mx<ParsedDname<Ref>>
+where
+    Ref: OctetsRef,
+{
+    pub fn flatten_into<Octets>(self) -> Result<Mx<Dname<Octets>>, PushError>
+    where
+        Octets: OctetsFrom<<Ref as OctetsRef>::Range> + FromBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        let Self {
+            preference,
+            exchange,
+        } = self;
+        Ok(Mx::new(preference, exchange.flatten_into()?))
     }
 }
 
@@ -825,6 +872,15 @@ impl<Octets: AsRef<[u8]>> Null<Octets> {
 
     pub fn is_empty(&self) -> bool {
         self.data.as_ref().is_empty()
+    }
+}
+
+impl<SrcOctets> Null<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Null<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        Ok(Null::new(self.data.octets_into()?))
     }
 }
 
@@ -1057,6 +1113,37 @@ impl<N> Soa<N> {
     /// The minimum TTL to be exported with any RR from this zone.
     pub fn minimum(&self) -> u32 {
         self.minimum
+    }
+}
+
+impl<Ref> Soa<ParsedDname<Ref>>
+where
+    Ref: OctetsRef,
+{
+    pub fn flatten_into<Octets>(self) -> Result<Soa<Dname<Octets>>, PushError>
+    where
+        Octets: OctetsFrom<Ref::Range> + FromBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        let Self {
+            mname,
+            rname,
+            serial,
+            refresh,
+            retry,
+            expire,
+            minimum,
+        } = self;
+
+        Ok(Soa::new(
+            mname.flatten_into()?,
+            rname.flatten_into()?,
+            serial,
+            refresh,
+            retry,
+            expire,
+            minimum,
+        ))
     }
 }
 
@@ -1377,6 +1464,15 @@ impl<Octets: AsRef<[u8]>> Txt<Octets> {
             res.append_slice(item)?;
         }
         Ok(res.freeze())
+    }
+}
+
+impl<SrcOctets> Txt<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Txt<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        Ok(Txt(self.0.octets_into()?))
     }
 }
 

--- a/src/rdata/rfc3596.rs
+++ b/src/rdata/rfc3596.rs
@@ -6,6 +6,7 @@
 
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
+use crate::base::name::PushError;
 use crate::base::net::Ipv6Addr;
 use crate::base::octets::{
     Compose, OctetsBuilder, OctetsFrom, Parse, ParseError, Parser, ShortBuf,
@@ -34,6 +35,10 @@ impl Aaaa {
     }
     pub fn set_addr(&mut self, addr: Ipv6Addr) {
         self.addr = addr
+    }
+
+    pub fn flatten_into(self) -> Result<Aaaa, PushError> {
+        Ok(self)
     }
 }
 

--- a/src/rdata/rfc4034.rs
+++ b/src/rdata/rfc4034.rs
@@ -6,12 +6,10 @@
 
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
-#[cfg(feature = "master")]
-use crate::base::name::Dname;
-use crate::base::name::{ParsedDname, ToDname};
+use crate::base::name::{Dname, ParsedDname, PushError, ToDname};
 use crate::base::octets::{
     Compose, EmptyBuilder, FormError, FromBuilder, OctetsBuilder, OctetsFrom,
-    OctetsRef, Parse, ParseError, Parser, ShortBuf,
+    OctetsInto, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 #[cfg(feature = "serde")]
 use crate::base::octets::{DeserializeOctets, SerializeOctets};
@@ -174,6 +172,27 @@ impl<Octets> Dnskey<Octets> {
             res += (res >> 16) & 0xFFFF;
             (res & 0xFFFF) as u16
         }
+    }
+}
+
+impl<SrcOctets> Dnskey<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Dnskey<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        let Self {
+            flags,
+            protocol,
+            algorithm,
+            public_key,
+        } = self;
+
+        Ok(Dnskey::new(
+            flags,
+            protocol,
+            algorithm,
+            public_key.octets_into()?,
+        ))
     }
 }
 
@@ -399,6 +418,41 @@ impl<Name> ProtoRrsig<Name> {
     }
 }
 
+impl<Ref> ProtoRrsig<ParsedDname<Ref>>
+where
+    Ref: OctetsRef,
+{
+    pub fn flatten_into<Octets>(
+        self,
+    ) -> Result<ProtoRrsig<Dname<Octets>>, PushError>
+    where
+        Octets: OctetsFrom<Ref::Range> + FromBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        let Self {
+            type_covered,
+            algorithm,
+            labels,
+            original_ttl,
+            expiration,
+            inception,
+            key_tag,
+            signer_name,
+        } = self;
+
+        Ok(ProtoRrsig::new(
+            type_covered,
+            algorithm,
+            labels,
+            original_ttl,
+            expiration,
+            inception,
+            key_tag,
+            signer_name.flatten_into()?,
+        ))
+    }
+}
+
 //--- OctetsFrom
 
 impl<Name, SrcName> OctetsFrom<ProtoRrsig<SrcName>> for ProtoRrsig<Name>
@@ -554,6 +608,44 @@ impl<Octets, Name> Rrsig<Octets, Name> {
 
     pub fn set_signature(&mut self, signature: Octets) {
         self.signature = signature
+    }
+}
+
+impl<SrcOctets, Ref> Rrsig<SrcOctets, ParsedDname<Ref>>
+where
+    SrcOctets: AsRef<[u8]>,
+    Ref: OctetsRef,
+{
+    pub fn flatten_into<Octets>(
+        self,
+    ) -> Result<Rrsig<Octets, Dname<Octets>>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets> + FromBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        let Self {
+            type_covered,
+            algorithm,
+            labels,
+            original_ttl,
+            expiration,
+            inception,
+            key_tag,
+            signer_name,
+            signature,
+        } = self;
+
+        Ok(Rrsig::new(
+            type_covered,
+            algorithm,
+            labels,
+            original_ttl,
+            expiration,
+            inception,
+            key_tag,
+            signer_name.to_dname()?,
+            Octets::octets_from(signature)?,
+        ))
     }
 }
 
@@ -916,6 +1008,23 @@ impl<Octets, Name> Nsec<Octets, Name> {
     }
 }
 
+impl<SrcOctets, Ref> Nsec<SrcOctets, ParsedDname<Ref>>
+where
+    SrcOctets: AsRef<[u8]>,
+    Ref: OctetsRef,
+{
+    pub fn flatten_into<Octets>(
+        self,
+    ) -> Result<Nsec<Octets, Dname<Octets>>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets> + FromBuilder,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        let Self { next_name, types } = self;
+        Ok(Nsec::new(next_name.to_dname()?, types.octets_into()?))
+    }
+}
+
 //--- OctetsFrom
 
 impl<Octets, SrcOctets, Name, SrcName> OctetsFrom<Nsec<SrcOctets, SrcName>>
@@ -1143,6 +1252,26 @@ impl<Octets> Ds<Octets> {
 
     pub fn into_digest(self) -> Octets {
         self.digest
+    }
+}
+
+impl<SrcOctets> Ds<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Ds<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        let Self {
+            key_tag,
+            algorithm,
+            digest_type,
+            digest,
+        } = self;
+        Ok(Ds::new(
+            key_tag,
+            algorithm,
+            digest_type,
+            digest.octets_into()?,
+        ))
     }
 }
 

--- a/src/rdata/rfc5155.rs
+++ b/src/rdata/rfc5155.rs
@@ -7,9 +7,10 @@
 use super::rfc4034::RtypeBitmap;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Nsec3HashAlg, Rtype};
+use crate::base::name::PushError;
 use crate::base::octets::{
-    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef,
-    Parse, ParseError, Parser, ShortBuf,
+    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom,
+    OctetsInto, OctetsRef, Parse, ParseError, Parser, ShortBuf,
 };
 #[cfg(feature = "serde")]
 use crate::base::octets::{DeserializeOctets, SerializeOctets};
@@ -94,6 +95,30 @@ impl<Octets> Nsec3<Octets> {
 
     pub fn types(&self) -> &RtypeBitmap<Octets> {
         &self.types
+    }
+}
+
+impl<SrcOctets> Nsec3<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Nsec3<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        let Self {
+            hash_algorithm,
+            flags,
+            iterations,
+            salt,
+            next_owner,
+            types,
+        } = self;
+        Ok(Nsec3::new(
+            hash_algorithm,
+            flags,
+            iterations,
+            salt.octets_into()?,
+            next_owner.octets_into()?,
+            types.octets_into()?,
+        ))
     }
 }
 
@@ -364,6 +389,26 @@ impl<Octets> Nsec3param<Octets> {
 
     pub fn salt(&self) -> &Nsec3Salt<Octets> {
         &self.salt
+    }
+}
+
+impl<SrcOctets> Nsec3param<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Nsec3param<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        let Self {
+            hash_algorithm,
+            flags,
+            iterations,
+            salt,
+        } = self;
+        Ok(Nsec3param::new(
+            hash_algorithm,
+            flags,
+            iterations,
+            salt.octets_into()?,
+        ))
     }
 }
 

--- a/src/rdata/rfc6672.rs
+++ b/src/rdata/rfc6672.rs
@@ -1,9 +1,9 @@
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
-use crate::base::name::{ParsedDname, ToDname};
+use crate::base::name::{ParsedDname, PushError, ToDname};
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
-    ShortBuf,
+    Compose, EmptyBuilder, FromBuilder, OctetsBuilder, OctetsFrom, OctetsRef,
+    Parse, ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature = "master")]

--- a/src/rdata/rfc7344.rs
+++ b/src/rdata/rfc7344.rs
@@ -3,9 +3,10 @@
 //! [RFC 7344]: https://tools.ietf.org/html/rfc7344
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
+use crate::base::name::PushError;
 use crate::base::octets::{
-    Compose, OctetsBuilder, OctetsFrom, OctetsRef, Parse, ParseError, Parser,
-    ShortBuf,
+    Compose, OctetsBuilder, OctetsFrom, OctetsInto, OctetsRef, Parse,
+    ParseError, Parser, ShortBuf,
 };
 use crate::base::rdata::RtypeRecordData;
 #[cfg(feature = "master")]
@@ -76,6 +77,26 @@ impl<Octets> Cdnskey<Octets> {
 
     pub fn public_key(&self) -> &Octets {
         &self.public_key
+    }
+}
+
+impl<SrcOctets> Cdnskey<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Cdnskey<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        let Self {
+            flags,
+            protocol,
+            algorithm,
+            public_key,
+        } = self;
+        Ok(Cdnskey::new(
+            flags,
+            protocol,
+            algorithm,
+            public_key.octets_into()?,
+        ))
     }
 }
 
@@ -308,6 +329,26 @@ impl<Octets> Cds<Octets> {
 
     pub fn into_digest(self) -> Octets {
         self.digest
+    }
+}
+
+impl<SrcOctets> Cds<SrcOctets> {
+    pub fn flatten_into<Octets>(self) -> Result<Cds<Octets>, PushError>
+    where
+        Octets: OctetsFrom<SrcOctets>,
+    {
+        let Self {
+            key_tag,
+            algorithm,
+            digest_type,
+            digest,
+        } = self;
+        Ok(Cds::new(
+            key_tag,
+            algorithm,
+            digest_type,
+            digest.octets_into()?,
+        ))
     }
 }
 


### PR DESCRIPTION
Hi,

This is a followup for #126, could you please let me know what do you think when you got a moment? Thanks.

The FlattenInto trait can help in case of converting ParsedDname into Dname in nested structure like `Record<N1, ZoneRecordData<O, N2>>`, so the user does not need to enumerate all the rdata types.