### PR TITLE
Move `flatten_into` for flattening domain names into a trait.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq         = "0.2"
+octseq         = { git = "https://github.com/NLnetLabs/octseq.git", branch = "append-error-alias" }
 time           = "0.3.1"
 
 rand           = { version = "0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq         = { git = "https://github.com/NLnetLabs/octseq.git", branch = "append-error-alias" }
+octseq         = { git = "https://github.com/NLnetLabs/octseq.git" }
 time           = "0.3.1"
 
 rand           = { version = "0.8", optional = true }

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -758,10 +758,7 @@ impl<'a, Octs: Octets + ?Sized> QuestionSection<'a, Octs> {
 
 impl<'a, Octs: ?Sized> Clone for QuestionSection<'a, Octs> {
     fn clone(&self) -> Self {
-        QuestionSection {
-            parser: self.parser,
-            count: self.count,
-        }
+        *self
     }
 }
 
@@ -986,11 +983,7 @@ impl<'a, Octs: Octets + ?Sized> RecordSection<'a, Octs> {
 
 impl<'a, Octs: ?Sized> Clone for RecordSection<'a, Octs> {
     fn clone(&self) -> Self {
-        RecordSection {
-            parser: self.parser,
-            section: self.section,
-            count: self.count,
-        }
+        *self
     }
 }
 

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -8,7 +8,7 @@ use super::super::wire::{FormError, ParseError};
 use super::builder::{DnameBuilder, FromStrError};
 use super::label::{Label, LabelTypeError, SplitLabelError};
 use super::relative::{DnameIter, RelativeDname};
-use super::traits::{ToDname, ToLabelIter};
+use super::traits::{FlattenInto, ToDname, ToLabelIter};
 #[cfg(feature = "bytes")]
 use bytes::Bytes;
 use core::ops::{Bound, RangeBounds};
@@ -704,6 +704,20 @@ where
     /// [`UncertainDname`]: struct.UncertainDname.html
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::from_chars(s.chars())
+    }
+}
+
+//--- FlattenInto
+
+impl<Octs, Target> FlattenInto<Dname<Target>> for Dname<Octs>
+where
+    Target: OctetsFrom<Octs>,
+{
+    type AppendError = Target::Error;
+
+    fn try_flatten_into(self) -> Result<Dname<Target>, Self::AppendError> {
+        Target::try_octets_from(self.0)
+            .map(|octets| unsafe { Dname::from_octets_unchecked(octets) })
     }
 }
 

--- a/src/base/name/mod.rs
+++ b/src/base/name/mod.rs
@@ -102,7 +102,7 @@ pub use self::relative::{
     DnameIter, RelativeDname, RelativeDnameError, RelativeFromStrError,
     StripSuffixError,
 };
-pub use self::traits::{ToDname, ToLabelIter, ToRelativeDname};
+pub use self::traits::{FlattenInto, ToDname, ToLabelIter, ToRelativeDname};
 pub use self::uncertain::UncertainDname;
 
 mod builder;

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -1491,22 +1491,30 @@ impl Into<Duration> for Ttl {
 #[cfg(test)]
 mod test {
     #[test]
-    #[cfg(features = "bytes")]
+    #[cfg(feature = "bytes")]
     fn ds_octets_into() {
-        use crate::base::iana::{DigestAlg, Rtype, SecAlg};
-        use crate::name::Dname;
-        use crate::octets::OctetsInto;
+        use crate::base::iana::{Class, DigestAlg, SecAlg};
+        use crate::base::name::Dname;
+        use crate::base::record::{Record, Ttl};
         use crate::rdata::Ds;
+        use bytes::Bytes;
+        use octseq::OctetsInto;
 
         let ds: Record<Dname<&[u8]>, Ds<&[u8]>> = Record::new(
-            "a.example".parse().unwrap(),
+            Dname::from_octets(b"\x01a\x07example\0".as_ref()).unwrap(),
             Class::In,
-            86400,
-            Ds::new(12, SecAlg::RsaSha256, b"something"),
+            Ttl::from_secs(86400),
+            Ds::new(
+                12,
+                SecAlg::RsaSha256,
+                DigestAlg::Sha256,
+                b"something".as_ref(),
+            )
+            .unwrap(),
         );
         let ds_bytes: Record<Dname<Bytes>, Ds<Bytes>> =
-            ds.octets_into().unwrap();
+            ds.clone().octets_into();
         assert_eq!(ds.owner(), ds_bytes.owner());
-        asswer_eq!(ds.data().digest(), ds_bytes.data().digest());
+        assert_eq!(ds.data().digest(), ds_bytes.data().digest());
     }
 }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -17,7 +17,7 @@
 
 use super::cmp::CanonicalOrd;
 use super::iana::{Class, Rtype};
-use super::name::{ParsedDname, ToDname};
+use super::name::{FlattenInto, ParsedDname, ToDname};
 use super::rdata::{ComposeRecordData, ParseRecordData, RecordData};
 use super::wire::{Compose, Composer, FormError, Parse, ParseError};
 use core::cmp::Ordering;
@@ -242,7 +242,7 @@ impl<N, D> From<(N, u32, D)> for Record<N, D> {
     }
 }
 
-//--- OctetsFrom
+//--- OctetsFrom and FlattenInto
 //
 // XXX We don’t have blanket FromOctets for a type T into itself, so this may
 //     not always work as expected. Not sure what we can do about it?
@@ -265,6 +265,26 @@ where
             ttl: source.ttl,
             data: Data::try_octets_from(source.data)?,
         })
