### PR TITLE
Add basic parse/compose tests to options.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,7 @@ required-features = ["resolv"]
 name = "resolv-sync"
 required-features = ["resolv-sync"]
 
+[[example]]
+name = "client"
+required-features = ["std", "rand"]
+

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 Breaking Changes
 
+* The minimal required Rust version is now 1.65. ([#160])
 * The generic octets foundation has been moved to a new crate *[octseq]*
   and completely revamped with Generic Associated Types stabilized in Rust
   1.65. This required changes all over the code but, hopefully, should

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -67,7 +67,8 @@
 //! The following example builds a message with both name compression and
 //! the stream length and simply puts two A records into it.
 //!
-//! ```
+#![cfg_attr(feature = "std", doc = "```")]
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! use std::str::FromStr;
 //! use domain::base::{
 //!     Dname, MessageBuilder, Rtype, StaticCompressor, StreamTarget
@@ -506,7 +507,8 @@ impl<Target: Composer> QuestionBuilder<Target> {
     ///
     /// In other words, the options are:
     ///
-    /// ```
+    #[cfg_attr(feature = "std", doc = "```")]
+    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
     /// use domain::base::{Dname, MessageBuilder, Question, Rtype};
     /// use domain::base::iana::Class;
     ///
@@ -739,7 +741,8 @@ impl<Target: Composer> AnswerBuilder<Target> {
     ///
     /// In other words, you can do the following things:
     ///
-    /// ```
+    #[cfg_attr(feature = "std", doc = "```")]
+    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
     /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;
@@ -982,7 +985,8 @@ impl<Target: Composer> AuthorityBuilder<Target> {
     ///
     /// In other words, you can do the following things:
     ///
-    /// ```
+    #[cfg_attr(feature = "std", doc = "```")]
+    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
     /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;
@@ -1232,7 +1236,8 @@ impl<Target: Composer> AdditionalBuilder<Target> {
     ///
     /// In other words, you can do the following things:
     ///
-    /// ```
+    #[cfg_attr(feature = "std", doc = "```")]
+    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
     /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;

--- a/src/base/opt/rfc5001.rs
+++ b/src/base/opt/rfc5001.rs
@@ -7,7 +7,8 @@ use super::{OptData, ComposeOptData, ParseOptData};
 use octseq::builder::OctetsBuilder;
 use octseq::octets::Octets;
 use octseq::parse::Parser;
-use core::{fmt, str};
+use core::{borrow, fmt, hash, str};
+use core::cmp::Ordering;
 
 
 //------------ Nsid ---------------------------------------------------------/
@@ -15,7 +16,7 @@ use core::{fmt, str};
 /// The Name Server Identifier (NSID) Option.
 ///
 /// Specified in RFC 5001.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct Nsid<Octs> {
     octets: Octs,
 }
@@ -31,7 +32,53 @@ impl<Octs> Nsid<Octs> {
         let len = parser.remaining();
         parser.parse_octets(len).map(Nsid::from_octets).map_err(Into::into)
     }
+
+    pub fn as_octets(&self) -> &Octs {
+        &self.octets
+    }
+
+    pub fn into_octets(self) -> Octs {
+        self.octets
+    }
+
+    pub fn as_slice(&self) -> &[u8]
+    where Octs: AsRef<[u8]> {
+        self.octets.as_ref()
+    }
+
+    pub fn as_slice_mut(&mut self) -> &mut [u8]
+    where Octs: AsMut<[u8]> {
+        self.octets.as_mut()
+    }
 }
+
+//--- AsRef, AsMut, Borrow, BorrowMut
+
+impl<Octs: AsRef<[u8]>> AsRef<[u8]> for Nsid<Octs> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl<Octs: AsMut<[u8]>> AsMut<[u8]> for Nsid<Octs> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_slice_mut()
+    }
+}
+
+impl<Octs: AsRef<[u8]>> borrow::Borrow<[u8]> for Nsid<Octs> {
+    fn borrow(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl<Octs: AsMut<[u8]> + AsRef<[u8]>> borrow::BorrowMut<[u8]> for Nsid<Octs> {
+    fn borrow_mut(&mut self) -> &mut [u8] {
+        self.as_slice_mut()
+    }
+}
+
+//--- OptData etc.
 
 impl<Octs> OptData for Nsid<Octs> {
     fn code(&self) -> OptionCode {
@@ -65,6 +112,8 @@ impl<Octs: AsRef<[u8]>> ComposeOptData for Nsid<Octs> {
     }
 }
 
+//--- Display
+
 impl<Octs: AsRef<[u8]>> fmt::Display for Nsid<Octs> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // RFC 5001 § 2.4:
@@ -81,6 +130,38 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Nsid<Octs> {
     }
 }
 
+//--- PartialEq and Eq
+
+impl<Octs: AsRef<[u8]>, Other: AsRef<[u8]>> PartialEq<Other> for Nsid<Octs> {
+    fn eq(&self, other: &Other) -> bool {
+        self.as_slice().eq(other.as_ref())
+    }
+}
+
+impl<Octs: AsRef<[u8]>> Eq for Nsid<Octs> { }
+
+//--- PartialOrd and Ord
+
+impl<Octs: AsRef<[u8]>, Other: AsRef<[u8]>> PartialOrd<Other> for Nsid<Octs> {
+    fn partial_cmp(&self, other: &Other) -> Option<Ordering> {
+        self.as_slice().partial_cmp(other.as_ref())
+    }
+}
+
+impl<Octs: AsRef<[u8]>> Ord for Nsid<Octs> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_slice().cmp(other.as_slice())
+    }
+}
+
+//--- Hash
+
+impl<Octs: AsRef<[u8]>> hash::Hash for Nsid<Octs> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state)
+    }
+}
+
 
 //------------ OptBuilder ----------------------------------------------------
 
