### PR TITLE
Fix scanning of the root name.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain"
-version = "0.8.0"
+version = "0.8.1-dev"
 rust-version = "1.65.0"
 edition = "2021"
 authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain"
-version = "0.8.0-dev"
+version = "0.8.0"
 rust-version = "1.65.0"
 edition = "2021"
 authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased future version
+## 0.8.0
 
 Breaking Changes
 
@@ -93,10 +93,6 @@ New
   canonical names. ([#200])
 * Added a `MAX_LEN` constant to various types that wrap length-limited
   octets sequences. ([#201] by [@CrabNejonas])
-
-Bug Fixes
-
-Other Changes
 
 [#109]: https://github.com/NLnetLabs/domain/pull/109
 [#142]: https://github.com/NLnetLabs/domain/pull/142

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## Unreleased next version
+
+Breaking changes
+
+New
+
+Bug fixes
+
+Other changes
+
+
 ## 0.8.0
 
 Breaking Changes

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -195,8 +195,7 @@ where
             }
             self.end_label();
             Ok(())
-        } else if
-            matches!(sym, Symbol::SimpleEscape(b'['))
+        } else if matches!(sym, Symbol::SimpleEscape(b'['))
             && !self.in_label()
         {
             Err(LabelFromStrError::BinaryLabel.into())
@@ -312,7 +311,9 @@ where
         &mut self,
         symbols: Sym,
     ) -> Result<(), FromStrError> {
-        symbols.into_iter().try_for_each(|symbol| self.push_symbol(symbol))
+        symbols
+            .into_iter()
+            .try_for_each(|symbol| self.push_symbol(symbol))
     }
 
     /// Appends a name from a sequence of characters.

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -184,7 +184,7 @@ where
         Ok(())
     }
 
-    /// Pushes a symbold to the end of the domain name.
+    /// Pushes a symbol to the end of the domain name.
     ///
     /// The symbol is iterpreted as part of the presentation format of a
     /// domain name, i.e., an unescaped dot is considered a label separator.

--- a/src/base/name/chain.rs
+++ b/src/base/name/chain.rs
@@ -427,6 +427,10 @@ mod test {
                 .unwrap(),
             &[b"www", b"example", b"com", b""],
         );
+        check_impl(
+            RelativeDname::empty_slice().chain(Dname::root_slice()).unwrap(),
+            &[b""]
+        );
 
         check_impl(
             UncertainDname::from(w.clone()).chain(ecr.clone()).unwrap(),

--- a/src/base/name/chain.rs
+++ b/src/base/name/chain.rs
@@ -428,8 +428,10 @@ mod test {
             &[b"www", b"example", b"com", b""],
         );
         check_impl(
-            RelativeDname::empty_slice().chain(Dname::root_slice()).unwrap(),
-            &[b""]
+            RelativeDname::empty_slice()
+                .chain(Dname::root_slice())
+                .unwrap(),
+            &[b""],
         );
 
         check_impl(

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -15,7 +15,7 @@ use core::ops::{Bound, RangeBounds};
 use core::str::FromStr;
 use core::{cmp, fmt, hash, str};
 use octseq::builder::{
-    EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder, Truncate
+    EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder, Truncate,
 };
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
@@ -105,18 +105,17 @@ impl<Octs> Dname<Octs> {
         };
         if first == Symbol::Char('.') {
             if symbols.next().is_some() {
-                return Err(FromStrError::EmptyLabel)
-            }
-            else {
+                return Err(FromStrError::EmptyLabel);
+            } else {
                 // Make a root name.
                 let mut builder =
                     <Octs as FromBuilder>::Builder::with_capacity(1);
-                builder.append_slice(b"\0").map_err(|_| {
-                    FromStrError::ShortBuf
-                })?;
+                builder
+                    .append_slice(b"\0")
+                    .map_err(|_| FromStrError::ShortBuf)?;
                 return Ok(unsafe {
                     Self::from_octets_unchecked(builder.freeze())
-                })
+                });
             }
         }
 
@@ -1021,7 +1020,6 @@ impl<'a, Octs: Octets + ?Sized> Iterator for SuffixIter<'a, Octs> {
     }
 }
 
-
 //------------ DisplayWithDot ------------------------------------------------
 
 struct DisplayWithDot<'a>(&'a Dname<[u8]>);
@@ -1030,8 +1028,7 @@ impl<'a> fmt::Display for DisplayWithDot<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.0.is_root() {
             f.write_str(".")
-        }
-        else {
+        } else {
             let mut iter = self.0.iter();
             write!(f, "{}", iter.next().unwrap())?;
             for label in iter {
@@ -1041,7 +1038,6 @@ impl<'a> fmt::Display for DisplayWithDot<'a> {
         }
     }
 }