+    }
+}
+
+impl<Name, TName, Data, TData> FlattenInto<Record<TName, TData>>
+    for Record<Name, Data>
+where
+    Name: FlattenInto<TName>,
+    Data: FlattenInto<TData, AppendError = Name::AppendError>,
+{
+    type AppendError = Name::AppendError;
+
+    fn try_flatten_into(
+        self,
+    ) -> Result<Record<TName, TData>, Name::AppendError> {
+        Ok(Record::new(
+            self.owner.try_flatten_into()?,
+            self.class,
+            self.ttl,
+            self.data.try_flatten_into()?,
+        ))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 #![allow(clippy::uninlined_format_args)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(any(feature = "std"))]
+#[cfg(feature = "std")]
 #[allow(unused_imports)] // Import macros even if unused.
 #[macro_use]
 extern crate std;

--- a/src/rdata/aaaa.rs
+++ b/src/rdata/aaaa.rs
@@ -37,11 +37,11 @@ impl Aaaa {
         self.addr = addr
     }
 
-    pub(super) fn flatten_into<E>(self) -> Result<Aaaa, E> {
+    pub(super) fn convert_octets<E>(self) -> Result<Self, E> {
         Ok(self)
     }
 
-    pub(super) fn convert_octets<E>(self) -> Result<Self, E> {
+    pub(super) fn flatten<E>(self) -> Result<Self, E> {
         Ok(self)
     }
 

--- a/src/rdata/cds.rs
+++ b/src/rdata/cds.rs
@@ -3,7 +3,6 @@
 //! [RFC 7344]: https://tools.ietf.org/html/rfc7344
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
-use crate::base::name::PushError;
 use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData
 };
@@ -113,6 +112,12 @@ impl<Octs> Cdnskey<Octs> {
         })
     }
 
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self,
+    ) -> Result<Cdnskey<Target>, Target::Error> {
+        self.convert_octets()
+    }
+
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
         parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
@@ -140,28 +145,6 @@ impl<Octs> Cdnskey<Octs> {
             SecAlg::scan(scanner)?,
             scanner.convert_entry(base64::SymbolConverter::new())?,
         ).map_err(|err| S::Error::custom(err.as_str()))
-    }
-}
-
-impl<SrcOcts> Cdnskey<SrcOcts> {
-    pub fn flatten_into<Octs>(self) -> Result<Cdnskey<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        let Self {
-            flags,
-            protocol,
-            algorithm,
-            public_key,
-        } = self;
-        Ok(unsafe {
-            Cdnskey::new_unchecked(
-                flags,
-                protocol,
-                algorithm,
-                public_key.try_octets_into().map_err(Into::into)?,
-            )
-        })
     }
 }
 
@@ -433,6 +416,12 @@ impl<Octs> Cds<Octs> {
         })
     }
 
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self,
+    ) -> Result<Cds<Target>, Target::Error> {
+        self.convert_octets()
+    }
+
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
         parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
@@ -460,22 +449,6 @@ impl<Octs> Cds<Octs> {
             DigestAlg::scan(scanner)?,
             scanner.convert_entry(base16::SymbolConverter::new())?,
         ).map_err(|err| S::Error::custom(err.as_str()))
-    }
-}
-
-impl<SrcOcts> Cds<SrcOcts> {
-    pub fn flatten_into<Octs>(self) -> Result<Cds<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        Ok(unsafe {
-            Cds::new_unchecked(
-                self.key_tag,
-                self.algorithm,
-                self.digest_type,
-                self.digest.try_octets_into().map_err(Into::into)?,
-            )
-        })
     }
 }
 

