### PR TITLE
Check for record data length upon creation.

### DIFF
--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -114,6 +114,9 @@ impl Opt<[u8]> {
 
     /// Checks that the slice contains acceptable OPT record data.
     fn check_slice(slice: &[u8]) -> Result<(), ParseError> {
+        if slice.len() > usize::from(u16::MAX) {
+            return Err(FormError::new("long record data").into())
+        }
         let mut parser = Parser::from_ref(slice);
         while parser.remaining() > 0 {
             parser.advance(2)?;
@@ -126,9 +129,13 @@ impl Opt<[u8]> {
 
 impl<Octs: AsRef<[u8]> + ?Sized> Opt<Octs> {
     /// Returns the length of the OPT record data.
-    #[allow(clippy::len_without_is_empty)] // never empty.
     pub fn len(&self) -> usize {
         self.octets.as_ref().len()
+    }
+
+    /// Returns whether the OPT record data is empty.
+    pub fn is_empty(&self) -> bool {
+        self.octets.as_ref().is_empty()
     }
 
     /// Returns an iterator over options of a given type.

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -115,7 +115,7 @@ impl Opt<[u8]> {
     /// Checks that the slice contains acceptable OPT record data.
     fn check_slice(slice: &[u8]) -> Result<(), ParseError> {
         if slice.len() > usize::from(u16::MAX) {
-            return Err(FormError::new("long record data").into())
+            return Err(FormError::new("long record data").into());
         }
         let mut parser = Parser::from_ref(slice);
         while parser.remaining() > 0 {

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -243,11 +243,8 @@ impl<Octs> UnknownRecordData<Octs> {
     where
         Octs: AsRef<[u8]>,
     {
-        if data.as_ref().len() > 0xFFFF {
-            Err(LongRecordData())
-        } else {
-            Ok(UnknownRecordData { rtype, data })
-        }
+        LongRecordData::check_len(data.as_ref().len())?;
+        Ok(UnknownRecordData { rtype, data })
     }
 
     /// Returns the record type this data is for.
@@ -450,9 +447,24 @@ impl<Octs: AsRef<[u8]>> fmt::Debug for UnknownRecordData<Octs> {
 #[derive(Clone, Copy, Debug)]
 pub struct LongRecordData();
 
+impl LongRecordData {
+    pub fn as_str(self) -> &'static str {
+        "record data too long"
+    }
+
+    pub fn check_len(len: usize) -> Result<(), Self> {
+        if len > usize::from(u16::MAX) {
+            Err(LongRecordData())
+        }
+        else {
+            Ok(())
+        }
+    }
+}
+
 impl fmt::Display for LongRecordData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("record data too long")
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -455,8 +455,7 @@ impl LongRecordData {
     pub fn check_len(len: usize) -> Result<(), Self> {
         if len > usize::from(u16::MAX) {
             Err(LongRecordData())
-        }
-        else {
+        } else {
             Ok(())
         }
     }

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -75,7 +75,7 @@ macro_rules! rdata_types {
             Unknown($crate::base::rdata::UnknownRecordData<O>),
         }
 
-        impl<Octets: AsRef<[u8]>, Name> ZoneRecordData<Octets, Name> {
+        impl<Octets: AsRef<[u8]>, Name: ToDname> ZoneRecordData<Octets, Name> {
             /// Scans a value of the given rtype.
             ///
             /// If the record data is given via the notation for unknown

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -154,9 +154,9 @@ impl<N, D> SortedRecords<N, D> {
                     name.owner().clone(),
                     name.class(),
                     rrset.ttl(),
-                    rrsig.into_rrsig(key.sign(&buf)?.into()).expect(
-                        "long signature"
-                    ),
+                    rrsig
+                        .into_rrsig(key.sign(&buf)?.into())
+                        .expect("long signature"),
                 ));
             }
         }

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -74,7 +74,7 @@ impl<N, D> SortedRecords<N, D> {
         N: ToDname + Clone,
         D: RecordData + ComposeRecordData,
         Key: SigningKey,
-        Octets: From<Key::Signature>,
+        Octets: From<Key::Signature> + AsRef<[u8]>,
         ApexName: ToDname + Clone,
     {
         let mut res = Vec::new();
@@ -154,7 +154,9 @@ impl<N, D> SortedRecords<N, D> {
                     name.owner().clone(),
                     name.class(),
                     rrset.ttl(),
-                    rrsig.into_rrsig(key.sign(&buf)?.into()),
+                    rrsig.into_rrsig(key.sign(&buf)?.into()).expect(
+                        "long signature"
+                    ),
                 ));
             }
         }

--- a/src/sign/ring.rs
+++ b/src/sign/ring.rs
@@ -52,7 +52,8 @@ impl<'a> Key<'a> {
                 3,
                 SecAlg::EcdsaP256Sha256,
                 public_key,
-            ).expect("long key"),
+            )
+            .expect("long key"),
             key: RingKey::Ecdsa(keypair),
             rng,
         })
@@ -82,7 +83,8 @@ impl<'a> SigningKey for Key<'a> {
             self.dnskey.algorithm(),
             DigestAlg::Sha256,
             digest,
-        ).expect("long digest"))
+        )
+        .expect("long digest"))
     }
 
     fn sign(&self, msg: &[u8]) -> Result<Self::Signature, Self::Error> {

--- a/src/sign/ring.rs
+++ b/src/sign/ring.rs
@@ -52,7 +52,7 @@ impl<'a> Key<'a> {
                 3,
                 SecAlg::EcdsaP256Sha256,
                 public_key,
-            ),
+            ).expect("long key"),
             key: RingKey::Ecdsa(keypair),
             rng,
         })
