### PR TITLE
Fix pointer conversion unsoundness.

### DIFF
--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -95,7 +95,7 @@ impl Header {
     /// This function panics if the slice is less than four octets long.
     pub fn for_message_slice_mut(s: &mut [u8]) -> &mut Header {
         assert!(s.len() >= mem::size_of::<Header>());
-        unsafe { &mut *(s.as_ptr() as *mut Header) }
+        unsafe { &mut *(s.as_mut_ptr() as *mut Header) }
     }
 
     /// Returns a reference to the underlying octets slice.
@@ -504,7 +504,7 @@ impl HeaderCounts {
     pub fn for_message_slice_mut(message: &mut [u8]) -> &mut Self {
         assert!(message.len() >= mem::size_of::<HeaderSection>());
         unsafe {
-            &mut *((message[mem::size_of::<Header>()..].as_ptr())
+            &mut *((message[mem::size_of::<Header>()..].as_mut_ptr())
                 as *mut HeaderCounts)
         }
     }
@@ -794,7 +794,7 @@ impl HeaderSection {
     /// This function panics if the octets slice is shorter than 12 octets.
     pub fn for_message_slice_mut(s: &mut [u8]) -> &mut HeaderSection {
         assert!(s.len() >= mem::size_of::<HeaderSection>());
-        unsafe { &mut *(s.as_ptr() as *mut HeaderSection) }
+        unsafe { &mut *(s.as_mut_ptr() as *mut HeaderSection) }
     }
 
     /// Returns a reference to the underlying octets slice.

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -301,7 +301,7 @@ impl OptHeader {
     /// Returns a mutable reference pointing into a record’s octets.
     pub fn for_record_slice_mut(slice: &mut [u8]) -> &mut OptHeader {
         assert!(slice.len() >= mem::size_of::<Self>());
-        unsafe { &mut *(slice.as_ptr() as *mut OptHeader) }
+        unsafe { &mut *(slice.as_mut_ptr() as *mut OptHeader) }
     }
 
     /// Returns the UDP payload size.


### PR DESCRIPTION
This PR fixes a few cases where `slice::as_ptr` was used rather than `slice::as_mut_ptr` when converting a slice into a mutable header.