### PR TITLE
Merge tag 'v0.7.2'

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -129,6 +129,24 @@ New
 [octseq]: https://crates.io/crates/octseq
 
 
+## 0.7.2
+
+Released 2023-03-02
+
+New
+
+* Added a new method `FoundSrvs::into_srvs` that converts the value into an
+  iterator over the found SRV records without resolving them further.
+  ([#174])
+
+Bug Fixes
+
+* Fix trait bounds on `FoundSrvs::into_stream` to make it usable again.
+  ([#174])
+
+[#174]: https://github.com/NLnetLabs/domain/pull/174
+
+
 ## 0.7.1
 
 Released 2022-10-06.

--- a/src/resolv/lookup/srv.rs
+++ b/src/resolv/lookup/srv.rs
@@ -89,6 +89,17 @@ pub struct FoundSrvs {
 }
 
 impl FoundSrvs {
+    /// Converts the found SRV records into socket addresses.
+    ///
+    /// The method takes a reference to a resolver and returns a stream of
+    /// socket addresses in the order prescribed by the SRV records. Each
+    /// returned item provides the set of addresses for one host.
+    ///
+    /// Note that if you are using the
+    /// [`StubResolver`][crate::resolv::stub::StubResolver], you will have to
+    /// pass in a double reference since [`Resolver`] is implemented for a
+    /// reference to it and this method requires a reference to that impl
+    /// being passed. This quirk will be fixed in future versions.
     pub fn into_stream<R: Resolver>(
         self,
         resolver: &R,
@@ -106,6 +117,18 @@ impl FoundSrvs {
             Err(one) => None.into_iter().flatten().chain(Some(one)),
         };
         stream::iter(iter).then(move |item| item.resolve(resolver))
+    }
+
+    /// Converts the value into an iterator over the found SRV records.
+    pub fn into_srvs(self) -> impl Iterator<Item = Srv<Dname<OctetsVec>>> {
+        let (left, right) = match self.items {
+            Ok(ok) => (Some(ok.into_iter()), None),
+            Err(err) => (None, Some(std::iter::once(err))),
+        };
+        left.into_iter()
+            .flatten()
+            .chain(right.into_iter().flatten())
+            .map(|item| item.srv)
     }
 
     /// Moves all results from `other` into `Self`, leaving `other` empty.


### PR DESCRIPTION
v0.7.2 contained fixed that were never ported to the main branch, and
lost in the v0.8.0 release.

Merge this branch to introduce both the changes themselves and retain
their history.

Fixes: https://github.com/NLnetLabs/domain/issues/213

