### PR TITLE
Drop random feature and use rand.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,11 @@ tokio          = { version = "1.0", optional = true, features = ["io-util", "mac
 libc = { version = "0.2.71", default-features = false, optional = true }
 
 [features]
-default     = ["std", "random"]
+default     = ["std", "rand"]
 bytes       = ["dep:bytes", "octseq/bytes"]
 heapless    = ["dep:heapless", "octseq/heapless"]
 interop     = ["bytes", "ring"]
-random      = ["rand"]
-resolv      = ["bytes", "futures", "smallvec", "std", "tokio", "libc", "random"]
+resolv      = ["bytes", "futures", "smallvec", "std", "tokio", "libc", "rand"]
 resolv-sync = ["resolv", "tokio/rt"]
 serde       = ["dep:serde", "octseq/serde"]
 sign        = ["std"]

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -132,7 +132,7 @@ impl Header {
     }
 
     /// Sets the value of the ID field to a randomly chosen number.
-    #[cfg(feature = "random")]
+    #[cfg(feature = "rand")]
     pub fn set_random_id(&mut self) {
         self.set_id(::rand::random())
     }

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -130,7 +130,7 @@
 //! [octets builder]: ../octets/trait.OctetsBuilder.html
 
 use super::header::{CountOverflow, Header, HeaderCounts, HeaderSection};
-#[cfg(feature = "random")]
+#[cfg(feature = "rand")]
 use super::iana::Rtype;
 use super::iana::{OptRcode, OptionCode, Rcode};
 use super::message::Message;
@@ -258,7 +258,7 @@ impl<Target: Composer> MessageBuilder<Target> {
     ///
     /// Sets a random ID, pushes the domain and the AXFR record type into
     /// the question section, and converts the builder into an answer builder.
-    #[cfg(feature = "random")]
+    #[cfg(feature = "rand")]
     pub fn request_axfr<N: ToDname>(
         mut self,
         apex: N,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! * `interop`: Activate interoperability tests that rely on other software
 //!   to be installed in the system (currently NSD and dig) and will fail if
 //!   it isn’t. This feature is not meaningful for users of the crate.
-//! * `random`: Enables a number of methods that rely on a random number
+//! * `rand`: Enables a number of methods that rely on a random number
 //!   generator being available in the system.
 //! * `resolv`: Enables the asynchronous stub resolver via the
 #![cfg_attr(feature = "resolv", doc = "  [resolv]")]


### PR DESCRIPTION
This PR drops the separate `random` feature and uses `rand` instead.

This is a breaking change.

Fixes #194.