### PR TITLE
Remove Deref and DerefMut from types that shouldn’t have them.

### DIFF
--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -231,7 +231,9 @@ impl<Octs: AsRef<[u8]> + ?Sized> CharStr<Octs> {
 
     /// Returns an iterator over the octets of the character string.
     pub fn iter(&self) -> Iter {
-        Iter { octets: self.as_slice() }
+        Iter {
+            octets: self.as_slice(),
+        }
     }
 }
 

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -10,7 +10,7 @@ use super::traits::{ToDname, ToRelativeDname};
 use super::Label;
 #[cfg(feature = "bytes")]
 use bytes::BytesMut;
-use core::{fmt, ops};
+use core::fmt;
 use octseq::builder::{EmptyBuilder, FreezeBuilder, OctetsBuilder, ShortBuf};
 #[cfg(feature = "std")]
 use std::vec::Vec;
@@ -393,15 +393,7 @@ impl<Builder: EmptyBuilder> Default for DnameBuilder<Builder> {
     }
 }
 
-//--- Deref and AsRef
-
-impl<Builder: AsRef<[u8]>> ops::Deref for DnameBuilder<Builder> {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        self.builder.as_ref()
-    }
-}
+//--- AsRef
 
 impl<Builder: AsRef<[u8]>> AsRef<[u8]> for DnameBuilder<Builder> {
     fn as_ref(&self) -> &[u8] {

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -376,7 +376,8 @@ impl PartialOrd for Label {
     ///
     /// [RFC 4034]: https://tools.ietf.org/html/rfc4034
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        self.as_slice().iter()
+        self.as_slice()
+            .iter()
             .map(u8::to_ascii_lowercase)
             .partial_cmp(other.as_slice().iter().map(u8::to_ascii_lowercase))
     }
@@ -384,7 +385,8 @@ impl PartialOrd for Label {
 
 impl Ord for Label {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.as_slice().iter()
+        self.as_slice()
+            .iter()
             .map(u8::to_ascii_lowercase)
             .cmp(other.as_slice().iter().map(u8::to_ascii_lowercase))
     }

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -6,7 +6,7 @@
 use super::super::wire::{FormError, ParseError};
 use super::builder::{parse_escape, LabelFromStrError};
 use core::str::FromStr;
-use core::{borrow, cmp, fmt, hash, ops};
+use core::{borrow, cmp, fmt, hash, iter, ops, slice};
 use octseq::builder::OctetsBuilder;
 
 //------------ Label ---------------------------------------------------------
@@ -28,8 +28,7 @@ use octseq::builder::OctetsBuilder;
 ///
 /// Consequently, `Label` will only ever contain an octets slice of up to 63
 /// octets. It only contains the label’s content, not the length octet it is
-/// preceded by in wire format. The type `Deref`s to `[u8]`, providing access
-/// to all of an octets slice’s methods. As an unsized type, it needs to be
+/// preceded by in wire format. As an unsized type, it needs to be
 /// used behind some kind of pointer, most likely a reference.
 ///
 /// `Label` differs from an octets slice in how it compares: as labels are to
@@ -182,6 +181,11 @@ impl Label {
         ))
     }
 
+    /// Iterator over the octets of the label.
+    pub fn iter(&self) -> iter::Copied<slice::Iter<u8>> {
+        self.as_slice().iter().copied()
+    }
+
     /// Iterates over the labels in some part of an octets slice.
     ///
     /// The first label is assumed to start at index `start`.
@@ -282,7 +286,7 @@ impl Label {
         target: &mut Builder,
     ) -> Result<(), Builder::AppendError> {
         target.append_slice(&[self.len() as u8])?;
-        for &ch in self.into_iter() {
+        for ch in self.into_iter() {
             target.append_slice(&[ch.to_ascii_lowercase()])?;
         }
         Ok(())
@@ -292,6 +296,19 @@ impl Label {
 /// # Properties
 ///
 impl Label {
+    /// Returns the length of the label.
+    ///
+    /// This length is that of the label’s content only. It will _not_ contain
+    /// the initial label length octet present in the wire format.
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    /// Returns whether this is the empty label.
+    pub fn is_empty(&self) -> bool {
+        self.as_slice().is_empty()
+    }
+
     /// Returns whether the label is the root label.
     pub fn is_root(&self) -> bool {
         self.is_empty()
@@ -311,21 +328,7 @@ impl Label {
     }
 }
 
-//--- Deref, DerefMut, AsRef, and AsMut
-
-impl ops::Deref for Label {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        self.as_slice()
-    }
-}
-
-impl ops::DerefMut for Label {
-    fn deref_mut(&mut self) -> &mut [u8] {
-        self.as_slice_mut()
-    }
-}
+//--- AsRef, and AsMut
 
 impl AsRef<[u8]> for Label {
     fn as_ref(&self) -> &[u8] {
@@ -354,7 +357,7 @@ impl std::borrow::ToOwned for Label {
 
 impl<T: AsRef<[u8]> + ?Sized> PartialEq<T> for Label {
     fn eq(&self, other: &T) -> bool {
-        self.eq_ignore_ascii_case(other.as_ref())
+        self.as_slice().eq_ignore_ascii_case(other.as_ref())
     }
 }
 
@@ -373,17 +376,17 @@ impl PartialOrd for Label {
     ///
     /// [RFC 4034]: https://tools.ietf.org/html/rfc4034
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        self.iter()
+        self.as_slice().iter()
             .map(u8::to_ascii_lowercase)
-            .partial_cmp(other.iter().map(u8::to_ascii_lowercase))
+            .partial_cmp(other.as_slice().iter().map(u8::to_ascii_lowercase))
     }
 }
 
 impl Ord for Label {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.iter()
+        self.as_slice().iter()
             .map(u8::to_ascii_lowercase)
-            .cmp(other.iter().map(u8::to_ascii_lowercase))
+            .cmp(other.as_slice().iter().map(u8::to_ascii_lowercase))
     }
 }
 
@@ -403,8 +406,8 @@ impl hash::Hash for Label {
 //--- IntoIterator
 
 impl<'a> IntoIterator for &'a Label {
-    type Item = &'a u8;
-    type IntoIter = core::slice::Iter<'a, u8>;
+    type Item = u8;
+    type IntoIter = iter::Copied<slice::Iter<'a, u8>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -415,7 +418,7 @@ impl<'a> IntoIterator for &'a Label {
 
 impl fmt::Display for Label {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for &ch in self.iter() {
+        for ch in self.iter() {
             if ch == b' ' || ch == b'.' || ch == b'\\' {
                 write!(f, "\\{}", ch as char)?;
             } else if !(0x20..0x7F).contains(&ch) {

--- a/src/rdata/aaaa.rs
+++ b/src/rdata/aaaa.rs
@@ -13,7 +13,7 @@ use crate::base::wire::{Composer, Parse, ParseError};
 use core::cmp::Ordering;
 use core::convert::Infallible;
 use core::str::FromStr;
-use core::{fmt, ops, str};
+use core::{fmt, str};
 use octseq::octets::OctetsFrom;
 use octseq::parse::Parser;
 
@@ -130,7 +130,7 @@ impl ComposeRecordData for Aaaa {
         &self,
         target: &mut Target,
     ) -> Result<(), Target::AppendError> {
-        target.append_slice(&self.octets())
+        target.append_slice(&self.addr().octets())
     }
 
     fn compose_canonical_rdata<Target: Composer + ?Sized>(
@@ -146,22 +146,6 @@ impl ComposeRecordData for Aaaa {
 impl fmt::Display for Aaaa {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.addr.fmt(f)
-    }
-}
-
-//--- Deref and DerefMut
-
-impl ops::Deref for Aaaa {
-    type Target = Ipv6Addr;
-
-    fn deref(&self) -> &Self::Target {
-        &self.addr
-    }
-}
-
-impl ops::DerefMut for Aaaa {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.addr
     }
 }
 

--- a/src/rdata/dname.rs
+++ b/src/rdata/dname.rs
@@ -3,7 +3,7 @@ use crate::base::name::{ParsedDname, PushError, ToDname};
 use crate::base::wire::ParseError;
 use core::cmp::Ordering;
 use core::str::FromStr;
-use core::{fmt, hash, ops};
+use core::{fmt, hash};
 use octseq::builder::{EmptyBuilder, FromBuilder};
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -1086,16 +1086,6 @@ macro_rules! dname_type_base {
                 write!(f, "{}.", self.$field)
             }
         }
-
-        //--- Deref
-
-        impl<N> ops::Deref for $target<N> {
-            type Target = N;
-
-            fn deref(&self) -> &Self::Target {
-                &self.$field
-            }
-        }
     }
 }
 
@@ -1115,7 +1105,7 @@ macro_rules! dname_type_well_known {
                     None
                 }
                 else {
-                    Some(self.compose_len())
+                    Some(self.$field.compose_len())
                 }
             }
 
@@ -1158,7 +1148,7 @@ macro_rules! dname_type_canonical {
         impl<N: ToDname> $crate::base::rdata::ComposeRecordData
         for $target<N> {
             fn rdlen(&self, _compress: bool) -> Option<u16> {
-                Some(self.compose_len())
+                Some(self.$field.compose_len())
             }
 
             fn compose_rdata<Target: $crate::base::wire::Composer + ?Sized>(

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -17,7 +17,7 @@ use crate::utils::{base16, base32};
 #[cfg(feature = "bytes")]
 use bytes::Bytes;
 use core::cmp::Ordering;
-use core::{fmt, hash, ops, str};
+use core::{fmt, hash, str};
 use octseq::builder::{
     EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder,
 };
@@ -903,15 +903,7 @@ where
     }
 }
 
-//--- Deref and AsRef
-
-impl<Octs: ?Sized> ops::Deref for Nsec3Salt<Octs> {
-    type Target = Octs;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+//--- AsRef
 
 impl<Octs: AsRef<U> + ?Sized, U: ?Sized> AsRef<U> for Nsec3Salt<Octs> {
     fn as_ref(&self) -> &U {
@@ -1255,15 +1247,7 @@ where
     }
 }
 
-//--- Deref and AsRef
-
-impl<Octs: ?Sized> ops::Deref for OwnerHash<Octs> {
-    type Target = Octs;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+//--- AsRef
 
 impl<Octs: AsRef<U> + ?Sized, U: ?Sized> AsRef<U> for OwnerHash<Octs> {
     fn as_ref(&self) -> &U {

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -21,7 +21,7 @@ use bytes::BytesMut;
 use core::cmp::Ordering;
 use core::convert::{Infallible, TryFrom};
 use core::str::FromStr;
-use core::{fmt, hash, ops, str};
+use core::{fmt, hash, str};
 use octseq::builder::{
     infallible, EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder,
     ShortBuf,
@@ -173,22 +173,6 @@ impl ComposeRecordData for A {
 impl fmt::Display for A {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.addr.fmt(f)
-    }
-}
-
-//--- Deref and DerefMut
-
-impl ops::Deref for A {
-    type Target = Ipv4Addr;
-
-    fn deref(&self) -> &Self::Target {
-        &self.addr
-    }
-}
-
-impl ops::DerefMut for A {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.addr
     }
 }
 

--- a/src/resolv/stub/conf.rs
+++ b/src/resolv/stub/conf.rs
@@ -15,6 +15,7 @@ use std::default::Default;
 use std::io::Read;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
+use std::slice::SliceIndex;
 use std::str::{self, FromStr, SplitWhitespace};
 use std::time::Duration;
 use std::vec::Vec;
@@ -640,6 +641,14 @@ impl SearchList {
         self.search.push(Dname::root())
     }
 
+    pub fn len(&self) -> usize {
+        self.search.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.search.is_empty()
+    }
+
     pub fn get(&self, pos: usize) -> Option<&SearchSuffix> {
         self.search.get(pos)
     }
@@ -657,19 +666,20 @@ impl From<SearchSuffix> for SearchList {
     }
 }
 
-//--- AsRef and Deref
+impl<I: SliceIndex<[SearchSuffix]>> ops::Index<I> for SearchList {
+    type Output = <I as SliceIndex<[SearchSuffix]>>::Output;
+
+    fn index(&self, index: I) -> &<I as SliceIndex<[SearchSuffix]>>::Output {
+        self.search.index(index)
+    }
+}
+
+
+//--- AsRef
 
 impl AsRef<[SearchSuffix]> for SearchList {
     fn as_ref(&self) -> &[SearchSuffix] {
         self.search.as_ref()
-    }
-}
-
-impl ops::Deref for SearchList {
-    type Target = [SearchSuffix];
-
-    fn deref(&self) -> &Self::Target {
-        self.as_ref()
     }
 }
 

--- a/src/resolv/stub/conf.rs
+++ b/src/resolv/stub/conf.rs
@@ -674,7 +674,6 @@ impl<I: SliceIndex<[SearchSuffix]>> ops::Index<I> for SearchList {
     }
 }
 
-
 //--- AsRef
 
 impl AsRef<[SearchSuffix]> for SearchList {

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -29,6 +29,7 @@ use std::boxed::Box;
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
+use std::slice::SliceIndex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::vec::Vec;
@@ -436,6 +437,20 @@ impl From<Message<Bytes>> for Answer {
     }
 }
 
+impl ops::Deref for Answer {
+    type Target = Message<Bytes>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.message
+    }
+}
+
+impl AsRef<Message<Bytes>> for Answer {
+    fn as_ref(&self) -> &Message<Bytes> {
+        &self.message
+    }
+}
+
 //------------ ServerInfo ----------------------------------------------------
 
 #[derive(Clone, Debug)]
@@ -666,11 +681,11 @@ impl<'a> IntoIterator for &'a ServerList {
     }
 }
 
-impl ops::Deref for ServerList {
-    type Target = [ServerInfo];
+impl<I: SliceIndex<[ServerInfo]>> ops::Index<I> for ServerList {
+    type Output = <I as SliceIndex<[ServerInfo]>>::Output;
 
-    fn deref(&self) -> &Self::Target {
-        self.servers.as_ref()
+    fn index(&self, index: I) -> &<I as SliceIndex<[ServerInfo]>>::Output {
+        self.servers.index(index)
     }
 }
 
@@ -739,20 +754,6 @@ impl<'a> Iterator for ServerListIter<'a> {
         } else {
             None
         }
-    }
-}
-
-impl ops::Deref for Answer {
-    type Target = Message<Bytes>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.message
-    }
-}
-
-impl AsRef<Message<Bytes>> for Answer {
-    fn as_ref(&self) -> &Message<Bytes> {
-        &self.message
     }
 }
 

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -515,7 +515,8 @@ impl<K: AsRef<Key>> ClientTransaction<K> {
             &tsig.variables(),
         );
         self.context.key().compare_signatures(
-            &signature, tsig.record.data().mac().as_ref()
+            &signature,
+            tsig.record.data().mac().as_ref(),
         )?;
         self.context.check_answer_time(message, &tsig, now)?;
         remove_tsig(tsig.into_original_id(), message);
@@ -777,9 +778,11 @@ impl<K: AsRef<Key>> ClientSequence<K> {
             &tsig.variables(),
         );
         self.context.key().compare_signatures(
-            &signature, tsig.record.data().mac().as_ref()
+            &signature,
+            tsig.record.data().mac().as_ref(),
         )?;
-        self.context.apply_signature(tsig.record.data().mac().as_ref());
+        self.context
+            .apply_signature(tsig.record.data().mac().as_ref());
         self.context.check_answer_time(message, &tsig, now)?;
         self.first = false;
         remove_tsig(tsig.into_original_id(), message);
@@ -821,9 +824,11 @@ impl<K: AsRef<Key>> ClientSequence<K> {
             &tsig.variables(),
         );
         self.context.key().compare_signatures(
-            &signature, tsig.record.data().mac().as_ref()
+            &signature,
+            tsig.record.data().mac().as_ref(),
         )?;
-        self.context.apply_signature(tsig.record.data().mac().as_ref());
+        self.context
+            .apply_signature(tsig.record.data().mac().as_ref());
         self.context.check_answer_time(message, &tsig, now)?;
         self.unsigned = 0;
         remove_tsig(tsig.into_original_id(), message);
@@ -1005,12 +1010,11 @@ impl<K: AsRef<Key>> SigningContext<K> {
         };
 
         // 4.5.1. KEY check and error handling
-        let algorithm = match Algorithm::from_dname(
-            tsig.record.data().algorithm()
-        ) {
-            Some(algorithm) => algorithm,
-            None => return Err(ServerError::unsigned(TsigRcode::BadKey)),
-        };
+        let algorithm =
+            match Algorithm::from_dname(tsig.record.data().algorithm()) {
+                Some(algorithm) => algorithm,
+                None => return Err(ServerError::unsigned(TsigRcode::BadKey)),
+            };
         let key = match store.get_key(tsig.record.owner(), algorithm) {
             Some(key) => key,
             None => return Err(ServerError::unsigned(TsigRcode::BadKey)),
@@ -1033,7 +1037,8 @@ impl<K: AsRef<Key>> SigningContext<K> {
             &variables,
         );
         let res = context.key.as_ref().compare_signatures(
-            &signature, tsig.record.data().mac().as_ref()
+            &signature,
+            tsig.record.data().mac().as_ref(),
         );
         if let Err(err) = res {
             return Err(ServerError::unsigned(match err {


### PR DESCRIPTION
This PR removes the `Deref` and `DerefMut` impls from types that aren’t smart pointers and thus shouldn’t really have them according to the advise given in the documentation.

Where appropriate, it adds `len` and `is_empty` methods. Additional methods likely should be added later as well.

In particular:

* Removed impls of `Deref` and (if present) `DerefMut` for the following types: `CharStr`, `CharStrBuilder`, `DnameBuilder`, `Label`, `A`, `Aaaa`, all record types that wrap a domain name, `Nsec3Salt`, `OwnerHash`,
  `SearchList`, `ServerList`. Where necessary, `len` and `is_empty` were added.
* IntoIterator for Label changed Self::Item.

This is a breaking change.