@@ -82,7 +82,7 @@ impl<'a> SigningKey for Key<'a> {
             self.dnskey.algorithm(),
             DigestAlg::Sha256,
             digest,
-        ))
+        ).expect("long digest"))
     }
 
     fn sign(&self, msg: &[u8]) -> Result<Self::Signature, Self::Error> {

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -1417,7 +1417,8 @@ impl Variables {
                 original_id,
                 self.error,
                 other,
-            ).expect("long MAC"),
+            )
+            .expect("long MAC"),
         ))
     }
 
@@ -1668,7 +1669,8 @@ impl<K: AsRef<Key>> ServerError<K> {
                         msg.header().id(),
                         error,
                         b"",
-                    ).expect("long record data"),
+                    )
+                    .expect("long record data"),
                 ))?;
             }
             ServerErrorInner::Signed { context, variables } => {

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -1406,6 +1406,9 @@ impl Variables {
             key.name.clone(),
             Class::Any,
             0,
+            // The only reason creating TSIG record data can fail here is
+            // that the hmac is unreasonable large. Since we control its
+            // creation, panicing in this case is fine.
             Tsig::new(
                 key.algorithm().to_dname(),
                 self.time_signed,
@@ -1414,7 +1417,7 @@ impl Variables {
                 original_id,
                 self.error,
                 other,
-            ),
+            ).expect("long MAC"),
         ))
     }
 
@@ -1656,6 +1659,7 @@ impl<K: AsRef<Key>> ServerError<K> {
                     tsig.owner(),
                     tsig.class(),
                     tsig.ttl(),
+                    // The TSIG record data can never ever be to long.
                     Tsig::new(
                         tsig.data().algorithm(),
                         tsig.data().time_signed(),
@@ -1664,7 +1668,7 @@ impl<K: AsRef<Key>> ServerError<K> {
                         msg.header().id(),
                         error,
                         b"",
-                    ),
+                    ).expect("long record data"),
                 ))?;
             }
             ServerErrorInner::Signed { context, variables } => {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -415,7 +415,8 @@ mod test {
                 "4G1EuAuPHTmpXAsNfGXQhFjogECbvGg0VxBCN8f47I0=",
             )
             .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             dnskey.digest(&owner, DigestAlg::Sha256).unwrap().as_ref(),
             expected.digest()
@@ -520,7 +521,8 @@ mod test {
                     F+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
                 )
                 .unwrap(),
-            ).unwrap(),
+            )
+            .unwrap(),
             Dnskey::new(
                 256,
                 3,
@@ -530,7 +532,8 @@ mod test {
                     d8KqXXFJkqmVfRvMGPmM1x8fGAa2XhSA==",
                 )
                 .unwrap(),
-            ).unwrap(),
+            )
+            .unwrap(),
         );
 
         let owner = Dname::from_str("cloudflare.com.").unwrap();
@@ -548,7 +551,8 @@ mod test {
                 zcJBLvRmofYFDAhju21p1uTfLaYHrg==",
             )
             .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         rrsig_verify_dnskey(ksk, zsk, rrsig);
     }
 
@@ -563,7 +567,8 @@ mod test {
                     "m1NELLVVQKl4fHVn/KKdeNO0PrYKGT3IGbYseT8XcKo=",
                 )
                 .unwrap(),
