### PR TITLE
Follow octseq change.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bytes          = { version = "1.0", optional = true }
 chrono         = { version = "0.4.6", optional = true, default-features = false }
 futures        = { version = "0.3", optional = true }
 heapless       = { version = "0.7", optional = true }
-octseq         = { git = "https://github.com/NLnetLabs/octseq.git" }
+octseq         = { git = "https://github.com/NLnetLabs/octseq.git", branch = "parse-be" }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.16.14", optional = true }
 serde          = { version = "1.0.130", optional = true, features = ["derive"] }

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -121,7 +121,7 @@ impl Opt<[u8]> {
         let mut parser = Parser::from_ref(slice);
         while parser.remaining() > 0 {
             parser.advance(2)?;
-            let len = parser.parse_u16()?;
+            let len = parser.parse_u16_be()?;
             parser.advance(len as usize)?;
         }
         Ok(())
@@ -552,7 +552,7 @@ impl OptionHeader {
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
         parser: &mut Parser<Octs>,
     ) -> Result<Self, ParseError> {
-        Ok(OptionHeader::new(parser.parse_u16()?, parser.parse_u16()?))
+        Ok(OptionHeader::new(parser.parse_u16_be()?, parser.parse_u16_be()?))
     }
 }
 
@@ -593,8 +593,8 @@ where
     /// parse error otherwise. Return `Ok(None)` if the option type didn’t
     /// want to parse this option.
     fn next_step(&mut self) -> Result<Option<D>, ParseError> {
-        let code = self.parser.parse_u16()?.into();
-        let len = self.parser.parse_u16()? as usize;
+        let code = self.parser.parse_u16_be()?.into();
+        let len = self.parser.parse_u16_be()? as usize;
         let mut parser = self.parser.parse_parser(len)?;
         let res = D::parse_option(code, &mut parser)?;
         if res.is_some() && parser.remaining() > 0 {

--- a/src/base/opt/subnet.rs
+++ b/src/base/opt/subnet.rs
@@ -100,7 +100,7 @@ impl ClientSubnet {
         const ERR_ADDR_LEN: &str = "invalid address length in client \
                                     subnet option";
 
-        let family = parser.parse_u16()?;
+        let family = parser.parse_u16_be()?;
         let source_prefix_len = parser.parse_u8()?;
         let scope_prefix_len = parser.parse_u8()?;
 

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -602,7 +602,7 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> RecordHeader<ParsedDname<&'a Octs>> {
             Rtype::parse(parser)?,
             Class::parse(parser)?,
             Ttl::parse(parser)?,
-            parser.parse_u16()?,
+            parser.parse_u16_be()?,
         ))
     }
 }
@@ -1385,7 +1385,7 @@ impl Ttl {
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
         parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
-        parser.parse_u32().map(Ttl::from_secs).map_err(Into::into)
+        parser.parse_u32_be().map(Ttl::from_secs).map_err(Into::into)
     }
 }
 

--- a/src/base/wire.rs
+++ b/src/base/wire.rs
@@ -181,37 +181,37 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for u8 {
 
 impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for i16 {
     fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
-        parser.parse_i16().map_err(Into::into)
+        parser.parse_i16_be().map_err(Into::into)
     }
 }
 
 impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for u16 {
     fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
-        parser.parse_u16().map_err(Into::into)
+        parser.parse_u16_be().map_err(Into::into)
     }
 }
 
 impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for i32 {
     fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
-        parser.parse_i32().map_err(Into::into)
+        parser.parse_i32_be().map_err(Into::into)
     }
 }
 
 impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for u32 {
     fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
-        parser.parse_u32().map_err(Into::into)
+        parser.parse_u32_be().map_err(Into::into)
     }
 }
 
 impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for u64 {
     fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
-        parser.parse_u64().map_err(Into::into)
+        parser.parse_u64_be().map_err(Into::into)
     }
 }
 
 impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for i64 {
     fn parse(parser: &mut Parser<'a, Octs>) -> Result<Self, ParseError> {
-        parser.parse_i64().map_err(Into::into)
+        parser.parse_i64_be().map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
This PR follows a breaking change in _octseq_ that changes the names of the methods for integer parsing.