### PR TITLE
Drop lifetime argument from ParsedDname.

### DIFF
--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -88,8 +88,10 @@ impl<N: ToDname> Question<N> {
 
 /// # Parsing and Composing
 ///
-impl<'a, Octs: Octets> Question<ParsedDname<'a, Octs>> {
-    pub fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
+impl<Octs> Question<ParsedDname<Octs>> {
+    pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized + 'a>(
+        parser: &mut Parser<'a, Src>,
+    ) -> Result<Self, ParseError> {
         Ok(Question::new(
             ParsedDname::parse(parser)?,
             Rtype::parse(parser)?,

--- a/src/rdata/rfc2782.rs
+++ b/src/rdata/rfc2782.rs
@@ -82,11 +82,11 @@ impl<N> Srv<N> {
     }
 }
 
-impl<'a, Octs> Srv<ParsedDname<'a, Octs>> {
+impl<Octs> Srv<ParsedDname<Octs>> {
     pub fn flatten_into<Target>(self) -> Result<Srv<Dname<Target>>, PushError>
     where
         Octs: Octets,
-        Target: OctetsFrom<Octs::Range<'a>> + FromBuilder,
+        Target: for<'a> OctetsFrom<Octs::Range<'a>> + FromBuilder,
         <Target as FromBuilder>::Builder: EmptyBuilder,
     {
         let Self {
@@ -99,8 +99,10 @@ impl<'a, Octs> Srv<ParsedDname<'a, Octs>> {
     }
 }
 
-impl<'a, Octs: Octets + ?Sized> Srv<ParsedDname<'a, Octs>> {
-    pub fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
+impl<Octs> Srv<ParsedDname<Octs>> {
+    pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized + 'a>(
+        parser: &mut Parser<'a, Src>,
+    ) -> Result<Self, ParseError> {
         Ok(Self::new(
             u16::parse(parser)?,
             u16::parse(parser)?,
@@ -213,9 +215,8 @@ impl<N> RecordData for Srv<N> {
     }
 }
 
-impl<'a, Octs> ParseRecordData<'a, Octs> for Srv<ParsedDname<'a, Octs>>
-where
-    Octs: Octets + ?Sized,
+impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
+    for Srv<ParsedDname<Octs::Range<'a>>>
 {
     fn parse_rdata(
         rtype: Rtype,

--- a/src/rdata/rfc5155.rs
+++ b/src/rdata/rfc5155.rs
@@ -155,7 +155,6 @@ impl<SrcOcts> Nsec3<SrcOcts> {
     pub fn flatten_into<Octs>(self) -> Result<Nsec3<Octs>, PushError>
     where
         Octs: OctetsFrom<SrcOcts>,
-        PushError: From<Octs::Error>,
     {
         let Self {
             hash_algorithm,
@@ -169,9 +168,9 @@ impl<SrcOcts> Nsec3<SrcOcts> {
             hash_algorithm,
             flags,
             iterations,
-            salt.try_octets_into()?,
-            next_owner.try_octets_into()?,
-            types.try_octets_into()?,
+            salt.try_octets_into().map_err(Into::into)?,
+            next_owner.try_octets_into().map_err(Into::into)?,
+            types.try_octets_into().map_err(Into::into)?,
         ))
     }
 }
@@ -479,7 +478,6 @@ impl<SrcOcts> Nsec3param<SrcOcts> {
     pub fn flatten_into<Octs>(self) -> Result<Nsec3param<Octs>, PushError>
     where
         Octs: OctetsFrom<SrcOcts>,
-        PushError: From<Octs::Error>,
     {
         let Self {
             hash_algorithm,
@@ -491,7 +489,7 @@ impl<SrcOcts> Nsec3param<SrcOcts> {
             hash_algorithm,
             flags,
             iterations,
-            salt.try_octets_into()?,
+            salt.try_octets_into().map_err(Into::into)?,
         ))
     }
 }

--- a/src/rdata/rfc6672.rs
+++ b/src/rdata/rfc6672.rs
@@ -17,7 +17,7 @@ dname_type_canonical! {
     /// name tree in the DNS.
     ///
     /// The DNAME type is defined in RFC 6672.
-    (Dname, Dname, dname)
+    (Dname, Dname, dname, into_dname)
 }
 
 #[cfg(test)]

--- a/src/rdata/rfc7344.rs
+++ b/src/rdata/rfc7344.rs
@@ -117,7 +117,6 @@ impl<SrcOcts> Cdnskey<SrcOcts> {
     pub fn flatten_into<Octs>(self) -> Result<Cdnskey<Octs>, PushError>
     where
         Octs: OctetsFrom<SrcOcts>,
-        PushError: From<Octs::Error>,
     {
         let Self {
             flags,
@@ -129,7 +128,7 @@ impl<SrcOcts> Cdnskey<SrcOcts> {
             flags,
             protocol,
             algorithm,
-            public_key.try_octets_into()?,
+            public_key.try_octets_into().map_err(Into::into)?,
         ))
     }
 }
@@ -406,7 +405,6 @@ impl<SrcOcts> Cds<SrcOcts> {
     pub fn flatten_into<Octs>(self) -> Result<Cds<Octs>, PushError>
     where
         Octs: OctetsFrom<SrcOcts>,
-        PushError: From<Octs::Error>,
     {
         let Self {
             key_tag,
@@ -418,7 +416,7 @@ impl<SrcOcts> Cds<SrcOcts> {
             key_tag,
             algorithm,
             digest_type,
-            digest.try_octets_into()?,
+            digest.try_octets_into().map_err(Into::into)?,
         ))
     }
 }

--- a/src/resolv/lookup/addr.rs
+++ b/src/resolv/lookup/addr.rs
@@ -63,7 +63,7 @@ impl<'a, R: Resolver> IntoIterator for &'a FoundAddrs<R>
 where
     R::Octets: Octets,
 {
-    type Item = ParsedDname<'a, R::Octets>;
+    type Item = ParsedDname<<<R as Resolver>::Octets as Octets>::Range<'a>>;
     type IntoIter = FoundAddrsIter<'a, R::Octets>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -75,12 +75,12 @@ where
 
 /// An iterator over host names returned by address lookup.
 pub struct FoundAddrsIter<'a, Octs: Octets> {
-    name: Option<ParsedDname<'a, Octs>>,
-    answer: Option<RecordIter<'a, Octs, Ptr<ParsedDname<'a, Octs>>>>,
+    name: Option<ParsedDname<Octs::Range<'a>>>,
+    answer: Option<RecordIter<'a, Octs, Ptr<ParsedDname<Octs::Range<'a>>>>>,
 }
 
 impl<'a, Octs: Octets> Iterator for FoundAddrsIter<'a, Octs> {
-    type Item = ParsedDname<'a, Octs>;
+    type Item = ParsedDname<Octs::Range<'a>>;
 
     #[allow(clippy::while_let_on_iterator)]
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/resolv/lookup/srv.rs
+++ b/src/resolv/lookup/srv.rs
@@ -70,7 +70,7 @@ pub async fn lookup_srv(
         Err(_) => return Err(SrvError::LongName),
     };
     let answer = resolver.query((full_name, Rtype::Srv)).await?;
-    FoundSrvs::new(&answer.as_ref().for_slice(), name, fallback_port)
+    FoundSrvs::new(answer.as_ref().for_slice(), name, fallback_port)
 }
 
 //------------ FoundSrvs -----------------------------------------------------
@@ -129,7 +129,7 @@ impl FoundSrvs {
 
 impl FoundSrvs {
     fn new(
-        answer: &Message<&[u8]>,
+        answer: &Message<[u8]>,
         fallback_name: impl ToDname,
         fallback_port: u16,
     ) -> Result<Option<Self>, SrvError> {
@@ -154,7 +154,7 @@ impl FoundSrvs {
     }
 
     fn process_records(
-        answer: &Message<&[u8]>,
+        answer: &Message<[u8]>,
         name: &impl ToDname,
     ) -> Result<Vec<SrvItem>, SrvError> {
         let mut res = Vec::new();
@@ -169,7 +169,7 @@ impl FoundSrvs {
 
     fn process_additional(
         items: &mut [SrvItem],
-        answer: &Message<&[u8]>,
+        answer: &Message<[u8]>,
     ) -> Result<(), SrvError> {
         let additional = answer.additional()?;
         for item in items {

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -1287,11 +1287,12 @@ impl<K: AsRef<Key>> SigningContext<K> {
 //------------ MessageTsig ---------------------------------------------------
 
 /// The TSIG record of a message.
-struct MessageTsig<'a, Octs: Octets> {
+struct MessageTsig<'a, Octs: Octets + 'a> {
     /// The actual record.
+    #[allow(clippy::type_complexity)]
     record: Record<
-        ParsedDname<'a, Octs>,
-        Tsig<<Octs as Octets>::Range<'a>, ParsedDname<'a, Octs>>,
+        ParsedDname<Octs::Range<'a>>,
+        Tsig<Octs::Range<'a>, ParsedDname<Octs::Range<'a>>>,
     >,
 
     /// The index of the start of the record.
@@ -1336,10 +1337,10 @@ impl<'a, Octs: Octets> MessageTsig<'a, Octs> {
     }
 }
 
-impl<'a, Octs: Octets> ops::Deref for MessageTsig<'a, Octs> {
+impl<'a, Octs: Octets + 'a> ops::Deref for MessageTsig<'a, Octs> {
     type Target = Record<
-        ParsedDname<'a, Octs>,
-        Tsig<<Octs as Octets>::Range<'a>, ParsedDname<'a, Octs>>,
+        ParsedDname<Octs::Range<'a>>,
+        Tsig<Octs::Range<'a>, ParsedDname<Octs::Range<'a>>>,
     >;
 
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
This PR changes `ParsedDname<'a, Octs>` to simply `ParsedDname<Octs>`. This makes it easier to keep values of the type around. But, naturally, it has consequences all over the code.