### PR TITLE
Clippy: Needless borrow.

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -54,7 +54,7 @@ fn main() {
 
     // Send message off to the server using our socket
     socket
-        .send_to(&message.as_dgram_slice(), (server, port))
+        .send_to(message.as_dgram_slice(), (server, port))
         .unwrap();
 
     // Create recv buffer

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -334,8 +334,8 @@ where
         use UncertainDname::*;
 
         match (self, other) {
-            (&Absolute(ref l), &Absolute(ref r)) => l.eq(r),
-            (&Relative(ref l), &Relative(ref r)) => l.eq(r),
+            (Absolute(l), Absolute(r)) => l.eq(r),
+            (Relative(l), Relative(r)) => l.eq(r),
             _ => false,
         }
     }


### PR DESCRIPTION
Hello a little PR for some easy clippy warning, also got one with default for Decoder<Builder> but don't included it since "trivial solution" ended up with stackoverflow. 

Found with #[warn(clippy::needless_borrowed_reference)]