@@ -92,3 +173,19 @@ impl<'a, Target: Composer> OptBuilder<'a, Target> {
     }
 }
 
+//============ Testing ======================================================
+
+#[cfg(test)]
+#[cfg(all(feature = "std", feature = "bytes"))]
+mod test {
+    use super::*;
+    use super::super::test::test_option_compose_parse;
+    
+    #[test]
+    fn nsid_compose_parse() {
+        test_option_compose_parse(
+            &Nsid::from_octets("foo"),
+            |parser| Nsid::parse(parser)
+        );
+    }
+}

--- a/src/base/opt/rfc7314.rs
+++ b/src/base/opt/rfc7314.rs
@@ -94,3 +94,24 @@ impl<'a, Target: Composer> OptBuilder<'a, Target> {
     }
 }
 
+//============ Testing ======================================================
+
+#[cfg(test)]
+#[cfg(all(feature = "std", feature = "bytes"))]
+mod test {
+    use super::*;
+    use super::super::test::test_option_compose_parse;
+    
+    #[test]
+    fn expire_compose_parse() {
+        test_option_compose_parse(
+            &Expire::new(None),
+            |parser| Expire::parse(parser)
+        );
+        test_option_compose_parse(
+            &Expire::new(Some(12)),
+            |parser| Expire::parse(parser)
+        );
+    }
+}
+

--- a/src/base/opt/rfc7828.rs
+++ b/src/base/opt/rfc7828.rs
@@ -80,3 +80,20 @@ impl<'a, Target: Composer> OptBuilder<'a, Target> {
     }
 }
 
+//============ Testing ======================================================
+
+#[cfg(test)]
+#[cfg(all(feature = "std", feature = "bytes"))]
+mod test {
+    use super::*;
+    use super::super::test::test_option_compose_parse;
+    
+    #[test]
+    fn tcp_keepalive_compose_parse() {
+        test_option_compose_parse(
+            &TcpKeepalive::new(12),
+            |parser| TcpKeepalive::parse(parser)
+        );
+    }
+}
+

--- a/src/base/opt/rfc7871.rs
+++ b/src/base/opt/rfc7871.rs
@@ -274,11 +274,13 @@ impl fmt::Display for ClientSubnet {
 
 //============ Testing =======================================================
 
-#[cfg(all(test, feature="std"))]
+#[cfg(all(test, feature="std", feature = "bytes"))]
 mod tests {
     use super::*;
+    use super::super::test::test_option_compose_parse;
     use octseq::builder::infallible;
     use std::vec::Vec;
+    use core::str::FromStr;
 
     macro_rules! check {
         ($name:ident, $addr:expr, $prefix:expr, $exp:expr, $ok:expr) => {
@@ -310,4 +312,12 @@ mod tests {
     check!(prefix_min, "192.0.2.0", 0, "0.0.0.0", true);
     check!(prefix_max, "192.0.2.0", 32, "192.0.2.0", true);
     check!(prefix_too_long, "192.0.2.0", 100, "192.0.2.0", false);
+    
+    #[test]
+    fn client_subnet_compose_parse() {
+        test_option_compose_parse(
+            &ClientSubnet::new(4, 6, IpAddr::from_str("127.0.0.1").unwrap()),
+            |parser| ClientSubnet::parse(parser)
+        );
+    }
 }


### PR DESCRIPTION
This PR adds a basic compose/parse test to most options. It skips those that are known to require some refactoring. Those will have their tests added later.