--- a/src/rdata/dname.rs
+++ b/src/rdata/dname.rs
@@ -1,10 +1,9 @@
 use crate::base::cmp::CanonicalOrd;
-use crate::base::name::{ParsedDname, PushError, ToDname};
+use crate::base::name::{ParsedDname, ToDname};
 use crate::base::wire::ParseError;
 use core::cmp::Ordering;
 use core::str::FromStr;
 use core::{fmt, hash};
-use octseq::builder::{EmptyBuilder, FromBuilder};
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -6,7 +6,7 @@
 
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
-use crate::base::name::{Dname, FlattenInto, ParsedDname, ToDname};
+use crate::base::name::{FlattenInto, ParsedDname, ToDname};
 use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData,
 };
@@ -2386,6 +2386,7 @@ fn read_window(data: &[u8]) -> Option<((u8, &[u8]), &[u8])> {
 mod test {
     use super::*;
     use crate::base::iana::Rtype;
+    use crate::base::name::Dname;
     use crate::base::rdata::test::{
         test_compose_parse, test_rdlen, test_scan,
     };

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -6,7 +6,7 @@
 
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{DigestAlg, Rtype, SecAlg};
-use crate::base::name::{Dname, ParsedDname, PushError, ToDname};
+use crate::base::name::{Dname, FlattenInto, ParsedDname, ToDname};
 use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData,
 };
@@ -219,6 +219,12 @@ impl<Octs> Dnskey<Octs> {
         })
     }
 
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self,
+    ) -> Result<Dnskey<Target>, Target::Error> {
+        self.convert_octets()
+    }
+
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
         parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
@@ -249,29 +255,6 @@ impl<Octs> Dnskey<Octs> {
             scanner.convert_entry(base64::SymbolConverter::new())?,
         )
         .map_err(|err| S::Error::custom(err.as_str()))
-    }
-}
-
-impl<SrcOcts> Dnskey<SrcOcts> {
-    pub fn flatten_into<Octs>(self) -> Result<Dnskey<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        let Self {
-            flags,
-            protocol,
-            algorithm,
-            public_key,
-        } = self;
-
-        Ok(unsafe {
-            Dnskey::new_unchecked(
-                flags,
-                protocol,
-                algorithm,
-                public_key.try_octets_into().map_err(Into::into)?,
-            )
-        })
     }
 }
 
@@ -499,63 +482,6 @@ impl<Name> ProtoRrsig<Name> {
     }
 }
 
-impl<Octs> ProtoRrsig<ParsedDname<Octs>> {
-    pub fn flatten_into<Target>(
-        self,
-    ) -> Result<ProtoRrsig<Dname<Target>>, PushError>
-    where
-        Octs: Octets,
-        Target: for<'a> OctetsFrom<Octs::Range<'a>> + FromBuilder,
-        <Target as FromBuilder>::Builder: EmptyBuilder,
-    {
-        let Self {
-            type_covered,
-            algorithm,
-            labels,
-            original_ttl,
-            expiration,
-            inception,
-            key_tag,
-            signer_name,
-        } = self;
-
-        Ok(ProtoRrsig::new(
-            type_covered,
-            algorithm,
-            labels,
-            original_ttl,
-            expiration,
-            inception,
-            key_tag,
-            signer_name.flatten_into()?,
-        ))
-    }
-}
-
-//--- OctetsFrom
-
-impl<Name, SrcName> OctetsFrom<ProtoRrsig<SrcName>> for ProtoRrsig<Name>
-where
-    Name: OctetsFrom<SrcName>,
-{
-    type Error = Name::Error;
-
-    fn try_octets_from(
-        source: ProtoRrsig<SrcName>,
-    ) -> Result<Self, Self::Error> {
-        Ok(ProtoRrsig::new(
-            source.type_covered,
-            source.algorithm,
-            source.labels,
-            source.original_ttl,
-            source.expiration,
-            source.inception,
-            source.key_tag,
-            Name::try_octets_from(source.signer_name)?,
-        ))
-    }
-}
-
 impl<Name: ToDname> ProtoRrsig<Name> {
     pub fn compose<Target: Composer + ?Sized>(
         &self,
@@ -596,6 +522,52 @@ impl<Name: ToDname> ProtoRrsig<Name> {
         self.expiration.compose(target)?;
         self.inception.compose(target)?;
         self.key_tag.compose(target)
+    }
+}
+
+//--- OctetsFrom and FlattenInto
+
+impl<Name, SrcName> OctetsFrom<ProtoRrsig<SrcName>> for ProtoRrsig<Name>
+where
+    Name: OctetsFrom<SrcName>,
+{
+    type Error = Name::Error;
+
+    fn try_octets_from(
+        source: ProtoRrsig<SrcName>,
+    ) -> Result<Self, Self::Error> {
+        Ok(ProtoRrsig::new(
+            source.type_covered,
+            source.algorithm,
+            source.labels,
+            source.original_ttl,
+            source.expiration,
+            source.inception,
+            source.key_tag,
+            Name::try_octets_from(source.signer_name)?,
+        ))
+    }
+}
+
+impl<Name, TName> FlattenInto<ProtoRrsig<TName>> for ProtoRrsig<Name>
+where
+    Name: FlattenInto<TName>,
+{
+    type AppendError = Name::AppendError;
+
+    fn try_flatten_into(
+        self
+    ) -> Result<ProtoRrsig<TName>, Name::AppendError> {
+        Ok(ProtoRrsig::new(
+            self.type_covered,
+            self.algorithm,
+            self.labels,
+            self.original_ttl,
+            self.expiration,
+            self.inception,
+            self.key_tag,
+            self.signer_name.try_flatten_into()?,
+        ))
     }
 }
 
@@ -773,6 +745,28 @@ impl<Octs, Name> Rrsig<Octs, Name> {
         })
     }
 
