### PR TITLE
doc: Change some information in the example

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -89,7 +89,7 @@ fn main() {
     }
 
     // Display is only implemented for some OPTs at the time of writing
-    for option in response.opt().unwrap().iter::<AllOptData<_, _>>() {
+    for option in response.opt().unwrap().iter::<AllOptData<_>>() {
         let opt = option.unwrap();
         match opt {
             AllOptData::Nsid(nsid) => println!("{}", nsid),


### PR DESCRIPTION
This error occurs when running the sample before changing

```
error[E0107]: this enum takes 1 generic argument but 2 generic arguments were supplied
  --> src\main.rs:92:50
   |
92 |     for option in response.opt().unwrap().iter::<AllOptData<_, _>>() {
   |                                                  ^^^^^^^^^^    - help: remove this generic argument
   |                                                  |
   |                                                  expected 1 generic argument
   |
note: enum defined here, with 1 generic parameter: `Octets`
```

I am learning rust. If there is something wrong, thank you for pointing out.