-
 
 //============ Error Types ===================================================
 
@@ -1920,10 +1916,7 @@ pub(crate) mod test {
         );
         assert_tokens(
             &Dname::root_vec().readable(),
-            &[
-                Token::NewtypeStruct { name: "Dname" },
-                Token::Str("."),
-            ],
+            &[Token::NewtypeStruct { name: "Dname" }, Token::Str(".")],
         );
     }
 }

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -3,7 +3,7 @@
 //! This is a private module. Its public types are re-exported by the parent.
 
 use super::super::cmp::CanonicalOrd;
-use super::super::scan::{Scanner, Symbol};
+use super::super::scan::{Scanner, Symbol, Symbols};
 use super::super::wire::{FormError, ParseError};
 use super::builder::{DnameBuilder, FromStrError};
 use super::label::{Label, LabelTypeError, SplitLabelError};
@@ -14,7 +14,9 @@ use bytes::Bytes;
 use core::ops::{Bound, RangeBounds};
 use core::str::FromStr;
 use core::{cmp, fmt, hash, str};
-use octseq::builder::{EmptyBuilder, FreezeBuilder, FromBuilder, Truncate};
+use octseq::builder::{
+    EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder, Truncate
+};
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 #[cfg(feature = "serde")]
@@ -94,7 +96,32 @@ impl<Octs> Dname<Octs> {
             + AsMut<[u8]>,
         Sym: IntoIterator<Item = Symbol>,
     {
+        // DnameBuilder can’t deal with a single dot, so we need to special
+        // case that.
+        let mut symbols = symbols.into_iter();
+        let first = match symbols.next() {
+            Some(first) => first,
+            None => return Err(FromStrError::UnexpectedEnd),
+        };
+        if first == Symbol::Char('.') {
+            if symbols.next().is_some() {
+                return Err(FromStrError::EmptyLabel)
+            }
+            else {
+                // Make a root name.
+                let mut builder =
+                    <Octs as FromBuilder>::Builder::with_capacity(1);
+                builder.append_slice(b"\0").map_err(|_| {
+                    FromStrError::ShortBuf
+                })?;
+                return Ok(unsafe {
+                    Self::from_octets_unchecked(builder.freeze())
+                })
+            }
+        }
+
         let mut builder = DnameBuilder::<Octs::Builder>::new();
+        builder.push_symbol(first)?;
         builder.append_symbols(symbols)?;
         builder.into_dname().map_err(Into::into)
     }
@@ -126,9 +153,7 @@ impl<Octs> Dname<Octs> {
             + AsMut<[u8]>,
         C: IntoIterator<Item = char>,
     {
-        let mut builder = DnameBuilder::<Octs::Builder>::new();
-        builder.append_chars(chars)?;
-        builder.into_dname().map_err(Into::into)
+        Self::from_symbols(Symbols::new(chars.into_iter()))
     }
 
     /// Reads a name in presentation format from the beginning of a scanner.
@@ -307,6 +332,10 @@ impl<Octs: AsRef<[u8]> + ?Sized> Dname<Octs> {
     #[allow(clippy::len_without_is_empty)] // never empty ...
     pub fn len(&self) -> usize {
         self.0.as_ref().len()
+    }
+
+    pub fn fmt_with_dot(&self) -> impl fmt::Display + '_ {
+        DisplayWithDot(self.for_slice())
     }
 }
 
@@ -814,8 +843,13 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Dname<Octs> {
     /// Formats the domain name.
     ///
     /// This will produce the domain name in ‘common display format’ without
-    /// the trailing dot.
+    /// the trailing dot with the exception of a root name which will be just
+    /// a dot.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_root() {
+            return f.write_str(".");
+        }
+
         let mut iter = self.iter();
         write!(f, "{}", iter.next().unwrap())?;
         for label in iter {
@@ -831,7 +865,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Dname<Octs> {
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Dname<Octs> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Dname({}.)", self)
+        write!(f, "Dname({})", self.fmt_with_dot())
     }
 }
 
@@ -986,6 +1020,28 @@ impl<'a, Octs: Octets + ?Sized> Iterator for SuffixIter<'a, Octs> {
         Some(res)
     }
 }
+
+
+//------------ DisplayWithDot ------------------------------------------------
+
+struct DisplayWithDot<'a>(&'a Dname<[u8]>);
+
+impl<'a> fmt::Display for DisplayWithDot<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.0.is_root() {
+            f.write_str(".")
+        }
+        else {
+            let mut iter = self.0.iter();
+            write!(f, "{}", iter.next().unwrap())?;
+            for label in iter {
+                write!(f, ".{}", label)?
+            }
+            Ok(())
+        }
+    }
+}
+
 
 //============ Error Types ===================================================
 