+    pub(super) fn flatten<TOcts, TName>(
+        self,
+    ) -> Result<Rrsig<TOcts, TName>, TOcts::Error>
+    where
+        TOcts: OctetsFrom<Octs>,
+        Name: FlattenInto<TName, AppendError = TOcts::Error>,
+    {
+        Ok(unsafe {
+            Rrsig::new_unchecked(
+                self.type_covered,
+                self.algorithm,
+                self.labels,
+                self.original_ttl,
+                self.expiration,
+                self.inception,
+                self.key_tag,
+                self.signer_name.try_flatten_into()?,
+                TOcts::try_octets_from(self.signature)?,
+            )
+        })
+    }
+
     pub fn scan<S: Scanner<Octets = Octs, Dname = Name>>(
         scanner: &mut S,
     ) -> Result<Self, S::Error>
@@ -792,45 +786,6 @@ impl<Octs, Name> Rrsig<Octs, Name> {
             scanner.convert_entry(base64::SymbolConverter::new())?,
         )
         .map_err(|err| S::Error::custom(err.as_str()))
-    }
-}
-
-impl<Octs, NOcts> Rrsig<Octs, ParsedDname<NOcts>> {
-    pub fn flatten_into<Target>(
-        self,
-    ) -> Result<Rrsig<Target, Dname<Target>>, PushError>
-    where
-        NOcts: Octets,
-        Target: OctetsFrom<Octs>
-            + for<'a> OctetsFrom<NOcts::Range<'a>>
-            + FromBuilder,
-        <Target as FromBuilder>::Builder: EmptyBuilder,
-    {
-        let Self {
-            type_covered,
-            algorithm,
-            labels,
-            original_ttl,
-            expiration,
-            inception,
-            key_tag,
-            signer_name,
-            signature,
-        } = self;
-
-        Ok(unsafe {
-            Rrsig::new_unchecked(
-                type_covered,
-                algorithm,
-                labels,
-                original_ttl,
-                expiration,
-                inception,
-                key_tag,
-                signer_name.flatten_into()?,
-                Target::try_octets_from(signature).map_err(Into::into)?,
-            )
-        })
     }
 }
 
@@ -864,7 +819,7 @@ impl<Octs> Rrsig<Octs, ParsedDname<Octs>> {
     }
 }
 
-//--- OctetsFrom
+//--- OctetsFrom and FlattenInto
 
 impl<Octs, SrcOcts, Name, SrcName> OctetsFrom<Rrsig<SrcOcts, SrcName>>
     for Rrsig<Octs, Name>
@@ -891,6 +846,19 @@ where
                 Octs::try_octets_from(source.signature)?,
             )
         })
+    }
+}
+
+impl<Octs, TOcts, Name, TName> FlattenInto<Rrsig<TOcts, TName>>
+    for Rrsig<Octs, Name>
+where
+    TOcts: OctetsFrom<Octs>,
+    Name: FlattenInto<TName, AppendError = TOcts::Error>,
+{
+    type AppendError = TOcts::Error;
+
+    fn try_flatten_into(self) -> Result<Rrsig<TOcts, TName>, TOcts::Error> {
+        self.flatten()
     }
 }
 