-            ).unwrap(),
+            )
+            .unwrap(),
             Dnskey::new(
                 256,
                 3,
@@ -572,12 +577,13 @@ mod test {
                     "2tstZAjgmlDTePn0NVXrAHBJmg84LoaFVxzLl1anjGI=",
                 )
                 .unwrap(),
-            ).unwrap(),
+            )
+            .unwrap(),
         );
 
-        let owner = Dname::from_octets(
-            Vec::from(b"\x07ED25519\x02nl\x00".as_ref())
-        ).unwrap();
+        let owner =
+            Dname::from_octets(Vec::from(b"\x07ED25519\x02nl\x00".as_ref()))
+                .unwrap();
         let rrsig = Rrsig::new(
             Rtype::Dnskey,
             SecAlg::Ed25519,
@@ -592,7 +598,8 @@ mod test {
                 QdtgPXja7YkTaqzrYUbYk01J8ICsAA==",
             )
             .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         rrsig_verify_dnskey(ksk, zsk, rrsig);
     }
 
@@ -617,7 +624,8 @@ mod test {
                 dg5fjeHDtz285xHt5HJpA5cOcctRo4ihybfow/+V7AQ==",
             )
             .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
 
         let mut records: Vec<Record<Dname, ZoneRecordData<Vec<u8>, Dname>>> =
             [&ksk, &zsk]
@@ -656,7 +664,8 @@ mod test {
                 vh0z2542lzMKR4Dh8uZffQ==",
             )
             .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let rrsig = Rrsig::new(
             Rtype::Mx,
             SecAlg::RsaSha1,
@@ -673,7 +682,8 @@ mod test {
                  36SR5xBni8vHI=",
             )
             .unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let record = Record::new(
             Dname::from_str("a.z.w.example.").unwrap(),
             Class::In,

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -382,8 +382,8 @@ mod test {
         )
         .unwrap();
         (
-            Dnskey::new(257, 3, SecAlg::RsaSha256, ksk),
-            Dnskey::new(256, 3, SecAlg::RsaSha256, zsk),
+            Dnskey::new(257, 3, SecAlg::RsaSha256, ksk).unwrap(),
+            Dnskey::new(256, 3, SecAlg::RsaSha256, zsk).unwrap(),
         )
     }
 
@@ -398,8 +398,8 @@ mod test {
         )
         .unwrap();
         (
-            Dnskey::new(257, 3, SecAlg::RsaSha256, ksk),
-            Dnskey::new(256, 3, SecAlg::RsaSha256, zsk),
+            Dnskey::new(257, 3, SecAlg::RsaSha256, ksk).unwrap(),
+            Dnskey::new(256, 3, SecAlg::RsaSha256, zsk).unwrap(),
         )
     }
 
@@ -415,7 +415,7 @@ mod test {
                 "4G1EuAuPHTmpXAsNfGXQhFjogECbvGg0VxBCN8f47I0=",
             )
             .unwrap(),
-        );
+        ).unwrap();
         assert_eq!(
             dnskey.digest(&owner, DigestAlg::Sha256).unwrap().as_ref(),
             expected.digest()
@@ -474,7 +474,7 @@ mod test {
                 "otBkINZAQu7AvPKjr/xWIEE7+SoZtKgF8bzVynX6bfJMJuPay8jPvNmwXkZOdSoYlvFp0bk9JWJKCh8y5uoNfMFkN6OSrDkr3t0E+c8c0Mnmwkk5CETH3Gqxthi0yyRX5T4VlHU06/Ks4zI+XAgl3FBpOc554ivdzez8YCjAIGx7XgzzooEb7heMSlLc7S7/HNjw51TPRs4RxrAVcezieKCzPPpeWBhjE6R3oiSwrl0SBD4/yplrDlr7UHs/Atcm3MSgemdyr2sOoOUkVQCVpcj3SQQezoD2tCM7861CXEQdg5fjeHDtz285xHt5HJpA5cOcctRo4ihybfow/+V7AQ==",
             )
             .unwrap()
-        );
+        ).unwrap();
         rrsig_verify_dnskey(ksk, zsk, rrsig);
 
         // Test 1024b long key