@@ -1718,6 +1774,10 @@ pub(crate) mod test {
         use std::vec::Vec;
 
         assert_eq!(
+            Dname::<Vec<u8>>::from_str(".").unwrap().as_slice(),
+            b"\0"
+        );
+        assert_eq!(
             Dname::<Vec<u8>>::from_str("www.example.com")
                 .unwrap()
                 .as_slice(),
@@ -1856,6 +1916,13 @@ pub(crate) mod test {
             &[
                 Token::NewtypeStruct { name: "Dname" },
                 Token::Str("www.example.com"),
+            ],
+        );
+        assert_tokens(
+            &Dname::root_vec().readable(),
+            &[
+                Token::NewtypeStruct { name: "Dname" },
+                Token::Str("."),
             ],
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 #![allow(clippy::uninlined_format_args)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(any(feature = "std"))]
+#[cfg(feature = "std")]
 #[allow(unused_imports)] // Import macros even if unused.
 #[macro_use]
 extern crate std;

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -660,15 +660,12 @@ impl<'a> Scanner for EntryScanner<'a> {
                     // continue to the next label.
                     if write == 1 {
                         if self.zonefile.buf.next_symbol()?.is_some() {
-                            return Err(EntryError::bad_dname())
-                        }
-                        else {
+                            return Err(EntryError::bad_dname());
+                        } else {
                             self.zonefile.buf.next_item()?;
-                            return Ok(
-                                RelativeDname::empty().chain(
-                                    Dname::root()
-                                ).expect("failed to make root name")
-                            )
+                            return Ok(RelativeDname::empty()
+                                .chain(Dname::root())
+                                .expect("failed to make root name"));
                         }
                     }
                     if write > 254 {

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -654,7 +654,23 @@ impl<'a> Scanner for EntryScanner<'a> {
                     }
                 }
                 Some(true) => {
-                    // Last symbol was a dot: check length and continue.
+                    // Last symbol was a dot. If it is was the very first
+                    // symbol, this can only be the root name. Check for that
+                    // and, if so, return. Otherwise, check length and
+                    // continue to the next label.
+                    if write == 1 {
+                        if self.zonefile.buf.next_symbol()?.is_some() {
+                            return Err(EntryError::bad_dname())
+                        }
+                        else {
+                            self.zonefile.buf.next_item()?;
+                            return Ok(
+                                RelativeDname::empty().chain(
+                                    Dname::root()
+                                ).expect("failed to make root name")
+                            )
+                        }
+                    }
                     if write > 254 {
                         return Err(EntryError::bad_dname());
                     }
@@ -1582,9 +1598,17 @@ mod test {
     }
 
     #[test]
-    fn test_data() {
+    fn test_basic_yaml() {
         TestCase::test(include_str!("../../test-data/zonefiles/basic.yaml"));
+    }
+
+    #[test]
+    fn test_escape_yaml() {
         TestCase::test(include_str!("../../test-data/zonefiles/escape.yaml"));
+    }
+
+    #[test]
+    fn test_unknown_yaml() {
         TestCase::test(include_str!(
             "../../test-data/zonefiles/unknown.yaml"
         ));

--- a/test-data/zonefiles/basic.yaml
+++ b/test-data/zonefiles/basic.yaml
@@ -8,7 +8,10 @@ zonefile: |
     3600	IN	A	192.0.2.11
   www.example.com. A 192.0.2.12
   $ORIGIN example.com.
-  @ A 192.0.2.13
+  www A 192.0.2.13
+  @ A 192.0.2.14
+  . TXT foo
+  @ MX 0 .
 result:
   - owner: example.com.
     class: IN
@@ -36,9 +39,25 @@ result:
     ttl: 3600
     data: !A
       addr: 192.0.2.12
-  - owner: example.com.
+  - owner: www.example.com.
     class: IN
     ttl: 3600
     data: !A
       addr: 192.0.2.13
+  - owner: example.com.
+    class: IN
+    ttl: 3600
+    data: !A
+      addr: 192.0.2.14
+  - owner: .
+    class: IN
+    ttl: 3600
+    data: !Txt
+      - foo
+  - owner: example.com.
+    class: IN
+    ttl: 3600
+    data: !Mx
+      preference: 0
+      exchange: .
 


### PR DESCRIPTION
This PR fixes scanning (i.e., reading from presentation format) of domain names that are just the root label. It also fixes how they are displayed: previously they were empty, now they are displayed as a dot. It also adds a new method `Dname::fmt_with_dot` that returns a placeholder type that displays the name with a dot at the end.

