### PR TITLE
Add methods to make or convert into canonical domain names.

### DIFF
--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -279,14 +279,7 @@ impl<Octs: ?Sized> Dname<Octs> {
     where
         Octs: AsMut<[u8]>,
     {
-        let mut slice = self.0.as_mut();
-
-        while !slice.is_empty() {
-            let (head, tail) =
-                Label::split_from_mut(slice).expect("invalid dname");
-            head.make_canonical();
-            slice = tail;
-        }
+        Label::make_slice_canonical(self.0.as_mut());
     }
 }
 

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -211,6 +211,25 @@ impl Label {
         self.0.make_ascii_lowercase()
     }
 
+    /// Converts a sequence of labels into the canonical form.
+    ///
+    /// The function takes a mutable octets slice that contains a sequence
+    /// of labels in wire format (vulgo: a domain name) and converts each
+    /// label into its canonical form.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if the slice does not contain a valid sequence
+    /// of labels.
+    pub(super) fn make_slice_canonical(mut slice: &mut [u8]) {
+        while !slice.is_empty() {
+            let (head, tail) =
+                Label::split_from_mut(slice).expect("invalid name");
+            head.make_canonical();
+            slice = tail;
+        }
+    }
+
     /// Returns the label in canonical form.
     ///
     /// In this form, all ASCII letters are lowercase.

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -258,14 +258,7 @@ impl<Octs: ?Sized> RelativeDname<Octs> {
     where
         Octs: AsMut<[u8]>,
     {
-        let mut slice = self.0.as_mut();
-
-        while !slice.is_empty() {
-            let (head, tail) =
-                Label::split_from_mut(slice).expect("invalid relative name");
-            head.make_canonical();
-            slice = tail;
-        }
+        Label::make_slice_canonical(self.0.as_mut());
     }
 }
 

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -252,6 +252,21 @@ impl<Octs: ?Sized> RelativeDname<Octs> {
     {
         unsafe { RelativeDname::from_slice_unchecked(self.0.as_ref()) }
     }
+
+    /// Converts the name into its canonical form.
+    pub fn make_canonical(&mut self)
+    where
+        Octs: AsMut<[u8]>,
+    {
+        let mut slice = self.0.as_mut();
+
+        while !slice.is_empty() {
+            let (head, tail) =
+                Label::split_from_mut(slice).expect("invalid relative name");
+            head.make_canonical();
+            slice = tail;
+        }
+    }
 }
 
 impl<Octs> RelativeDname<Octs> {
@@ -1185,6 +1200,17 @@ mod test {
             .unwrap()
             .into_absolute()
             .unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn make_canonical() {
+        let mut name = Dname::vec_from_str("wWw.exAmpLE.coM.").unwrap();
+        name.make_canonical();
+        assert_eq!(
+            name,
+            Dname::from_octets(b"\x03www\x07example\x03com\0").unwrap()
+        );
     }
 
     // chain is tested with the Chain type.


### PR DESCRIPTION
This PR adds `Dname::make_canonical` and `RelativeDname::make_canonical` to convert a domain name into its canonical form in place as well as `ToDname::to_canonical_dname` and `ToRelativeDname::to_canonical_relative_dname` to produce new canonical domain names.

Fixes #182.