### PR TITLE
refactor: use `Duration` instead of `u32`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.showUnlinkedFileNotification": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "rust-analyzer.showUnlinkedFileNotification": false
-}

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -2232,6 +2232,7 @@ mod test {
     use crate::base::{iana::Rtype, opt, Dname};
     use crate::rdata::{Ns, Soa, A};
     use core::str::FromStr;
+    use core::time::Duration;
     use std::vec::Vec;
 
     #[test]
@@ -2349,10 +2350,10 @@ mod test {
                 mname,
                 rname,
                 Serial(2020081701),
-                1800,
-                900,
-                604800,
-                86400,
+                Duration::from_secs(1800),
+                Duration::from_secs(900),
+                Duration::from_secs(604800),
+                Duration::from_secs(86400),
             ),
         ))
         .unwrap();

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -744,13 +744,14 @@ impl<Target: Composer> AnswerBuilder<Target> {
     ///
     #[cfg_attr(feature = "std", doc = "```")]
     #[cfg_attr(not(feature = "std"), doc = "```ignore")]
+    /// use core::time::Duration;
     /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;
     ///
     /// let mut msg = MessageBuilder::new_vec().answer();
     /// let record = Record::new(
-    ///     Dname::root_ref(), Class::In, 86400, A::from_octets(192, 0, 2, 1)
+    ///     Dname::root_ref(), Class::In, Duration::from_secs(86400), A::from_octets(192, 0, 2, 1)
     /// );
     /// msg.push(&record).unwrap();
     /// msg.push(record).unwrap();
@@ -988,13 +989,14 @@ impl<Target: Composer> AuthorityBuilder<Target> {
     ///
     #[cfg_attr(feature = "std", doc = "```")]
     #[cfg_attr(not(feature = "std"), doc = "```ignore")]
+    /// use core::time::Duration;
     /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;
     ///
     /// let mut msg = MessageBuilder::new_vec().authority();
     /// let record = Record::new(
-    ///     Dname::root_ref(), Class::In, 86400, A::from_octets(192, 0, 2, 1)
+    ///     Dname::root_ref(), Class::In, Duration::from_secs(86400), A::from_octets(192, 0, 2, 1)
     /// );
     /// msg.push(&record).unwrap();
     /// msg.push(record).unwrap();
@@ -1239,13 +1241,14 @@ impl<Target: Composer> AdditionalBuilder<Target> {
     ///
     #[cfg_attr(feature = "std", doc = "```")]
     #[cfg_attr(not(feature = "std"), doc = "```ignore")]
+    /// use core::time::Duration;
     /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;
     ///
     /// let mut msg = MessageBuilder::new_vec().additional();
     /// let record = Record::new(
-    ///     Dname::root_ref(), Class::In, 86400, A::from_octets(192, 0, 2, 1)
+    ///     Dname::root_ref(), Class::In, Duration::from_secs(86400), A::from_octets(192, 0, 2, 1)
     /// );
     /// msg.push(&record).unwrap();
     /// msg.push(record).unwrap();

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -2228,11 +2228,11 @@ impl std::error::Error for PushError {}
 #[cfg(feature = "std")]
 mod test {
     use super::*;
+    use crate::base::Ttl;
     use crate::base::Serial;
     use crate::base::{iana::Rtype, opt, Dname};
     use crate::rdata::{Ns, Soa, A};
     use core::str::FromStr;
-    use core::time::Duration;
     use std::vec::Vec;
 
     #[test]
@@ -2350,10 +2350,10 @@ mod test {
                 mname,
                 rname,
                 Serial(2020081701),
-                Duration::from_secs(1800),
-                Duration::from_secs(900),
-                Duration::from_secs(604800),
-                Duration::from_secs(86400),
+                Ttl::from_secs(1800),
+                Ttl::from_secs(900),
+                Ttl::from_secs(604800),
+                Ttl::from_secs(86400),
             ),
         ))
         .unwrap();

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -744,14 +744,13 @@ impl<Target: Composer> AnswerBuilder<Target> {
     ///
     #[cfg_attr(feature = "std", doc = "```")]
     #[cfg_attr(not(feature = "std"), doc = "```ignore")]
-    /// use core::time::Duration;
-    /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
+    /// use domain::base::{Dname, MessageBuilder, Record, Rtype, Ttl};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;
     ///
     /// let mut msg = MessageBuilder::new_vec().answer();
     /// let record = Record::new(
-    ///     Dname::root_ref(), Class::In, Duration::from_secs(86400), A::from_octets(192, 0, 2, 1)
+    ///     Dname::root_ref(), Class::In, Ttl::from_secs(86400), A::from_octets(192, 0, 2, 1)
     /// );
     /// msg.push(&record).unwrap();
     /// msg.push(record).unwrap();
@@ -989,14 +988,13 @@ impl<Target: Composer> AuthorityBuilder<Target> {
     ///
     #[cfg_attr(feature = "std", doc = "```")]
     #[cfg_attr(not(feature = "std"), doc = "```ignore")]
-    /// use core::time::Duration;
-    /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
+    /// use domain::base::{Dname, MessageBuilder, Record, Rtype, Ttl};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;
     ///
     /// let mut msg = MessageBuilder::new_vec().authority();
     /// let record = Record::new(
-    ///     Dname::root_ref(), Class::In, Duration::from_secs(86400), A::from_octets(192, 0, 2, 1)
+    ///     Dname::root_ref(), Class::In, Ttl::from_secs(86400), A::from_octets(192, 0, 2, 1)
     /// );
     /// msg.push(&record).unwrap();
     /// msg.push(record).unwrap();
@@ -1241,14 +1239,13 @@ impl<Target: Composer> AdditionalBuilder<Target> {
     ///
     #[cfg_attr(feature = "std", doc = "```")]
     #[cfg_attr(not(feature = "std"), doc = "```ignore")]
-    /// use core::time::Duration;
-    /// use domain::base::{Dname, MessageBuilder, Record, Rtype};
+    /// use domain::base::{Dname, MessageBuilder, Record, Rtype, Ttl};
     /// use domain::base::iana::Class;
     /// use domain::rdata::A;
     ///
     /// let mut msg = MessageBuilder::new_vec().additional();
     /// let record = Record::new(
-    ///     Dname::root_ref(), Class::In, Duration::from_secs(86400), A::from_octets(192, 0, 2, 1)
+    ///     Dname::root_ref(), Class::In, Ttl::from_secs(86400), A::from_octets(192, 0, 2, 1)
     /// );
     /// msg.push(&record).unwrap();
     /// msg.push(record).unwrap();
@@ -2228,8 +2225,8 @@ impl std::error::Error for PushError {}
 #[cfg(feature = "std")]
 mod test {
     use super::*;
-    use crate::base::Ttl;
     use crate::base::Serial;
+    use crate::base::Ttl;
     use crate::base::{iana::Rtype, opt, Dname};
     use crate::rdata::{Ns, Soa, A};
     use core::str::FromStr;

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -108,9 +108,7 @@ pub use self::name::{
 };
 pub use self::question::Question;
 pub use self::rdata::{ParseRecordData, RecordData, UnknownRecordData};
-pub use self::record::{
-    Ttl, ParsedRecord, Record, RecordHeader,
-};
+pub use self::record::{ParsedRecord, Record, RecordHeader, Ttl};
 pub use self::serial::Serial;
 
 //--- Modules

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -108,7 +108,9 @@ pub use self::name::{
 };
 pub use self::question::Question;
 pub use self::rdata::{ParseRecordData, RecordData, UnknownRecordData};
-pub use self::record::{ParsedRecord, Record, RecordHeader};
+pub use self::record::{
+    Ttl, ParsedRecord, Record, RecordHeader,
+};
 pub use self::serial::Serial;
 
 //--- Modules

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -422,9 +422,9 @@ impl<Octs> OptRecord<Octs> {
     pub fn from_record<N: ToDname>(record: Record<N, Opt<Octs>>) -> Self {
         OptRecord {
             udp_payload_size: record.class().to_int(),
-            ext_rcode: (record.ttl() >> 24) as u8,
-            version: (record.ttl() >> 16) as u8,
-            flags: record.ttl() as u16,
+            ext_rcode: (record.ttl().as_secs() >> 24) as u8,
+            version: (record.ttl().as_secs() >> 16) as u8,
+            flags: record.ttl().as_secs() as u16,
             data: record.into_data(),
         }
     }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -997,6 +997,8 @@ const SECS_PER_DAY: u32 = 86400;
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default,
 )]
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ttl(u32);
 
 impl Ttl {

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -996,6 +996,8 @@ impl Ttl {
 
     pub const MAX: Ttl = Ttl::from_secs(u32::MAX);
 
+    pub const COMPOSE_LEN: u16 = 4;
+
     #[must_use]
     #[inline]
     pub const fn as_secs(&self) -> u32 {
@@ -1112,6 +1114,18 @@ impl Ttl {
         } else {
             None
         }
+    }
+    pub fn compose<Target: OctetsBuilder + ?Sized>(
+        &self,
+        target: &mut Target,
+    ) -> Result<(), Target::AppendError> {
+        target.append_slice(&(self.as_secs()).to_be_bytes())
+    }
+
+    pub fn parse<'a, Octs: AsRef<[u8]> + ?Sized>(
+        parser: &mut Parser<'a, Octs>,
+    ) -> Result<Self, ParseError> {
+        parser.parse_u32().map(Ttl::from_secs).map_err(Into::into)
     }
 }
 

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -153,7 +153,7 @@ impl<Name, Data> Record<Name, Data> {
     }
 
     /// Returns the record’s time-to-live.
-    pub fn ttl(&self) -> &Ttl {
+    pub fn ttl(&self) -> Ttl {
         &self.ttl
     }
 
@@ -567,7 +567,7 @@ impl<Name> RecordHeader<Name> {
     }
 
     /// Returns the TTL of the record.
-    pub fn ttl(&self) -> &Ttl {
+    pub fn ttl(&self) -> Ttl {
         &self.ttl
     }
 
@@ -842,7 +842,7 @@ impl<'a, Octs: Octets + ?Sized> ParsedRecord<'a, Octs> {
     }
 
     /// Returns the TTL of the record.
-    pub fn ttl(&self) -> &Ttl {
+    pub fn ttl(&self) -> Ttl {
         self.header.ttl()
     }
 

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -1191,7 +1191,7 @@ impl Ttl {
     ///
     /// assert!(Ttl::ZERO.is_zero());
     /// assert!(Ttl::from_secs(0).is_zero());
-    /// assert!(Ttl::from_minutes(0).is_zero());
+    /// assert!(Ttl::from_mins(0).is_zero());
     /// assert!(Ttl::from_hours(0).is_zero());
     /// assert!(Ttl::from_days(0).is_zero());
     /// ```
@@ -1210,7 +1210,7 @@ impl Ttl {
     /// use domain::base::Ttl;
     ///
     /// assert_eq!(Ttl::from_secs(0).checked_add(Ttl::from_secs(1)), Some(Ttl::from_secs(1)));
-    /// assert_eq!(Ttl::from_secs(1).checked_add(Ttl::MAX, None);
+    /// assert_eq!(Ttl::from_secs(1).checked_add(Ttl::MAX), None);
     /// ```
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
@@ -1232,7 +1232,7 @@ impl Ttl {
     /// use domain::base::Ttl;
     ///
     /// assert_eq!(Ttl::from_secs(0).saturating_add(Ttl::from_secs(1)), Ttl::from_secs(1));
-    /// assert_eq!(Ttl::from_secs(1).saturating_add(Ttl::MAX), Duration::MAX);
+    /// assert_eq!(Ttl::from_secs(1).saturating_add(Ttl::MAX), Ttl::MAX);
     /// ```
     #[must_use = "this returns the result of the operation, \
     without modifying the original"]
@@ -1274,7 +1274,7 @@ impl Ttl {
     /// ```
     /// use domain::base::Ttl;
     ///
-    /// assert_eq!(Ttl::from_secs(1).saturating_sub(Ttl::from_secs(0)), Some(Ttl::from_secs(1)));
+    /// assert_eq!(Ttl::from_secs(1).saturating_sub(Ttl::from_secs(0)), Ttl::from_secs(1));
     /// assert_eq!(Ttl::from_secs(0).saturating_sub(Ttl::from_secs(1)), Ttl::ZERO);
     /// ```
     #[must_use = "this returns the result of the operation, \
@@ -1317,7 +1317,7 @@ impl Ttl {
     /// ```
     /// use domain::base::Ttl;
     ///
-    /// assert_eq!(Ttl::from_secs(5).saturating_mul(2), Some(Ttl::from_secs(10)));
+    /// assert_eq!(Ttl::from_secs(5).saturating_mul(2), Ttl::from_secs(10));
     /// assert_eq!(Ttl::from_secs(u32::MAX - 1).saturating_mul(2), Ttl::MAX);
     /// ```
     #[must_use = "this returns the result of the operation, \
@@ -1360,7 +1360,7 @@ impl Ttl {
     /// ```
     /// use domain::base::Ttl;
     ///
-    /// assert_eq!(Ttl::from_minutes(5).cap(), Ttl::from_minutes(5));
+    /// assert_eq!(Ttl::from_mins(5).cap(), Ttl::from_mins(5));
     /// assert_eq!(Ttl::from_days(50).cap(), Ttl::from_days(7));
     /// ```
     #[must_use = "this returns the result of the operation, \
@@ -1381,8 +1381,8 @@ impl Ttl {
         target.append_slice(&(self.as_secs()).to_be_bytes())
     }
 
-    pub fn parse<'a, Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<'a, Octs>,
+    pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         parser.parse_u32().map(Ttl::from_secs).map_err(Into::into)
     }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -154,7 +154,7 @@ impl<Name, Data> Record<Name, Data> {
 
     /// Returns the record’s time-to-live.
     pub fn ttl(&self) -> Ttl {
-        &self.ttl
+        self.ttl
     }
 
     /// Sets the record’s time-to-live.
@@ -568,7 +568,7 @@ impl<Name> RecordHeader<Name> {
 
     /// Returns the TTL of the record.
     pub fn ttl(&self) -> Ttl {
-        &self.ttl
+        self.ttl
     }
 
     /// Returns the data length of the record.

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -986,18 +986,17 @@ const SECS_PER_DAY: u32 = 86400;
 ///
 /// `Ttl` implements many common traits, including [`core::ops::Add`], [`core::ops::Sub`], and other [`core::ops`] traits. It implements Default by returning a zero-length `Ttl`.
 ///
-/// # Why not [`core::time::Duration`]?
+/// # Why not [`std::time::Duration`]?
 ///
-/// Two reasons make [`core::time::Duration`] not suited for representing DNS TTL values:
-/// 1. According to [RFC 2181](https://datatracker.ietf.org/doc/html/rfc2181#section-8) TTL values have second-level precision while [`core::time::Duration`] can represent time down to the nanosecond level.
+/// Two reasons make [`std::time::Duration`] not suited for representing DNS TTL values:
+/// 1. According to [RFC 2181](https://datatracker.ietf.org/doc/html/rfc2181#section-8) TTL values have second-level precision while [`std::time::Duration`] can represent time down to the nanosecond level.
 ///     This amount of precision is simply not needed and might cause confusion when sending `Duration`s over the network.
-/// 2. When working with DNS TTL values it's common to want to know a time to live in minutes or hours. [`core::time::Duration`] does not expose easy to use methods for this purpose, while `Ttl` does.
+/// 2. When working with DNS TTL values it's common to want to know a time to live in minutes or hours. [`std::time::Duration`] does not expose easy to use methods for this purpose, while `Ttl` does.
 ///
 /// `Ttl` provides two methods [`Ttl::from_duration_lossy`] and [`Ttl::into_duration`] to convert between `Duration` and `Ttl`.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default,
 )]
-
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ttl(u32);
 
@@ -1098,13 +1097,13 @@ impl Ttl {
         (self.0 / SECS_PER_DAY) as u16
     }
 
-    /// Converts a `Ttl` into a [`core::time::Duration`].
+    /// Converts a `Ttl` into a [`std::time::Duration`].
     ///
     /// # Examples
     ///
     /// ```
     /// use domain::base::Ttl;
-    /// use core::time::Duration;
+    /// use std::time::Duration;
     ///
     /// let ttl = Ttl::from_mins(2);
     /// let duration = ttl.into_duration();
@@ -1162,7 +1161,7 @@ impl Ttl {
         Self(days as u32 * SECS_PER_DAY)
     }
 
-    /// Creates a new `Ttl` from a [`core::time::Duration`].
+    /// Creates a new `Ttl` from a [`std::time::Duration`].
     ///
     /// This operation is lossy as [`Duration`] stores seconds as `u64`, while `Ttl` stores seconds as `u32` to comply with the DNS specifications.
     /// [`Duration`] also represents time using sub-second precision, which is not kept when converting into a `Ttl`.
@@ -1171,7 +1170,7 @@ impl Ttl {
     ///
     /// ```
     /// use domain::base::Ttl;
-    /// use core::time::Duration;
+    /// use std::time::Duration;
     ///
     /// assert_eq!(Ttl::from_duration_lossy(Duration::new(1, 0)), Ttl::from_secs(1));
     /// assert_eq!(Ttl::from_duration_lossy(Duration::new(1, 6000)), Ttl::from_secs(1));

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -100,12 +100,7 @@ pub struct Record<Name, Data> {
 ///
 impl<Name, Data> Record<Name, Data> {
     /// Creates a new record from its parts.
-    pub fn new(
-        owner: Name,
-        class: Class,
-        ttl: Ttl,
-        data: Data,
-    ) -> Self {
+    pub fn new(owner: Name, class: Class, ttl: Ttl, data: Data) -> Self {
         Record {
             owner,
             class,
@@ -235,21 +230,14 @@ impl<N, D> From<(N, Class, u32, D)> for Record<N, D> {
 }
 
 impl<N, D> From<(N, Class, Ttl, D)> for Record<N, D> {
-    fn from(
-        (owner, class, ttl, data): (N, Class, Ttl, D),
-    ) -> Self {
+    fn from((owner, class, ttl, data): (N, Class, Ttl, D)) -> Self {
         Self::new(owner, class, ttl, data)
     }
 }
 
 impl<N, D> From<(N, u32, D)> for Record<N, D> {
     fn from((owner, ttl, data): (N, u32, D)) -> Self {
-        Self::new(
-            owner,
-            Class::In,
-            Ttl::from_secs(ttl),
-            data,
-        )
+        Self::new(owner, Class::In, Ttl::from_secs(ttl), data)
     }
 }
 
@@ -466,13 +454,8 @@ where
         &self,
         target: &mut Target,
     ) -> Result<(), Target::AppendError> {
-        Record::new(
-            &self.0,
-            self.1,
-            Ttl::from_secs(self.2),
-            &self.3,
-        )
-        .compose(target)
+        Record::new(&self.0, self.1, Ttl::from_secs(self.2), &self.3)
+            .compose(target)
     }
 }
 
@@ -498,13 +481,8 @@ where
         &self,
         target: &mut Target,
     ) -> Result<(), Target::AppendError> {
-        Record::new(
-            &self.0,
-            Class::In,
-            Ttl::from_secs(self.1),
-            &self.2,
-        )
-        .compose(target)
+        Record::new(&self.0, Class::In, Ttl::from_secs(self.1), &self.2)
+            .compose(target)
     }
 }
 
@@ -1008,19 +986,15 @@ const SECS_PER_HOUR: u32 = 3600;
 pub struct Ttl(u32);
 
 impl Ttl {
-    pub const SECOND: Ttl =
-        Ttl::from_secs(1);
+    pub const SECOND: Ttl = Ttl::from_secs(1);
 
-    pub const MINUTE: Ttl =
-        Ttl::from_minutes(1);
+    pub const MINUTE: Ttl = Ttl::from_minutes(1);
 
-    pub const HOUR: Ttl =
-        Ttl::from_hours(1);
+    pub const HOUR: Ttl = Ttl::from_hours(1);
 
     pub const ZERO: Ttl = Ttl::from_secs(0);
 
-    pub const MAX: Ttl =
-        Ttl::from_secs(u32::MAX);
+    pub const MAX: Ttl = Ttl::from_secs(u32::MAX);
 
     #[must_use]
     #[inline]
@@ -1069,10 +1043,7 @@ impl Ttl {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[inline]
-    pub const fn checked_add(
-        self,
-        rhs: Ttl,
-    ) -> Option<Ttl> {
+    pub const fn checked_add(self, rhs: Ttl) -> Option<Ttl> {
         if let Some(secs) = self.0.checked_add(rhs.0) {
             Some(Ttl(secs))
         } else {
@@ -1083,10 +1054,7 @@ impl Ttl {
     #[must_use = "this returns the result of the operation, \
     without modifying the original"]
     #[inline]
-    pub const fn saturating_add(
-        self,
-        rhs: Ttl,
-    ) -> Ttl {
+    pub const fn saturating_add(self, rhs: Ttl) -> Ttl {
         match self.0.checked_add(rhs.0) {
             Some(secs) => Ttl(secs),
             None => Ttl::MAX,
@@ -1096,10 +1064,7 @@ impl Ttl {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[inline]
-    pub const fn checked_sub(
-        self,
-        rhs: Ttl,
-    ) -> Option<Ttl> {
+    pub const fn checked_sub(self, rhs: Ttl) -> Option<Ttl> {
         if let Some(secs) = self.0.checked_sub(rhs.0) {
             Some(Ttl(secs))
         } else {
@@ -1110,10 +1075,7 @@ impl Ttl {
     #[must_use = "this returns the result of the operation, \
     without modifying the original"]
     #[inline]
-    pub const fn saturating_sub(
-        self,
-        rhs: Ttl,
-    ) -> Ttl {
+    pub const fn saturating_sub(self, rhs: Ttl) -> Ttl {
         match self.0.checked_sub(rhs.0) {
             Some(secs) => Ttl(secs),
             None => Ttl::ZERO,
@@ -1228,17 +1190,13 @@ macro_rules! sum_durations {
 }
 
 impl std::iter::Sum for Ttl {
-    fn sum<I: Iterator<Item = Ttl>>(
-        iter: I,
-    ) -> Ttl {
+    fn sum<I: Iterator<Item = Ttl>>(iter: I) -> Ttl {
         sum_durations!(iter)
     }
 }
 
 impl<'a> std::iter::Sum<&'a Ttl> for Ttl {
-    fn sum<I: Iterator<Item = &'a Ttl>>(
-        iter: I,
-    ) -> Ttl {
+    fn sum<I: Iterator<Item = &'a Ttl>>(iter: I) -> Ttl {
         sum_durations!(iter)
     }
 }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -1115,7 +1115,7 @@ impl Ttl {
     }
 }
 
-impl std::ops::Add for Ttl {
+impl core::ops::Add for Ttl {
     type Output = Ttl;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -1124,13 +1124,13 @@ impl std::ops::Add for Ttl {
     }
 }
 
-impl std::ops::AddAssign for Ttl {
+impl core::ops::AddAssign for Ttl {
     fn add_assign(&mut self, rhs: Ttl) {
         *self = *self + rhs;
     }
 }
 
-impl std::ops::Sub for Ttl {
+impl core::ops::Sub for Ttl {
     type Output = Ttl;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -1139,13 +1139,13 @@ impl std::ops::Sub for Ttl {
     }
 }
 
-impl std::ops::SubAssign for Ttl {
+impl core::ops::SubAssign for Ttl {
     fn sub_assign(&mut self, rhs: Ttl) {
         *self = *self - rhs;
     }
 }
 
-impl std::ops::Mul<u32> for Ttl {
+impl core::ops::Mul<u32> for Ttl {
     type Output = Ttl;
 
     fn mul(self, rhs: u32) -> Self::Output {
@@ -1154,13 +1154,13 @@ impl std::ops::Mul<u32> for Ttl {
     }
 }
 
-impl std::ops::MulAssign<u32> for Ttl {
+impl core::ops::MulAssign<u32> for Ttl {
     fn mul_assign(&mut self, rhs: u32) {
         *self = *self * rhs;
     }
 }
 
-impl std::ops::Div<u32> for Ttl {
+impl core::ops::Div<u32> for Ttl {
     type Output = Ttl;
 
     fn div(self, rhs: u32) -> Ttl {
@@ -1169,7 +1169,7 @@ impl std::ops::Div<u32> for Ttl {
     }
 }
 
-impl std::ops::DivAssign<u32> for Ttl {
+impl core::ops::DivAssign<u32> for Ttl {
     fn div_assign(&mut self, rhs: u32) {
         *self = *self / rhs;
     }
@@ -1189,13 +1189,13 @@ macro_rules! sum_durations {
     }};
 }
 
-impl std::iter::Sum for Ttl {
+impl core::iter::Sum for Ttl {
     fn sum<I: Iterator<Item = Ttl>>(iter: I) -> Ttl {
         sum_durations!(iter)
     }
 }
 
-impl<'a> std::iter::Sum<&'a Ttl> for Ttl {
+impl<'a> core::iter::Sum<&'a Ttl> for Ttl {
     fn sum<I: Iterator<Item = &'a Ttl>>(iter: I) -> Ttl {
         sum_durations!(iter)
     }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -1474,6 +1474,14 @@ impl<'a> core::iter::Sum<&'a Ttl> for Ttl {
     }
 }
 
+// No From impl because conversion is lossy
+#[allow(clippy::from_over_into)]
+impl Into<Duration> for Ttl {
+    fn into(self) -> Duration {
+        Duration::from_secs(u64::from(self.0))
+    }
+}
+
 //============ Testing ======================================================
 
 #[cfg(test)]

--- a/src/base/scan.rs
+++ b/src/base/scan.rs
@@ -97,12 +97,12 @@ impl<S: Scanner> Scan<S> for Ttl {
     fn scan(scanner: &mut S) -> Result<Self, <S as Scanner>::Error> {
         let mut res: u32 = 0;
         scanner.scan_symbols(|ch| {
-            res = res.checked_mul(10).ok_or_else(|| {
-                S::Error::custom("decimal number overflow")
-            })?;
-            res += ch.into_digit(10).map_err(|_| {
-                S::Error::custom("expected decimal number")
-            })?;
+            res = res
+                .checked_mul(10)
+                .ok_or_else(|| S::Error::custom("decimal number overflow"))?;
+            res += ch
+                .into_digit(10)
+                .map_err(|_| S::Error::custom("expected decimal number"))?;
             Ok(())
         })?;
         Ok(Ttl::from_secs(res))

--- a/src/base/wire.rs
+++ b/src/base/wire.rs
@@ -2,7 +2,6 @@
 
 use super::name::ToDname;
 use super::net::{Ipv4Addr, Ipv6Addr};
-use super::Ttl;
 use core::fmt;
 use octseq::builder::{OctetsBuilder, Truncate};
 use octseq::parse::{Parser, ShortInput};

--- a/src/base/wire.rs
+++ b/src/base/wire.rs
@@ -246,14 +246,9 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for Ipv6Addr {
     }
 }
 
-impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs>
-    for Ttl
-{
+impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for Ttl {
     fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
-        parser
-            .parse_u32()
-            .map(Ttl::from_secs)
-            .map_err(Into::into)
+        parser.parse_u32().map(Ttl::from_secs).map_err(Into::into)
     }
 }
 

--- a/src/base/wire.rs
+++ b/src/base/wire.rs
@@ -149,17 +149,6 @@ impl Compose for Ipv6Addr {
     }
 }
 
-impl Compose for Ttl {
-    const COMPOSE_LEN: u16 = 4;
-
-    fn compose<Target: OctetsBuilder + ?Sized>(
-        &self,
-        target: &mut Target,
-    ) -> Result<(), Target::AppendError> {
-        target.append_slice(&(self.as_secs()).to_be_bytes())
-    }
-}
-
 // No impl for [u8; const N: usize] because we can’t guarantee a correct
 // COMPOSE_LEN -- it may be longer than a u16 can hold.
 
@@ -243,12 +232,6 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for Ipv6Addr {
         let mut buf = [0u8; 16];
         parser.parse_buf(&mut buf)?;
         Ok(buf.into())
-    }
-}
-
-impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for Ttl {
-    fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
-        parser.parse_u32().map(Ttl::from_secs).map_err(Into::into)
     }
 }
 

--- a/src/base/wire.rs
+++ b/src/base/wire.rs
@@ -2,8 +2,8 @@
 
 use super::name::ToDname;
 use super::net::{Ipv4Addr, Ipv6Addr};
+use super::Ttl;
 use core::fmt;
-use core::time::Duration;
 use octseq::builder::{OctetsBuilder, Truncate};
 use octseq::parse::{Parser, ShortInput};
 
@@ -149,14 +149,14 @@ impl Compose for Ipv6Addr {
     }
 }
 
-impl Compose for Duration {
+impl Compose for Ttl {
     const COMPOSE_LEN: u16 = 4;
 
     fn compose<Target: OctetsBuilder + ?Sized>(
         &self,
         target: &mut Target,
     ) -> Result<(), Target::AppendError> {
-        target.append_slice(&(self.as_secs() as u32).to_be_bytes())
+        target.append_slice(&(self.as_secs()).to_be_bytes())
     }
 }
 
@@ -246,11 +246,13 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for Ipv6Addr {
     }
 }
 
-impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for Duration {
+impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs>
+    for Ttl
+{
     fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
         parser
             .parse_u32()
-            .map(|v| Duration::from_secs(v as u64))
+            .map(Ttl::from_secs)
             .map_err(Into::into)
     }
 }

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -2451,7 +2451,7 @@ mod test {
             Rtype::A,
             SecAlg::RsaSha1,
             3,
-            12,
+            Ttl::from_secs(12),
             Serial::from(13),
             Serial::from(14),
             15,

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -723,7 +723,7 @@ impl<Octs, Name> Rrsig<Octs, Name> {
         self.labels
     }
 
-    pub fn original_ttl(&self) -> &Ttl {
+    pub fn original_ttl(&self) -> Ttl {
         &self.original_ttl
     }
 

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -724,7 +724,7 @@ impl<Octs, Name> Rrsig<Octs, Name> {
     }
 
     pub fn original_ttl(&self) -> Ttl {
-        &self.original_ttl
+        self.original_ttl
     }
 
     pub fn expiration(&self) -> Serial {

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -10,13 +10,13 @@ use crate::base::name::{Dname, ParsedDname, PushError, ToDname};
 use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData,
 };
+use crate::base::Ttl;
 use crate::base::scan::{Scan, Scanner, ScannerError};
 use crate::base::serial::Serial;
 use crate::base::wire::{Compose, Composer, FormError, Parse, ParseError};
 use crate::utils::{base16, base64};
 use core::cmp::Ordering;
 use core::convert::TryInto;
-use core::time::Duration;
 use core::{fmt, hash, ptr};
 use octseq::builder::{
     EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder, Truncate,
@@ -447,7 +447,7 @@ pub struct ProtoRrsig<Name> {
     type_covered: Rtype,
     algorithm: SecAlg,
     labels: u8,
-    original_ttl: Duration,
+    original_ttl: Ttl,
     expiration: Serial,
     inception: Serial,
     key_tag: u16,
@@ -460,7 +460,7 @@ impl<Name> ProtoRrsig<Name> {
         type_covered: Rtype,
         algorithm: SecAlg,
         labels: u8,
-        original_ttl: Duration,
+        original_ttl: Ttl,
         expiration: Serial,
         inception: Serial,
         key_tag: u16,
@@ -622,7 +622,7 @@ pub struct Rrsig<Octs, Name> {
     type_covered: Rtype,
     algorithm: SecAlg,
     labels: u8,
-    original_ttl: Duration,
+    original_ttl: Ttl,
     expiration: Serial,
     inception: Serial,
     key_tag: u16,
@@ -640,7 +640,7 @@ impl<Octs, Name> Rrsig<Octs, Name> {
         type_covered: Rtype,
         algorithm: SecAlg,
         labels: u8,
-        original_ttl: Duration,
+        original_ttl: Ttl,
         expiration: Serial,
         inception: Serial,
         key_tag: u16,
@@ -691,7 +691,7 @@ impl<Octs, Name> Rrsig<Octs, Name> {
         type_covered: Rtype,
         algorithm: SecAlg,
         labels: u8,
-        original_ttl: Duration,
+        original_ttl: Ttl,
         expiration: Serial,
         inception: Serial,
         key_tag: u16,
@@ -723,7 +723,7 @@ impl<Octs, Name> Rrsig<Octs, Name> {
         self.labels
     }
 
-    pub fn original_ttl(&self) -> &Duration {
+    pub fn original_ttl(&self) -> &Ttl {
         &self.original_ttl
     }
 
@@ -784,7 +784,7 @@ impl<Octs, Name> Rrsig<Octs, Name> {
             Rtype::scan(scanner)?,
             SecAlg::scan(scanner)?,
             u8::scan(scanner)?,
-            Duration::from_secs(u32::scan(scanner)? as u64),
+            Ttl::scan(scanner)?,
             Serial::scan_rrsig(scanner)?,
             Serial::scan_rrsig(scanner)?,
             u16::scan(scanner)?,
@@ -841,7 +841,7 @@ impl<Octs> Rrsig<Octs, ParsedDname<Octs>> {
         let type_covered = Rtype::parse(parser)?;
         let algorithm = SecAlg::parse(parser)?;
         let labels = u8::parse(parser)?;
-        let original_ttl = Duration::parse(parser)?;
+        let original_ttl = Ttl::parse(parser)?;
         let expiration = Serial::parse(parser)?;
         let inception = Serial::parse(parser)?;
         let key_tag = u16::parse(parser)?;

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -1259,22 +1259,22 @@ impl<N> Soa<N> {
     }
 
     /// The time interval before the zone should be refreshed.
-    pub fn refresh(&self) -> &Ttl {
+    pub fn refresh(&self) -> Ttl {
         &self.refresh
     }
 
     /// The time before a failed refresh is retried.
-    pub fn retry(&self) -> &Ttl {
+    pub fn retry(&self) -> Ttl {
         &self.retry
     }
 
     /// The upper limit of time the zone is authoritative.
-    pub fn expire(&self) -> &Ttl {
+    pub fn expire(&self) -> Ttl {
         &self.expire
     }
 
     /// The minimum TTL to be exported with any RR from this zone.
-    pub fn minimum(&self) -> &Ttl {
+    pub fn minimum(&self) -> Ttl {
         &self.minimum
     }
 

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -1260,22 +1260,22 @@ impl<N> Soa<N> {
 
     /// The time interval before the zone should be refreshed.
     pub fn refresh(&self) -> Ttl {
-        &self.refresh
+        self.refresh
     }
 
     /// The time before a failed refresh is retried.
     pub fn retry(&self) -> Ttl {
-        &self.retry
+        self.retry
     }
 
     /// The upper limit of time the zone is authoritative.
     pub fn expire(&self) -> Ttl {
-        &self.expire
+        self.expire
     }
 
     /// The minimum TTL to be exported with any RR from this zone.
     pub fn minimum(&self) -> Ttl {
-        &self.minimum
+        self.minimum
     }
 
     pub(super) fn convert_octets<Target: OctetsFrom<N>>(

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -12,6 +12,7 @@ use crate::base::net::Ipv4Addr;
 use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData
 };
+use crate::base::Ttl;
 use crate::base::scan::{Scan, Scanner, ScannerError, Symbol};
 use crate::base::serial::Serial;
 use crate::base::wire::{Compose, Composer, FormError, Parse, ParseError};
@@ -20,7 +21,6 @@ use bytes::BytesMut;
 use core::cmp::Ordering;
 use core::convert::{Infallible, TryFrom};
 use core::str::FromStr;
-use core::time::Duration;
 use core::{fmt, hash, ops, str};
 use octseq::builder::{
     infallible, EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder,
@@ -1215,10 +1215,10 @@ pub struct Soa<N> {
     mname: N,
     rname: N,
     serial: Serial,
-    refresh: Duration,
-    retry: Duration,
-    expire: Duration,
-    minimum: Duration,
+    refresh: Ttl,
+    retry: Ttl,
+    expire: Ttl,
+    minimum: Ttl,
 }
 
 impl<N> Soa<N> {
@@ -1227,10 +1227,10 @@ impl<N> Soa<N> {
         mname: N,
         rname: N,
         serial: Serial,
-        refresh: Duration,
-        retry: Duration,
-        expire: Duration,
-        minimum: Duration,
+        refresh: Ttl,
+        retry: Ttl,
+        expire: Ttl,
+        minimum: Ttl,
     ) -> Self {
         Soa {
             mname,
@@ -1259,22 +1259,22 @@ impl<N> Soa<N> {
     }
 
     /// The time interval before the zone should be refreshed.
-    pub fn refresh(&self) -> &Duration {
+    pub fn refresh(&self) -> &Ttl {
         &self.refresh
     }
 
     /// The time before a failed refresh is retried.
-    pub fn retry(&self) -> &Duration {
+    pub fn retry(&self) -> &Ttl {
         &self.retry
     }
 
     /// The upper limit of time the zone is authoritative.
-    pub fn expire(&self) -> &Duration {
+    pub fn expire(&self) -> &Ttl {
         &self.expire
     }
 
     /// The minimum TTL to be exported with any RR from this zone.
-    pub fn minimum(&self) -> &Duration {
+    pub fn minimum(&self) -> &Ttl {
         &self.minimum
     }
 
@@ -1299,10 +1299,10 @@ impl<N> Soa<N> {
             scanner.scan_dname()?,
             scanner.scan_dname()?,
             Serial::scan(scanner)?,
-            Duration::from_secs(u32::scan(scanner)? as u64),
-            Duration::from_secs(u32::scan(scanner)? as u64),
-            Duration::from_secs(u32::scan(scanner)? as u64),
-            Duration::from_secs(u32::scan(scanner)? as u64),
+            Ttl::scan(scanner)?,
+            Ttl::scan(scanner)?,
+            Ttl::scan(scanner)?,
+            Ttl::scan(scanner)?,
         ))
     }
 }
@@ -1344,10 +1344,10 @@ impl<Octs> Soa<ParsedDname<Octs>> {
             ParsedDname::parse(parser)?,
             ParsedDname::parse(parser)?,
             Serial::parse(parser)?,
-            Duration::parse(parser)?,
-            Duration::parse(parser)?,
-            Duration::parse(parser)?,
-            Duration::parse(parser)?,
+            Ttl::parse(parser)?,
+            Ttl::parse(parser)?,
+            Ttl::parse(parser)?,
+            Ttl::parse(parser)?,
         ))
     }
 }

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -1299,10 +1299,10 @@ impl<N> Soa<N> {
             scanner.scan_dname()?,
             scanner.scan_dname()?,
             Serial::scan(scanner)?,
-            u32::scan(scanner)?,
-            u32::scan(scanner)?,
-            u32::scan(scanner)?,
-            u32::scan(scanner)?,
+            Duration::from_secs(u32::scan(scanner)? as u64),
+            Duration::from_secs(u32::scan(scanner)? as u64),
+            Duration::from_secs(u32::scan(scanner)? as u64),
+            Duration::from_secs(u32::scan(scanner)? as u64),
         ))
     }
 }
@@ -1344,10 +1344,10 @@ impl<Octs> Soa<ParsedDname<Octs>> {
             ParsedDname::parse(parser)?,
             ParsedDname::parse(parser)?,
             Serial::parse(parser)?,
-            u32::parse(parser)?,
-            u32::parse(parser)?,
-            u32::parse(parser)?,
-            u32::parse(parser)?,
+            Duration::parse(parser)?,
+            Duration::parse(parser)?,
+            Duration::parse(parser)?,
+            Duration::parse(parser)?,
         ))
     }
 }
@@ -1573,10 +1573,10 @@ impl<N: fmt::Display> fmt::Display for Soa<N> {
             self.mname,
             self.rname,
             self.serial,
-            self.refresh,
-            self.retry,
-            self.expire,
-            self.minimum
+            self.refresh.as_secs(),
+            self.retry.as_secs(),
+            self.expire.as_secs(),
+            self.minimum.as_secs()
         )
     }
 }

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -20,6 +20,7 @@ use bytes::BytesMut;
 use core::cmp::Ordering;
 use core::convert::{Infallible, TryFrom};
 use core::str::FromStr;
+use core::time::Duration;
 use core::{fmt, hash, ops, str};
 use octseq::builder::{
     infallible, EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder,
@@ -1214,10 +1215,10 @@ pub struct Soa<N> {
     mname: N,
     rname: N,
     serial: Serial,
-    refresh: u32,
-    retry: u32,
-    expire: u32,
-    minimum: u32,
+    refresh: Duration,
+    retry: Duration,
+    expire: Duration,
+    minimum: Duration,
 }
 
 impl<N> Soa<N> {
@@ -1226,10 +1227,10 @@ impl<N> Soa<N> {
         mname: N,
         rname: N,
         serial: Serial,
-        refresh: u32,
-        retry: u32,
-        expire: u32,
-        minimum: u32,
+        refresh: Duration,
+        retry: Duration,
+        expire: Duration,
+        minimum: Duration,
     ) -> Self {
         Soa {
             mname,
@@ -1257,24 +1258,24 @@ impl<N> Soa<N> {
         self.serial
     }
 
-    /// The time interval in seconds before the zone should be refreshed.
-    pub fn refresh(&self) -> u32 {
-        self.refresh
+    /// The time interval before the zone should be refreshed.
+    pub fn refresh(&self) -> &Duration {
+        &self.refresh
     }
 
-    /// The time in seconds before a failed refresh is retried.
-    pub fn retry(&self) -> u32 {
-        self.retry
+    /// The time before a failed refresh is retried.
+    pub fn retry(&self) -> &Duration {
+        &self.retry
     }
 
-    /// The upper limit of time in seconds the zone is authoritative.
-    pub fn expire(&self) -> u32 {
-        self.expire
+    /// The upper limit of time the zone is authoritative.
+    pub fn expire(&self) -> &Duration {
+        &self.expire
     }
 
     /// The minimum TTL to be exported with any RR from this zone.
-    pub fn minimum(&self) -> u32 {
-        self.minimum
+    pub fn minimum(&self) -> &Duration {
+        &self.minimum
     }
 
     pub(super) fn convert_octets<Target: OctetsFrom<N>>(

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -1,13 +1,13 @@
 //! Actual signing.
 
 use super::key::SigningKey;
-use crate::base::Ttl;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Class, Rtype};
 use crate::base::name::ToDname;
 use crate::base::rdata::{ComposeRecordData, RecordData};
 use crate::base::record::Record;
 use crate::base::serial::Serial;
+use crate::base::Ttl;
 use crate::rdata::dnssec::{ProtoRrsig, RtypeBitmap};
 use crate::rdata::{Dnskey, Ds, Nsec, Rrsig};
 use octseq::builder::{EmptyBuilder, FromBuilder, OctetsBuilder, Truncate};
@@ -373,11 +373,7 @@ impl<N> FamilyName<N> {
         self.class
     }
 
-    pub fn into_record<D>(
-        self,
-        ttl: Ttl,
-        data: D,
-    ) -> Record<N, D>
+    pub fn into_record<D>(self, ttl: Ttl, data: D) -> Record<N, D>
     where
         N: Clone,
     {

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -166,7 +166,7 @@ impl<N, D> SortedRecords<N, D> {
     pub fn nsecs<Octets, ApexName>(
         &self,
         apex: &FamilyName<ApexName>,
-        ttl: u32,
+        ttl: Duration,
     ) -> Vec<Record<N, Nsec<Octets, N>>>
     where
         N: ToDname + Clone,
@@ -372,7 +372,7 @@ impl<N> FamilyName<N> {
         self.class
     }
 
-    pub fn into_record<D>(self, ttl: u32, data: D) -> Record<N, D>
+    pub fn into_record<D>(self, ttl: Duration, data: D) -> Record<N, D>
     where
         N: Clone,
     {
@@ -381,7 +381,7 @@ impl<N> FamilyName<N> {
 
     pub fn dnskey<K: SigningKey, Octets: From<K::Octets>>(
         &self,
-        ttl: u32,
+        ttl: Duration,
         key: K,
     ) -> Result<Record<N, Dnskey<Octets>>, K::Error>
     where
@@ -393,7 +393,7 @@ impl<N> FamilyName<N> {
 
     pub fn ds<K: SigningKey>(
         &self,
-        ttl: u32,
+        ttl: Duration,
         key: K,
     ) -> Result<Record<N, Ds<K::Octets>>, K::Error>
     where

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -1,6 +1,7 @@
 //! Actual signing.
 
 use super::key::SigningKey;
+use crate::base::Ttl;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Class, Rtype};
 use crate::base::name::ToDname;
@@ -166,7 +167,7 @@ impl<N, D> SortedRecords<N, D> {
     pub fn nsecs<Octets, ApexName>(
         &self,
         apex: &FamilyName<ApexName>,
-        ttl: LowPrecisionDuration,
+        ttl: Ttl,
     ) -> Vec<Record<N, Nsec<Octets, N>>>
     where
         N: ToDname + Clone,
@@ -374,7 +375,7 @@ impl<N> FamilyName<N> {
 
     pub fn into_record<D>(
         self,
-        ttl: LowPrecisionDuration,
+        ttl: Ttl,
         data: D,
     ) -> Record<N, D>
     where
@@ -385,7 +386,7 @@ impl<N> FamilyName<N> {
 
     pub fn dnskey<K: SigningKey, Octets: From<K::Octets>>(
         &self,
-        ttl: LowPrecisionDuration,
+        ttl: Ttl,
         key: K,
     ) -> Result<Record<N, Dnskey<Octets>>, K::Error>
     where
@@ -397,7 +398,7 @@ impl<N> FamilyName<N> {
 
     pub fn ds<K: SigningKey>(
         &self,
-        ttl: LowPrecisionDuration,
+        ttl: Ttl,
         key: K,
     ) -> Result<Record<N, Ds<K::Octets>>, K::Error>
     where
@@ -460,7 +461,7 @@ impl<'a, N, D> Rrset<'a, N, D> {
         self.slice[0].rtype()
     }
 
-    pub fn ttl(&self) -> u32 {
+    pub fn ttl(&self) -> Ttl {
         self.slice[0].ttl()
     }
 

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -166,7 +166,7 @@ impl<N, D> SortedRecords<N, D> {
     pub fn nsecs<Octets, ApexName>(
         &self,
         apex: &FamilyName<ApexName>,
-        ttl: Duration,
+        ttl: LowPrecisionDuration,
     ) -> Vec<Record<N, Nsec<Octets, N>>>
     where
         N: ToDname + Clone,
@@ -372,7 +372,11 @@ impl<N> FamilyName<N> {
         self.class
     }
 
-    pub fn into_record<D>(self, ttl: Duration, data: D) -> Record<N, D>
+    pub fn into_record<D>(
+        self,
+        ttl: LowPrecisionDuration,
+        data: D,
+    ) -> Record<N, D>
     where
         N: Clone,
     {
@@ -381,7 +385,7 @@ impl<N> FamilyName<N> {
 
     pub fn dnskey<K: SigningKey, Octets: From<K::Octets>>(
         &self,
-        ttl: Duration,
+        ttl: LowPrecisionDuration,
         key: K,
     ) -> Result<Record<N, Dnskey<Octets>>, K::Error>
     where
@@ -393,7 +397,7 @@ impl<N> FamilyName<N> {
 
     pub fn ds<K: SigningKey>(
         &self,
-        ttl: Duration,
+        ttl: LowPrecisionDuration,
         key: K,
     ) -> Result<Record<N, Ds<K::Octets>>, K::Error>
     where

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -346,9 +346,9 @@ impl error::Error for AlgorithmError {}
 #[cfg(feature = "std")]
 mod test {
     use super::*;
-    use crate::base::Ttl;
     use crate::base::iana::{Class, Rtype, SecAlg};
     use crate::base::serial::Serial;
+    use crate::base::Ttl;
     use crate::rdata::{Mx, ZoneRecordData};
     use crate::utils::base64;
     use bytes::Bytes;

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -346,6 +346,7 @@ impl error::Error for AlgorithmError {}
 #[cfg(feature = "std")]
 mod test {
     use super::*;
+    use crate::base::Ttl;
     use crate::base::iana::{Class, Rtype, SecAlg};
     use crate::base::serial::Serial;
     use crate::rdata::{Mx, ZoneRecordData};
@@ -438,7 +439,7 @@ mod test {
                 Record::new(
                     rrsig.signer_name().clone(),
                     Class::In,
-                    0,
+                    Ttl::from_secs(0),
                     x.clone(),
                 )
             })
@@ -466,7 +467,7 @@ mod test {
             Rtype::Dnskey,
             SecAlg::RsaSha256,
             0,
-            172800,
+            Ttl::from_secs(172800),
             1560211200.into(),
             1558396800.into(),
             20326,
@@ -484,7 +485,7 @@ mod test {
             Rtype::Dnskey,
             SecAlg::RsaSha256,
             1,
-            86400,
+            Ttl::from_secs(86400),
             Serial::rrsig_from_str("20210921162830").unwrap(),
             Serial::rrsig_from_str("20210906162330").unwrap(),
             35886,
@@ -541,7 +542,7 @@ mod test {
             Rtype::Dnskey,
             SecAlg::EcdsaP256Sha256,
             2,
-            3600,
+            Ttl::from_secs(3600),
             1560314494.into(),
             1555130494.into(),
             2371,
@@ -588,7 +589,7 @@ mod test {
             Rtype::Dnskey,
             SecAlg::Ed25519,
             2,
-            3600,
+            Ttl::from_secs(3600),
             1559174400.into(),
             1557360000.into(),
             45515,
@@ -610,7 +611,7 @@ mod test {
             Rtype::Dnskey,
             SecAlg::RsaSha256,
             0,
-            172800,
+            Ttl::from_secs(172800),
             1560211200.into(),
             1558396800.into(),
             20326,
@@ -636,7 +637,7 @@ mod test {
                     Record::new(
                         rrsig.signer_name().clone(),
                         Class::In,
-                        0,
+                        Ttl::from_secs(0),
                         data,
                     )
                 })
@@ -670,7 +671,7 @@ mod test {
             Rtype::Mx,
             SecAlg::RsaSha1,
             2,
-            3600,
+            Ttl::from_secs(3600),
             Serial::rrsig_from_str("20040509183619").unwrap(),
             Serial::rrsig_from_str("20040409183619").unwrap(),
             38519,
@@ -687,7 +688,7 @@ mod test {
         let record = Record::new(
             Dname::from_str("a.z.w.example.").unwrap(),
             Class::In,
-            3600,
+            Ttl::from_secs(3600),
             Mx::new(1, Dname::from_str("ai.example.").unwrap()),
         );
         let signed_data = {

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -12,7 +12,6 @@
 #![cfg(feature = "bytes")]
 #![cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 
-use crate::base::Ttl;
 use crate::base::charstr::CharStr;
 use crate::base::iana::{Class, Rtype};
 use crate::base::name::{Chain, Dname, RelativeDname, ToDname};
@@ -21,6 +20,7 @@ use crate::base::scan::{
     BadSymbol, ConvertSymbols, EntrySymbol, Scan, Scanner, ScannerError,
     Symbol, SymbolOctetsError,
 };
+use crate::base::Ttl;
 use crate::rdata::ZoneRecordData;
 use bytes::buf::UninitSlice;
 use bytes::{Buf, BufMut, Bytes, BytesMut};


### PR DESCRIPTION
Use the proper `Duration` instead of `u32` for time values such as ttl.

This leads to less error prone and more readable code since plain `u32` values carry no information about unit. Using `Duration ` ensures time values are always correctly given as seconds.