### PR TITLE
Allow ?Sized where appropriate.

### DIFF
--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -126,8 +126,7 @@ impl CharStr<[u8]> {
     fn check_slice(slice: &[u8]) -> Result<(), CharStrError> {
         if slice.len() > 255 {
             Err(CharStrError)
-        }
-        else {
+        } else {
             Ok(())
         }
     }
@@ -451,7 +450,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized + 'a> IntoIterator for &'a CharStr<T> {
 #[cfg(feature = "serde")]
 impl<T> serde::Serialize for CharStr<T>
 where
-    T: AsRef<[u8]> + SerializeOctets + ?Sized
+    T: AsRef<[u8]> + SerializeOctets + ?Sized,
 {
     fn serialize<S: serde::Serializer>(
         &self,
@@ -883,10 +882,7 @@ mod test {
             CharStr::from_octets("01234").unwrap().as_slice(),
             b"01234"
         );
-        assert_eq!(
-            CharStr::from_octets("").unwrap().as_slice(),
-            b""
-        );
+        assert_eq!(CharStr::from_octets("").unwrap().as_slice(), b"");
         assert!(CharStr::from_octets(vec![0; 255]).is_ok());
         assert!(CharStr::from_octets(vec![0; 256]).is_err());
     }

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -1151,7 +1151,6 @@ impl fmt::Display for ShortMessage {
 #[cfg(feature = "std")]
 impl std::error::Error for ShortMessage {}
 
-
 //------------ CopyRecordsError ----------------------------------------------
 
 /// An error occurrd while copying records.

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -1505,12 +1505,12 @@ where
 /// header values of the record and push options to the record data.
 ///
 /// [`AdditionalBuilder::opt`]: struct.AdditonalBuilder.html#method.opt
-pub struct OptBuilder<'a, Target: AsRef<[u8]> + AsMut<[u8]>> {
+pub struct OptBuilder<'a, Target: ?Sized> {
     start: usize,
     target: &'a mut Target,
 }
 
-impl<'a, Target: Composer> OptBuilder<'a, Target> {
+impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
     /// Creates a new opt builder atop an additional builder.
     fn new(target: &'a mut Target) -> Result<Self, ShortBuf> {
         let start = target.as_ref().len();
@@ -1544,7 +1544,7 @@ impl<'a, Target: Composer> OptBuilder<'a, Target> {
     }
 
     /// Appends an option to the OPT record.
-    pub fn push<Opt: ComposeOptData>(
+    pub fn push<Opt: ComposeOptData + ?Sized>(
         &mut self,
         opt: &Opt,
     ) -> Result<(), Target::AppendError> {

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -234,7 +234,7 @@ impl<Target: Composer> MessageBuilder<Target> {
     ///
     /// The method converts the message builder into an answer builder ready
     /// to receive the answer for the question.
-    pub fn start_answer<Octs: Octets>(
+    pub fn start_answer<Octs: Octets + ?Sized>(
         mut self,
         msg: &Message<Octs>,
         rcode: Rcode,

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -320,8 +320,17 @@ where
 
 //--- AsRef
 
-impl<Octets: AsRef<T>, T> AsRef<T> for UncertainDname<Octets> {
-    fn as_ref(&self) -> &T {
+impl<Octs> AsRef<Octs> for UncertainDname<Octs> {
+    fn as_ref(&self) -> &Octs {
+        match *self {
+            UncertainDname::Absolute(ref name) => name.as_ref(),
+            UncertainDname::Relative(ref name) => name.as_ref(),
+        }
+    }
+}
+
+impl<Octs: AsRef<[u8]>> AsRef<[u8]> for UncertainDname<Octs> {
+    fn as_ref(&self) -> &[u8] {
         match *self {
             UncertainDname::Absolute(ref name) => name.as_ref(),
             UncertainDname::Relative(ref name) => name.as_ref(),

--- a/src/base/opt/rfc5001.rs
+++ b/src/base/opt/rfc5001.rs
@@ -17,7 +17,7 @@ use core::cmp::Ordering;
 ///
 /// Specified in RFC 5001.
 #[derive(Clone, Copy, Debug)]
-pub struct Nsid<Octs> {
+pub struct Nsid<Octs: ?Sized> {
     octets: Octs,
 }
 
@@ -32,47 +32,83 @@ impl<Octs> Nsid<Octs> {
         let len = parser.remaining();
         parser.parse_octets(len).map(Nsid::from_octets).map_err(Into::into)
     }
+}
 
+impl Nsid<[u8]> {
+    pub fn from_slice(slice: &[u8]) -> &Self {
+        unsafe { &*(slice as *const [u8] as *const Self) }
+    }
+
+    pub fn from_slice_mut(slice: &mut [u8]) -> &mut Self {
+        unsafe { &mut *(slice as *mut [u8] as *mut Self) }
+    }
+}
+
+impl<Octs: ?Sized> Nsid<Octs> {
     pub fn as_octets(&self) -> &Octs {
         &self.octets
     }
 
-    pub fn into_octets(self) -> Octs {
+    pub fn into_octets(self) -> Octs
+    where
+        Octs: Sized,
+    {
         self.octets
     }
 
     pub fn as_slice(&self) -> &[u8]
-    where Octs: AsRef<[u8]> {
+    where
+        Octs: AsRef<[u8]>,
+    {
         self.octets.as_ref()
     }
 
     pub fn as_slice_mut(&mut self) -> &mut [u8]
-    where Octs: AsMut<[u8]> {
+    where
+        Octs: AsMut<[u8]>,
+    {
         self.octets.as_mut()
+    }
+
+    pub fn for_slice(&self) -> &Nsid<[u8]>
+    where
+        Octs: AsRef<[u8]>
+    {
+        Nsid::from_slice(self.octets.as_ref())
+    }
+
+    pub fn for_slice_mut(&mut self) -> &mut Nsid<[u8]>
+    where
+        Octs: AsMut<[u8]>
+    {
+        Nsid::from_slice_mut(self.octets.as_mut())
     }
 }
 
 //--- AsRef, AsMut, Borrow, BorrowMut
 
-impl<Octs: AsRef<[u8]>> AsRef<[u8]> for Nsid<Octs> {
+impl<Octs: AsRef<[u8]> + ?Sized> AsRef<[u8]> for Nsid<Octs> {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
     }
 }
 
-impl<Octs: AsMut<[u8]>> AsMut<[u8]> for Nsid<Octs> {
+impl<Octs: AsMut<[u8]> + ?Sized> AsMut<[u8]> for Nsid<Octs> {
     fn as_mut(&mut self) -> &mut [u8] {
         self.as_slice_mut()
     }
 }
 
-impl<Octs: AsRef<[u8]>> borrow::Borrow<[u8]> for Nsid<Octs> {
+impl<Octs: AsRef<[u8]> + ?Sized> borrow::Borrow<[u8]> for Nsid<Octs> {
     fn borrow(&self) -> &[u8] {
         self.as_slice()
     }
 }
 
-impl<Octs: AsMut<[u8]> + AsRef<[u8]>> borrow::BorrowMut<[u8]> for Nsid<Octs> {
+impl<Octs> borrow::BorrowMut<[u8]> for Nsid<Octs>
+where
+    Octs: AsMut<[u8]> + AsRef<[u8]> + ?Sized
+{
     fn borrow_mut(&mut self) -> &mut [u8] {
         self.as_slice_mut()
     }
@@ -80,7 +116,7 @@ impl<Octs: AsMut<[u8]> + AsRef<[u8]>> borrow::BorrowMut<[u8]> for Nsid<Octs> {
 
 //--- OptData etc.
 
-impl<Octs> OptData for Nsid<Octs> {
+impl<Octs: ?Sized> OptData for Nsid<Octs> {
     fn code(&self) -> OptionCode {
         OptionCode::Nsid
     }
@@ -100,7 +136,7 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for Nsid<Octs::Range<'a>> {
     }
 }
 
-impl<Octs: AsRef<[u8]>> ComposeOptData for Nsid<Octs> {
+impl<Octs: AsRef<[u8]> + ?Sized> ComposeOptData for Nsid<Octs> {
     fn compose_len(&self) -> u16 {
         self.octets.as_ref().len().try_into().expect("long option data")
     }
@@ -114,7 +150,7 @@ impl<Octs: AsRef<[u8]>> ComposeOptData for Nsid<Octs> {
 
 //--- Display
 
-impl<Octs: AsRef<[u8]>> fmt::Display for Nsid<Octs> {
+impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Nsid<Octs> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // RFC 5001 § 2.4:
         // | User interfaces MUST read and write the contents of the NSID
@@ -132,23 +168,31 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Nsid<Octs> {
 
 //--- PartialEq and Eq
 
-impl<Octs: AsRef<[u8]>, Other: AsRef<[u8]>> PartialEq<Other> for Nsid<Octs> {
+impl<Octs, Other> PartialEq<Other> for Nsid<Octs>
+where
+    Octs: AsRef<[u8]> + ?Sized,
+    Other: AsRef<[u8]> + ?Sized,
+{
     fn eq(&self, other: &Other) -> bool {
         self.as_slice().eq(other.as_ref())
     }
 }
 
-impl<Octs: AsRef<[u8]>> Eq for Nsid<Octs> { }
+impl<Octs: AsRef<[u8]> + ?Sized> Eq for Nsid<Octs> { }
 
 //--- PartialOrd and Ord
 
-impl<Octs: AsRef<[u8]>, Other: AsRef<[u8]>> PartialOrd<Other> for Nsid<Octs> {
+impl<Octs, Other> PartialOrd<Other> for Nsid<Octs>
+where
+    Octs: AsRef<[u8]> + ?Sized,
+    Other: AsRef<[u8]> + ?Sized,
+{
     fn partial_cmp(&self, other: &Other) -> Option<Ordering> {
         self.as_slice().partial_cmp(other.as_ref())
     }
 }
 
-impl<Octs: AsRef<[u8]>> Ord for Nsid<Octs> {
+impl<Octs: AsRef<[u8]> + ?Sized> Ord for Nsid<Octs> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_slice().cmp(other.as_slice())
     }
@@ -156,7 +200,7 @@ impl<Octs: AsRef<[u8]>> Ord for Nsid<Octs> {
 
 //--- Hash
 
-impl<Octs: AsRef<[u8]>> hash::Hash for Nsid<Octs> {
+impl<Octs: AsRef<[u8]> + ?Sized> hash::Hash for Nsid<Octs> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.as_slice().hash(state)
     }
@@ -167,9 +211,9 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Nsid<Octs> {
 
 impl<'a, Target: Composer> OptBuilder<'a, Target> {
     pub fn nsid(
-        &mut self, data: &impl AsRef<[u8]>
+        &mut self, data: &(impl AsRef<[u8]> + ?Sized)
     ) -> Result<(), Target::AppendError> {
-        self.push(&Nsid::from_octets(data.as_ref()))
+        self.push(Nsid::from_slice(data.as_ref()))
     }
 }
 

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -8,12 +8,12 @@ macro_rules! rdata_types {
         $module:ident::{
             $(
                 zone {
-                    $( $mtype:ident $( < $( $mn:ident ),* > )*, )*
+                    $( $mtype:ident $( < $( $mn:ident ),* > ),* $(,)? )*
                 }
             )*
             $(
                 pseudo {
-                    $( $ptype:ident $( < $( $pn:ident ),* > )*, )*
+                    $( $ptype:ident $( < $( $pn:ident ),* > ),*  $(,)? )*
                 }
             )*
 
@@ -24,6 +24,10 @@ macro_rules! rdata_types {
                 $( $( $mtype, )* )*
                 $( $( $ptype ),* )*
             };
+        )*
+
+        $(
+            pub mod $module;
         )*
 
         use crate::base::name::{ParsedDname, PushError, ToDname};

--- a/src/rdata/mod.rs
+++ b/src/rdata/mod.rs
@@ -47,20 +47,10 @@
 #[macro_use]
 mod macros;
 
-pub mod rfc1035;
-pub mod rfc2782;
-pub mod rfc2845;
-pub mod rfc3596;
-pub mod rfc4034;
-pub mod rfc5155;
-pub mod rfc6672;
-pub mod rfc7344;
-pub mod svcb;
-
-// The rdata_types! macro (defined in self::macros) re-exports the record data
-// types here and creates the ZoneRecordData and AllRecordData enums
-// containing all record types that can appear in a zone and all record
-// types that exist.
+// The rdata_types! macro (defined in self::macros) defines the modules
+// containing the record data types, re-exports those here, and creates the
+// ZoneRecordData and AllRecordData enums containing all record types that
+// can appear in a zone file and all record types that exist.
 //
 // All record data types listed here MUST have the same name as the
 // `Rtype` variant they implement – some of the code implemented by the macro
@@ -69,10 +59,8 @@ pub mod svcb;
 // Add any new module here and then add all record types in that module that
 // can appear in zone files under "zone" and all others under "pseudo".
 // Your type can be generic over an octet type "O" and a domain name type "N".
-// Add these as needed.
-//
-// Each type entry has to be followed by a comma, even the last one. The macro
-// is messy enough as it is ...
+// Add these as needed. Trait bounds on them differ for different methods, so
+// check the bounds on ZoneRecordData and AllRecordData if there are errors.
 rdata_types! {
     rfc1035::{
         zone {
@@ -92,7 +80,7 @@ rdata_types! {
             Txt<O>,
         }
         pseudo {
-            Null<O>,
+            Null<O>
         }
     }
     rfc2782::{


### PR DESCRIPTION
This PR adds an `?Sized` trait bound to all types that exclusively wrap an octets sequence. In the process, it also does some cleanup here and there to improve consistency of the crate.

Specifically, it includes the following noteworthy changes:

* All types that wrap an octets sequence only allow unsized octets sequence types. They all have an associated function `from_slice` to create a reference to a value wrapping an (unsized) octets slice and method `for_slice` that converts a `&self` into such a reference. Where the latter already existed but returned a value wrapping a `&[u8]` (e.g., `Dname<_>` and `Message<_>`, the return type has changed accordingly.

* Removed `CharStr::from_bytes`. Use `CharStr::from_octets` instead.

* `Message::from_octets` now returns a new error type `ShortMessage`.

* Dropped `Deref` impls for `Dname<_>`, `RelativeDname<_>`.

* Renamed `opt::KeyTag::new` to `opt::KeyTag::from_octets`.

* Renamed `rdata::Txt::try_from_slice` to `build_from_slice`.

This is currently a draft – more changes may be added with additional commits.