### PR TITLE
Add borrow impl for Dname<Vec<u8>>

### DIFF
--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -13,7 +13,7 @@ use super::traits::{ToDname, ToLabelIter};
 use bytes::Bytes;
 use core::ops::{Bound, RangeBounds};
 use core::str::FromStr;
-use core::{cmp, fmt, hash, str};
+use core::{borrow, cmp, fmt, hash, str};
 use octseq::builder::{EmptyBuilder, FreezeBuilder, FromBuilder, Truncate};
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
@@ -832,6 +832,27 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Dname<Octs> {
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Dname<Octs> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Dname({}.)", self)
+    }
+}
+
+//--- Borrow
+
+/// Containers holding `Dname<Vec<u8>>` may be queried either by `Dname<Vec<u8>>` or borrowed
+/// forms. This `Borrow` impl supports user code querying containers with compatible-but-different
+/// types like the following example:
+/// ```
+/// use std::collections::HashMap;
+///
+/// use domain::base::Dname;
+///
+/// fn get_description(hash: &HashMap<Dname<Vec<u8>>, String>) -> Option<&str> {
+///     let lookup_name: &Dname<[u8]> = Dname::from_slice(b"\x03www\x07example\x03com\0").unwrap();
+///     hash.get(lookup_name).map(|x| x.as_ref())
+/// }
+/// ```
+impl<Octs: AsRef<[u8]>> borrow::Borrow<Dname<[u8]>> for Dname<Octs> {
+    fn borrow(&self) -> &Dname<[u8]> {
+        self.for_slice()
     }
 }
 


### PR DESCRIPTION
This impl supports users of `domain` that may use `Dname` as keys in standard library collections, who may want to query those collections with non-owned `Dname`.

Include a doc comment testing that a collection of `Dname<Vec<u8>>` can be queried with a `Dname<[u8]>`.

this comes from talking with @edmonds today, who was trying to do the seemingly-reasonable operation of building a map of `Dname` and associated attributes, then looking entries in that map up from a `Dname` built from a `&[u8]`. unfortunately, i think the best we can do is best-effort implementations of `Borrow` for `T: AsRef<[u8]>` that seem "useful enough"; there would need to be another impl for someone who has made a collection keyed on `Dname<Bytes>`, for example.

~_ideally_ we'd be able to write `impl<Octs: AsRef<[u8]>> Borrow<Dname<[u8]>> for Dname<Octs>`, but `rustc` (unfortunately, correctly), realizes that that permits `impl Borrow<Dname<[u8]>> for Dname<[u8]>`, which conflicts with the [blanket impl of `Borrow<T> for T`](https://doc.rust-lang.org/std/borrow/trait.Borrow.html#impl-Borrow%3CT%3E-for-T) in stdlib. i figured noting that wrinkle is helpful in the doc comment for any future confused souls, but i don't know your appetite for other `Borrow` impls (or this one!) in `domain` itself - users _could_ add a newtype in their code and write an appropriate `Borrow` impl for any owned octet collections they're using in their containers.~

edit: turns out the above issue was trying to write an `impl<Octs: AsRef<[u8]> + ?Sized>`, but `impl<Octs: AsRef<[u8]>` alone is accepted by rustc and looks to do the right things.