@@ -492,7 +492,7 @@ mod test {
                 "j1s1IPMoZd0mbmelNVvcbYNe2tFCdLsLpNCnQ8xW6d91ujwPZ2yDlc3lU3hb+Jq3sPoj+5lVgB7fZzXQUQTPFWLF7zvW49da8pWuqzxFtg6EjXRBIWH5rpEhOcr+y3QolJcPOTx+/utCqt2tBKUUy3LfM6WgvopdSGaryWdwFJPW7qKHjyyLYxIGx5AEuLfzsA5XZf8CmpUheSRH99GRZoIB+sQzHuelWGMQ5A42DPvOVZFmTpIwiT2QaIpid4nJ7jNfahfwFrCoS+hvqjK9vktc5/6E/Mt7DwCQDaPt5cqDfYltUitQy+YA5YP5sOhINChYadZe+2N80OA+RKz0mA==",
             )
             .unwrap()
-        );
+        ).unwrap();
         rrsig_verify_dnskey(ksk, zsk, rrsig.clone());
 
         // Test that 512b short RSA DNSKEY is not supported (too short)
@@ -501,7 +501,7 @@ mod test {
         )
         .unwrap();
 
-        let short_key = Dnskey::new(256, 3, SecAlg::RsaSha256, data);
+        let short_key = Dnskey::new(256, 3, SecAlg::RsaSha256, data).unwrap();
         let err = rrsig
             .verify_signed_data(&short_key, &vec![0; 100])
             .unwrap_err();
@@ -520,7 +520,7 @@ mod test {
                     F+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
                 )
                 .unwrap(),
-            ),
+            ).unwrap(),
             Dnskey::new(
                 256,
                 3,
@@ -530,7 +530,7 @@ mod test {
                     d8KqXXFJkqmVfRvMGPmM1x8fGAa2XhSA==",
                 )
                 .unwrap(),
-            ),
+            ).unwrap(),
         );
 
         let owner = Dname::from_str("cloudflare.com.").unwrap();
@@ -548,7 +548,7 @@ mod test {
                 zcJBLvRmofYFDAhju21p1uTfLaYHrg==",
             )
             .unwrap(),
-        );
+        ).unwrap();
         rrsig_verify_dnskey(ksk, zsk, rrsig);
     }
 
@@ -563,7 +563,7 @@ mod test {
                     "m1NELLVVQKl4fHVn/KKdeNO0PrYKGT3IGbYseT8XcKo=",
                 )
                 .unwrap(),
-            ),
+            ).unwrap(),
             Dnskey::new(
                 256,
                 3,
@@ -572,12 +572,12 @@ mod test {
                     "2tstZAjgmlDTePn0NVXrAHBJmg84LoaFVxzLl1anjGI=",
                 )
                 .unwrap(),
-            ),
+            ).unwrap(),
         );
 
-        let owner =
-            Dname::from_octets(Vec::from(b"\x07ED25519\x02nl\x00".as_ref()))
-                .unwrap();
+        let owner = Dname::from_octets(
+            Vec::from(b"\x07ED25519\x02nl\x00".as_ref())
+        ).unwrap();
         let rrsig = Rrsig::new(
             Rtype::Dnskey,
             SecAlg::Ed25519,
@@ -592,7 +592,7 @@ mod test {
                 QdtgPXja7YkTaqzrYUbYk01J8ICsAA==",
             )
             .unwrap(),
-        );
+        ).unwrap();
         rrsig_verify_dnskey(ksk, zsk, rrsig);
     }
 
@@ -617,7 +617,7 @@ mod test {
                 dg5fjeHDtz285xHt5HJpA5cOcctRo4ihybfow/+V7AQ==",
             )
             .unwrap(),
-        );
+        ).unwrap();
 
         let mut records: Vec<Record<Dname, ZoneRecordData<Vec<u8>, Dname>>> =
             [&ksk, &zsk]
@@ -656,7 +656,7 @@ mod test {
                 vh0z2542lzMKR4Dh8uZffQ==",
             )
             .unwrap(),
-        );
+        ).unwrap();
         let rrsig = Rrsig::new(
             Rtype::Mx,
             SecAlg::RsaSha1,
@@ -673,7 +673,7 @@ mod test {
                  36SR5xBni8vHI=",
             )
             .unwrap(),
-        );
+        ).unwrap();
         let record = Record::new(
             Dname::from_str("a.z.w.example.").unwrap(),
             Class::In,


### PR DESCRIPTION
This PR changes the `new` function of the following record types to check whether the wire format representation of the record data is too long and thus returns a result: `Tsig<_, _>`, `Dnskey<_>`, `Rrsig<_, _>`, `Ds<_>`,  `Cdnskey<_>`, `Cds<_>`. In addition, it changes the `Null::new` to `Null::from_octets`.