### PR TITLE
Drop the try_ prefix from message builder methods.

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -10,7 +10,7 @@ use domain::rdata::AllRecordData;
 fn create_message() -> StreamTarget<Vec<u8>> {
     // Create a message builder wrapping a compressor wrapping a stream
     // target.
-    let mut msg = MessageBuilder::try_from_target(StaticCompressor::new(
+    let mut msg = MessageBuilder::from_target(StaticCompressor::new(
         StreamTarget::new_vec(),
     ))
     .unwrap();

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -2321,8 +2321,7 @@ mod test {
     where
         T::AppendError: fmt::Debug,
     {
-        let mut msg =
-            MessageBuilder::from_target(target).unwrap().question();
+        let mut msg = MessageBuilder::from_target(target).unwrap().question();
         msg.header_mut().set_rcode(Rcode::NXDomain);
         msg.header_mut().set_rd(true);
         msg.header_mut().set_ra(true);

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -321,10 +321,9 @@ impl<'a> Query<'a> {
     }
 
     fn create_message(question: Question<impl ToDname>) -> QueryMessage {
-        let mut message = MessageBuilder::try_from_target(
-            StreamTarget::try_new(Default::default()).unwrap(),
-        )
-        .unwrap();
+        let mut message = MessageBuilder::from_target(
+            StreamTarget::new(Default::default()).unwrap(),
+        ).unwrap();
         message.header_mut().set_rd(true);
         let mut message = message.question();
         message.push(question).unwrap();

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -323,7 +323,8 @@ impl<'a> Query<'a> {
     fn create_message(question: Question<impl ToDname>) -> QueryMessage {
         let mut message = MessageBuilder::from_target(
             StreamTarget::new(Default::default()).unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         message.header_mut().set_rd(true);
         let mut message = message.question();
         message.push(question).unwrap();

--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -82,9 +82,7 @@ fn tsig_client_nsd() {
         // Create an AXFR request and send it to NSD.
         let request = TestBuilder::new_stream_vec();
         let mut request = request
-            .request_axfr(
-                Dname::<Vec<u8>>::from_str("example.com.").unwrap(),
-            )
+            .request_axfr(Dname::<Vec<u8>>::from_str("example.com.").unwrap())
             .unwrap()
             .additional();
         let tran = tsig::ClientTransaction::request(
@@ -233,9 +231,7 @@ fn tsig_client_sequence_nsd() {
         let mut sock = TcpStream::connect("127.0.0.1:54323").unwrap();
         let request = TestBuilder::new_stream_vec();
         let mut request = request
-            .request_axfr(
-                Dname::<Vec<u8>>::from_str("example.com.").unwrap(),
-            )
+            .request_axfr(Dname::<Vec<u8>>::from_str("example.com.").unwrap())
             .unwrap()
             .additional();
         let mut tran =

--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -82,7 +82,7 @@ fn tsig_client_nsd() {
         // Create an AXFR request and send it to NSD.
         let request = TestBuilder::new_stream_vec();
         let mut request = request
-            .try_request_axfr(
+            .request_axfr(
                 Dname::<Vec<u8>>::from_str("example.com.").unwrap(),
             )
             .unwrap()
@@ -146,7 +146,7 @@ fn tsig_server_drill() {
             };
             let answer = TestBuilder::new_stream_vec();
             let answer =
-                answer.try_start_answer(&request, Rcode::NoError).unwrap();
+                answer.start_answer(&request, Rcode::NoError).unwrap();
             let tran = match tsig::ServerTransaction::request(
                 &&key,
                 &mut request,
@@ -233,7 +233,7 @@ fn tsig_client_sequence_nsd() {
         let mut sock = TcpStream::connect("127.0.0.1:54323").unwrap();
         let request = TestBuilder::new_stream_vec();
         let mut request = request
-            .try_request_axfr(
+            .request_axfr(
                 Dname::<Vec<u8>>::from_str("example.com.").unwrap(),
             )
             .unwrap()
@@ -347,7 +347,7 @@ fn send_tcp(sock: &mut TcpStream, msg: &[u8]) -> Result<(), io::Error> {
 
 fn make_first_axfr(request: &TestMessage) -> TestAdditional {
     let msg = TestBuilder::new_stream_vec();
-    let mut msg = msg.try_start_answer(request, Rcode::NoError).unwrap();
+    let mut msg = msg.start_answer(request, Rcode::NoError).unwrap();
     push_soa(&mut msg);
     push_a(&mut msg, 0, 0, 0);
     msg.additional()
@@ -359,14 +359,14 @@ fn make_middle_axfr(
     two: u8,
 ) -> TestAdditional {
     let msg = TestBuilder::new_stream_vec();
-    let mut msg = msg.try_start_answer(request, Rcode::NoError).unwrap();
+    let mut msg = msg.start_answer(request, Rcode::NoError).unwrap();
     push_a(&mut msg, 1, one, two);
     msg.additional()
 }
 
 fn make_last_axfr(request: &TestMessage) -> TestAdditional {
     let msg = TestBuilder::new_stream_vec();
-    let mut msg = msg.try_start_answer(request, Rcode::NoError).unwrap();
+    let mut msg = msg.start_answer(request, Rcode::NoError).unwrap();
     push_a(&mut msg, 2, 0, 0);
     push_soa(&mut msg);
     msg.additional()

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -1643,7 +1643,7 @@ impl<K: AsRef<Key>> ServerError<K> {
         Octs: Octets,
         Target: Composer,
     {
-        let builder = builder.try_start_answer(msg, Rcode::NotAuth)?;
+        let builder = builder.start_answer(msg, Rcode::NotAuth)?;
         let mut builder = builder.additional();
         match self.0 {
             ServerErrorInner::Unsigned { error } => {


### PR DESCRIPTION
This PR drops the `try_` prefix from `MessageBuilder` functions that still have it.