### PR TITLE
Apply various Clippy-suggested fixes.

### DIFF
--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -133,7 +133,7 @@ macro_rules! int_enum {
             fn partial_cmp(
                 &self, other: &Self
             ) -> Option<core::cmp::Ordering> {
-                self.to_int().partial_cmp(&other.to_int())
+                Some(self.cmp(other))
             }
         }
 

--- a/src/base/iana/rcode.rs
+++ b/src/base/iana/rcode.rs
@@ -276,7 +276,7 @@ impl cmp::Eq for Rcode {}
 
 impl cmp::PartialOrd for Rcode {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        self.to_int().partial_cmp(&other.to_int())
+        Some(self.cmp(other))
     }
 }
 

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -758,10 +758,7 @@ impl<'a, Octs: Octets + ?Sized> QuestionSection<'a, Octs> {
 
 impl<'a, Octs: ?Sized> Clone for QuestionSection<'a, Octs> {
     fn clone(&self) -> Self {
-        QuestionSection {
-            parser: self.parser,
-            count: self.count,
-        }
+        *self
     }
 }
 
@@ -986,11 +983,7 @@ impl<'a, Octs: Octets + ?Sized> RecordSection<'a, Octs> {
 
 impl<'a, Octs: ?Sized> Clone for RecordSection<'a, Octs> {
     fn clone(&self) -> Self {
-        RecordSection {
-            parser: self.parser,
-            section: self.section,
-            count: self.count,
-        }
+        *self
     }
 }
 

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -376,10 +376,7 @@ impl PartialOrd for Label {
     ///
     /// [RFC 4034]: https://tools.ietf.org/html/rfc4034
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        self.as_slice()
-            .iter()
-            .map(u8::to_ascii_lowercase)
-            .partial_cmp(other.as_slice().iter().map(u8::to_ascii_lowercase))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -1491,22 +1491,27 @@ impl Into<Duration> for Ttl {
 #[cfg(test)]
 mod test {
     #[test]
-    #[cfg(features = "bytes")]
+    #[cfg(feature = "bytes")]
     fn ds_octets_into() {
-        use crate::base::iana::{DigestAlg, Rtype, SecAlg};
-        use crate::name::Dname;
-        use crate::octets::OctetsInto;
+        use super::*;
+        use bytes::Bytes;
+        use octseq::octets::OctetsInto;
+        use crate::base::iana::{DigestAlg, SecAlg};
+        use crate::base::name::Dname;
         use crate::rdata::Ds;
 
         let ds: Record<Dname<&[u8]>, Ds<&[u8]>> = Record::new(
-            "a.example".parse().unwrap(),
+            Dname::from_octets(b"\x01a\x07example\0".as_ref()).unwrap(),
             Class::In,
-            86400,
-            Ds::new(12, SecAlg::RsaSha256, b"something"),
+            Ttl::from_secs(86400),
+            Ds::new(
+                12, SecAlg::RsaSha256, DigestAlg::Sha256,
+                b"something".as_ref(),
+            ).unwrap(),
         );
         let ds_bytes: Record<Dname<Bytes>, Ds<Bytes>> =
-            ds.octets_into().unwrap();
+            ds.clone().octets_into();
         assert_eq!(ds.owner(), ds_bytes.owner());
-        asswer_eq!(ds.data().digest(), ds_bytes.data().digest());
+        assert_eq!(ds.data().digest(), ds_bytes.data().digest());
     }
 }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -1494,20 +1494,23 @@ mod test {
     #[cfg(feature = "bytes")]
     fn ds_octets_into() {
         use super::*;
-        use bytes::Bytes;
-        use octseq::octets::OctetsInto;
         use crate::base::iana::{DigestAlg, SecAlg};
         use crate::base::name::Dname;
         use crate::rdata::Ds;
+        use bytes::Bytes;
+        use octseq::octets::OctetsInto;
 
         let ds: Record<Dname<&[u8]>, Ds<&[u8]>> = Record::new(
             Dname::from_octets(b"\x01a\x07example\0".as_ref()).unwrap(),
             Class::In,
             Ttl::from_secs(86400),
             Ds::new(
-                12, SecAlg::RsaSha256, DigestAlg::Sha256,
+                12,
+                SecAlg::RsaSha256,
+                DigestAlg::Sha256,
                 b"something".as_ref(),
-            ).unwrap(),
+            )
+            .unwrap(),
         );
         let ds_bytes: Record<Dname<Bytes>, Ds<Bytes>> =
             ds.clone().octets_into();


### PR DESCRIPTION
This PR applies various fixes suggested by recently added Clippy lints. As a consequence it also fixes a test that previously was never compiled due to a misspelled cfg attr.