@@ -1218,31 +1186,25 @@ impl<Octs, Name> Nsec<Octs, Name> {
         ))
     }
 
+    pub(super) fn flatten<TOcts, TName>(
+        self,
+    ) -> Result<Nsec<TOcts, TName>, TOcts::Error>
+    where
+        TOcts: OctetsFrom<Octs>,
+        Name: FlattenInto<TName, AppendError = TOcts::Error>,
+    {
+        Ok(Nsec::new(
+            self.next_name.try_flatten_into()?,
+            self.types.convert_octets()?,
+        ))
+    }
+
     pub fn scan<S: Scanner<Octets = Octs, Dname = Name>>(
         scanner: &mut S,
     ) -> Result<Self, S::Error> {
         Ok(Self::new(
             scanner.scan_dname()?,
             RtypeBitmap::scan(scanner)?,
-        ))
-    }
-}
-
-impl<Octs, NOcts> Nsec<Octs, ParsedDname<NOcts>> {
-    pub fn flatten_into<Target>(
-        self,
-    ) -> Result<Nsec<Target, Dname<Target>>, PushError>
-    where
-        NOcts: Octets,
-        Target: OctetsFrom<Octs>
-            + for<'a> OctetsFrom<NOcts::Range<'a>>
-            + FromBuilder,
-        <Target as FromBuilder>::Builder: EmptyBuilder,
-    {
-        let Self { next_name, types } = self;
-        Ok(Nsec::new(
-            next_name.flatten_into()?,
-            types.try_octets_into().map_err(Into::into)?,
         ))
     }
 }
@@ -1258,7 +1220,7 @@ impl<Octs: AsRef<[u8]>> Nsec<Octs, ParsedDname<Octs>> {
     }
 }
 
-//--- OctetsFrom
+//--- OctetsFrom and FlattenInto
 
 impl<Octs, SrcOcts, Name, SrcName> OctetsFrom<Nsec<SrcOcts, SrcName>>
     for Nsec<Octs, Name>
@@ -1275,6 +1237,19 @@ where
             Name::try_octets_from(source.next_name)?,
             RtypeBitmap::try_octets_from(source.types)?,
         ))
+    }
+}
+
+impl<Octs, TOcts, Name, TName> FlattenInto<Nsec<TOcts, TName>>
+    for Nsec<Octs, Name>
+where
+    TOcts: OctetsFrom<Octs>,
+    Name: FlattenInto<TName, AppendError = TOcts::Error>,
+{
+    type AppendError = TOcts::Error;
+
+    fn try_flatten_into(self) -> Result<Nsec<TOcts, TName>, TOcts::Error> {
+        self.flatten()
     }
 }
 
@@ -1539,6 +1514,12 @@ impl<Octs> Ds<Octs> {
         })
     }
 
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self,
+    ) -> Result<Ds<Target>, Target::Error> {
+        self.convert_octets()
+    }
+
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
         parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
@@ -1569,28 +1550,6 @@ impl<Octs> Ds<Octs> {
             scanner.convert_entry(base16::SymbolConverter::new())?,
         )
         .map_err(|err| S::Error::custom(err.as_str()))
-    }
-}
-
-impl<SrcOcts> Ds<SrcOcts> {
-    pub fn flatten_into<Octs>(self) -> Result<Ds<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        let Self {
-            key_tag,
-            algorithm,
-            digest_type,
-            digest,
-        } = self;
-        Ok(unsafe {
-            Ds::new_unchecked(
-                key_tag,
-                algorithm,
-                digest_type,
-                digest.try_octets_into().map_err(Into::into)?,
-            )
-        })
     }
 }
 

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -7,7 +7,6 @@
 use super::dnssec::RtypeBitmap;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::{Nsec3HashAlg, Rtype};
-use crate::base::name::PushError;
 use crate::base::rdata::{ComposeRecordData, ParseRecordData, RecordData};
 use crate::base::scan::{
     ConvertSymbols, EntrySymbol, Scan, Scanner, ScannerError,
@@ -116,6 +115,12 @@ impl<Octs> Nsec3<Octs> {
         ))
     }
 
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self,
+    ) -> Result<Nsec3<Target>, Target::Error> {
+        self.convert_octets()
+    }
+
     pub fn scan<S: Scanner<Octets = Octs>>(
         scanner: &mut S,
     ) -> Result<Self, S::Error> {
@@ -147,30 +152,6 @@ impl<Octs: AsRef<[u8]>> Nsec3<Octs> {
             salt,
             next_owner,
             types,
-        ))
-    }
-}
-
-impl<SrcOcts> Nsec3<SrcOcts> {
-    pub fn flatten_into<Octs>(self) -> Result<Nsec3<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        let Self {
-            hash_algorithm,
-            flags,
-            iterations,
-            salt,
-            next_owner,
-            types,
-        } = self;
-        Ok(Nsec3::new(
-            hash_algorithm,
-            flags,
-            iterations,
-            salt.try_octets_into().map_err(Into::into)?,
-            next_owner.try_octets_into().map_err(Into::into)?,
-            types.try_octets_into().map_err(Into::into)?,
         ))
     }
 }
@@ -451,6 +432,12 @@ impl<Octs> Nsec3param<Octs> {
         ))
     }
 
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self,
+    ) -> Result<Nsec3param<Target>, Target::Error> {
+        self.convert_octets()
+    }
+
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
         parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
@@ -470,26 +457,6 @@ impl<Octs> Nsec3param<Octs> {
             u8::scan(scanner)?,
             u16::scan(scanner)?,
             Nsec3Salt::scan(scanner)?,
-        ))
-    }
-}
-
-impl<SrcOcts> Nsec3param<SrcOcts> {
-    pub fn flatten_into<Octs>(self) -> Result<Nsec3param<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        let Self {
-            hash_algorithm,
-            flags,
-            iterations,
-            salt,
-        } = self;
-        Ok(Nsec3param::new(
-            hash_algorithm,
-            flags,
-            iterations,
-            salt.try_octets_into().map_err(Into::into)?,
         ))
     }
 }

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -7,7 +7,7 @@
 use crate::base::charstr::CharStr;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
-use crate::base::name::{Dname, ParsedDname, PushError, ToDname};
+use crate::base::name::{FlattenInto, ParsedDname, ToDname};
 use crate::base::net::Ipv4Addr;
 use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData,
@@ -64,11 +64,11 @@ impl A {
         self.addr = addr
     }
 
-    pub fn flatten_into(self) -> Result<A, PushError> {
+    pub(super) fn convert_octets<E>(self) -> Result<Self, E> {
         Ok(self)
     }
 
-    pub(super) fn convert_octets<E>(self) -> Result<Self, E> {
+    pub(super) fn flatten<E>(self) -> Result<Self, E> {
         Ok(self)
     }
 
@@ -252,6 +252,12 @@ impl<Octs> Hinfo<Octs> {
         ))
     }
 
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self,
+    ) -> Result<Hinfo<Target>, Target::Error> {
+        self.convert_octets()
+    }
+
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
         parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
@@ -262,19 +268,6 @@ impl<Octs> Hinfo<Octs> {
         scanner: &mut S,
     ) -> Result<Self, S::Error> {
         Ok(Self::new(scanner.scan_charstr()?, scanner.scan_charstr()?))
-    }
-}
-
-impl<SrcOcts> Hinfo<SrcOcts> {
-    pub fn flatten_into<Octs>(self) -> Result<Hinfo<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        let Self { cpu, os } = self;
-        Ok(Hinfo::new(
-            cpu.try_octets_into().map_err(Into::into)?,
-            os.try_octets_into().map_err(Into::into)?,
-        ))
     }
 }
 
@@ -528,23 +521,20 @@ impl<N> Minfo<N> {
         ))
     }
 
+    pub(super) fn flatten<TargetName>(
+        self,
+    ) -> Result<Minfo<TargetName>, N::AppendError>
+    where N: FlattenInto<TargetName> {
+        Ok(Minfo::new(
+            self.rmailbx.try_flatten_into()?,
+            self.emailbx.try_flatten_into()?,
+        ))
+    }
+
     pub fn scan<S: Scanner<Dname = N>>(
         scanner: &mut S,
     ) -> Result<Self, S::Error> {
         Ok(Self::new(scanner.scan_dname()?, scanner.scan_dname()?))
-    }
-}
-
-impl<Octs: Octets> Minfo<ParsedDname<Octs>> {
-    pub fn flatten_into<Target>(
-        self,
-    ) -> Result<Minfo<Dname<Target>>, PushError>
-    where
-        Target: for<'a> OctetsFrom<Octs::Range<'a>> + FromBuilder,
-        <Target as FromBuilder>::Builder: EmptyBuilder,
-    {
-        let Self { rmailbx, emailbx } = self;
-        Ok(Minfo::new(rmailbx.flatten_into()?, emailbx.flatten_into()?))
     }
 }
 
@@ -559,7 +549,7 @@ impl<Octs> Minfo<ParsedDname<Octs>> {
     }
 }
 
-//--- OctetsFrom
+//--- OctetsFrom and FlattenInto
 
 impl<Name, SrcName> OctetsFrom<Minfo<SrcName>> for Minfo<Name>
 where
@@ -572,6 +562,17 @@ where
             Name::try_octets_from(source.rmailbx)?,
             Name::try_octets_from(source.emailbx)?,
         ))
+    }
+}
+
+impl<Name, TName> FlattenInto<Minfo<TName>> for Minfo<Name>
+where
+    Name: FlattenInto<TName>,
+{
+    type AppendError = Name::AppendError;
+
+    fn try_flatten_into(self) -> Result<Minfo<TName>, Name::AppendError> {
+        self.flatten()
     }
 }
 
@@ -745,24 +746,17 @@ impl<N> Mx<N> {
         Ok(Mx::new(self.preference, self.exchange.try_octets_into()?))
     }
 
+    pub(super) fn flatten<TargetName>(
+        self,
+    ) -> Result<Mx<TargetName>, N::AppendError>
+    where N: FlattenInto<TargetName> {
+        Ok(Mx::new(self.preference, self.exchange.try_flatten_into()?))
+    }
+
     pub fn scan<S: Scanner<Dname = N>>(
         scanner: &mut S,
     ) -> Result<Self, S::Error> {
         Ok(Self::new(u16::scan(scanner)?, scanner.scan_dname()?))
-    }
-}
-
-impl<Octs: Octets> Mx<ParsedDname<Octs>> {
-    pub fn flatten_into<Target>(self) -> Result<Mx<Dname<Target>>, PushError>
-    where
-        Target: for<'a> OctetsFrom<Octs::Range<'a>> + FromBuilder,
-        <Target as FromBuilder>::Builder: EmptyBuilder,
-    {
-        let Self {
-            preference,
-            exchange,
-        } = self;
-        Ok(Mx::new(preference, exchange.flatten_into()?))
     }
 }
 
@@ -774,7 +768,7 @@ impl<Octs> Mx<ParsedDname<Octs>> {
     }
 }
 
-//--- OctetsFrom
+//--- OctetsFrom and FlattenInto
 
 impl<Name, SrcName> OctetsFrom<Mx<SrcName>> for Mx<Name>
 where
@@ -787,6 +781,17 @@ where
             source.preference,
             Name::try_octets_from(source.exchange)?,
         ))
+    }
+}
+
+impl<Name, TName> FlattenInto<Mx<TName>> for Mx<Name>
+where
+    Name: FlattenInto<TName>,
+{
+    type AppendError = Name::AppendError;
+
+    fn try_flatten_into(self) -> Result<Mx<TName>, Name::AppendError> {
+        self.flatten()
     }
 }
 
@@ -1010,6 +1015,12 @@ impl<Octs> Null<Octs> {
             Null::from_octets_unchecked(self.data.try_octets_into()?)
         })
     }
+
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self,
+    ) -> Result<Null<Target>, Target::Error> {
+        self.convert_octets()
+    }
 }
 
 impl<Octs> Null<Octs> {
@@ -1021,19 +1032,6 @@ impl<Octs> Null<Octs> {
             .parse_octets(len)
             .map(|res| unsafe { Self::from_octets_unchecked(res) })
             .map_err(Into::into)
-    }
-}
-
-impl<SrcOcts> Null<SrcOcts> {
-    pub fn flatten_into<Octs>(self) -> Result<Null<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        Ok(unsafe {
-            Null::from_octets_unchecked(
-                self.data.try_octets_into().map_err(Into::into)?,
-            )
-        })
     }
 }
 
@@ -1278,6 +1276,21 @@ impl<N> Soa<N> {
         ))
     }
 
+    pub(super) fn flatten<TargetName>(
+        self,
+    ) -> Result<Soa<TargetName>, N::AppendError>
+    where N: FlattenInto<TargetName> {
+        Ok(Soa::new(
+            self.mname.try_flatten_into()?,
+            self.rname.try_flatten_into()?,
+            self.serial,
+            self.refresh,
+            self.retry,
+            self.expire,
+            self.minimum,
+        ))
+    }
+
     pub fn scan<S: Scanner<Dname = N>>(
         scanner: &mut S,
     ) -> Result<Self, S::Error> {
@@ -1289,35 +1302,6 @@ impl<N> Soa<N> {
             Ttl::scan(scanner)?,
             Ttl::scan(scanner)?,
             Ttl::scan(scanner)?,
-        ))
-    }
-}
-
-impl<Octs> Soa<ParsedDname<Octs>> {
-    pub fn flatten_into<Target>(self) -> Result<Soa<Dname<Target>>, PushError>
-    where
-        Octs: Octets,
-        Target: for<'a> OctetsFrom<Octs::Range<'a>> + FromBuilder,
-        <Target as FromBuilder>::Builder: EmptyBuilder,
-    {
-        let Self {
-            mname,
-            rname,
-            serial,
-            refresh,
-            retry,
-            expire,
-            minimum,
-        } = self;
-
-        Ok(Soa::new(
-            mname.flatten_into()?,
-            rname.flatten_into()?,
-            serial,
-            refresh,
-            retry,
-            expire,
-            minimum,
         ))
     }
 }
@@ -1338,7 +1322,7 @@ impl<Octs> Soa<ParsedDname<Octs>> {
     }
 }
 
-//--- OctetsFrom
+//--- OctetsFrom and FlattenInto
 
 impl<Name, SrcName> OctetsFrom<Soa<SrcName>> for Soa<Name>
 where
@@ -1356,6 +1340,17 @@ where
             source.expire,
             source.minimum,
         ))
+    }
+}
+
+impl<Name, TName> FlattenInto<Soa<TName>> for Soa<Name>
+where
+    Name: FlattenInto<TName>,
+{
+    type AppendError = Name::AppendError;
+
+    fn try_flatten_into(self) -> Result<Soa<TName>, Name::AppendError> {
+        self.flatten()
     }
 }
 
@@ -1735,11 +1730,10 @@ impl<SrcOcts> Txt<SrcOcts> {
         Ok(Txt(self.0.try_octets_into()?))
     }
 
-    pub fn flatten_into<Octs>(self) -> Result<Txt<Octs>, PushError>
-    where
-        Octs: OctetsFrom<SrcOcts>,
-    {
-        Ok(Txt(self.0.try_octets_into().map_err(Into::into)?))
+    pub(super) fn flatten<Octs: OctetsFrom<SrcOcts>>(
+        self,
+    ) -> Result<Txt<Octs>, Octs::Error> {
+        self.convert_octets()
     }
 }
 

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -1110,7 +1110,7 @@ mod test {
                 value::Ipv4Hint::<Octets512>::from_addrs(
                     [
                         [192, 0, 2, 1].into(), [192, 0, 2, 2].into()
-                    ].into_iter()
+                    ]
                 ).unwrap()
             )
         );

--- a/src/rdata/svcb/value.rs
+++ b/src/rdata/svcb/value.rs
@@ -1639,9 +1639,9 @@ mod test {
         assert!(
             alpn.iter().eq(
                 [
-                    br#"f\oo,bar"#.as_ref(),
+                    br"f\oo,bar".as_ref(),
                     b"h2".as_ref(),
-                ].into_iter()
+                ]
             )
         );
     }

--- a/src/rdata/zonemd.rs
+++ b/src/rdata/zonemd.rs
@@ -6,7 +6,6 @@
 
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
-use crate::base::name::PushError;
 use crate::base::rdata::{ComposeRecordData, RecordData};
 use crate::base::scan::{Scan, Scanner};
 use crate::base::serial::Serial;
@@ -114,23 +113,10 @@ impl<Octs> Zonemd<Octs> {
         })
     }
 
-    pub fn flatten_into<OO>(self) -> Result<Zonemd<OO>, PushError>
-    where
-        OO: OctetsFrom<Octs>,
-    {
-        let Zonemd {
-            serial,
-            scheme,
-            algo,
-            digest,
-        } = self;
-
-        Ok(Zonemd {
-            serial,
-            scheme,
-            algo,
-            digest: digest.try_octets_into().map_err(Into::into)?,
-        })
+    pub(super) fn flatten<Target: OctetsFrom<Octs>>(
+        self
+    ) -> Result<Zonemd<Target>, Target::Error> {
+        self.convert_octets()
     }
 
     pub(super) fn convert_octets<Target: OctetsFrom<Octs>>(


### PR DESCRIPTION
This PR moves the `flatten_into` method present on various types that either are or contain domain names into a `FlattenInto` trait.

Turns out that flattening is not only necessary for parsed names as I originally thought but also in chained names such as those produced by the current version of the zonefile parser.

The PR removes the method from all types that aren’t or don’t contain domain names and only had it to be able to make the big record data type enums.

With apologies to @xofyarg who originally proposed this as a trait and, turns out, was right.