### PR TITLE
Mark function without side effects as must_use

### DIFF
--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -62,6 +62,7 @@ impl CharStr<()> {
 
 impl<Octs: ?Sized> CharStr<Octs> {
     /// Creates a new empty character string.
+    #[must_use]
     pub fn empty() -> Self
     where
         Octs: From<&'static [u8]>,
@@ -103,6 +104,7 @@ impl CharStr<[u8]> {
     }
 
     /// Creates a new empty character string on an octets slice.
+    #[must_use]
     pub fn empty_slice() -> &'static Self {
         unsafe { Self::from_slice_unchecked(b"".as_ref()) }
     }
@@ -113,6 +115,7 @@ impl CharStr<[u8]> {
     ///
     /// The caller has to make sure that `octets` is at most 255 octets
     /// long. Otherwise, the behaviour is undefined.
+    #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         &*(slice as *const [u8] as *const Self)
     }
@@ -139,6 +142,7 @@ impl CharStr<[u8]> {
 
 impl<Octs: ?Sized> CharStr<Octs> {
     /// Creates a new empty builder for this character string type.
+    #[must_use]
     pub fn builder() -> CharStrBuilder<Octs::Builder>
     where
         Octs: IntoBuilder,
@@ -592,11 +596,13 @@ pub struct CharStrBuilder<Builder>(Builder);
 
 impl<Builder: EmptyBuilder> CharStrBuilder<Builder> {
     /// Creates a new empty builder with default capacity.
+    #[must_use]
     pub fn new() -> Self {
         CharStrBuilder(Builder::empty())
     }
 
     /// Creates a new empty builder with the given capacity.
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         CharStrBuilder(Builder::with_capacity(capacity))
     }
@@ -627,11 +633,13 @@ impl<Builder: OctetsBuilder + AsRef<[u8]>> CharStrBuilder<Builder> {
 #[cfg(feature = "std")]
 impl CharStrBuilder<Vec<u8>> {
     /// Creates a new empty characater string builder atop an octets vec.
+    #[must_use]
     pub fn new_vec() -> Self {
         Self::new()
     }
 
     /// Creates a new empty builder atop an octets vec with a given capacity.
+    #[must_use]
     pub fn vec_with_capacity(capacity: usize) -> Self {
         Self::with_capacity(capacity)
     }

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -74,6 +74,7 @@ impl Header {
     /// The new header has all fields as either zero or false. Thus, the
     /// opcode will be [`Opcode::Query`] and the response code will be
     /// [`Rcode::NoError`].
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -83,6 +84,7 @@ impl Header {
     /// # Panics
     ///
     /// This function panics if the slice is less than four octets long.
+    #[must_use]
     pub fn for_message_slice(s: &[u8]) -> &Header {
         assert!(s.len() >= mem::size_of::<Header>());
         unsafe { &*(s.as_ptr() as *const Header) }
@@ -99,6 +101,7 @@ impl Header {
     }
 
     /// Returns a reference to the underlying octets slice.
+    #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         &self.inner
     }
@@ -122,6 +125,7 @@ impl Header {
     )]
     #[cfg_attr(not(feature = "std"), doc = "`set_random_id`")]
     /// can be used for this purpose.
+    #[must_use]
     pub fn id(self) -> u16 {
         u16::from_be_bytes(self.inner[..2].try_into().unwrap())
     }
@@ -138,6 +142,7 @@ impl Header {
     }
 
     /// Returns whether the [QR](Flags::qr) bit is set.
+    #[must_use]
     pub fn qr(self) -> bool {
         self.get_bit(2, 7)
     }
@@ -153,6 +158,7 @@ impl Header {
     /// the [`Opcode`] type for more information on the possible values and
     /// their meaning. Normal queries have the variant [`Opcode::Query`]
     /// which is also the default value when creating a new header.
+    #[must_use]
     pub fn opcode(self) -> Opcode {
         Opcode::from_int((self.inner[2] >> 3) & 0x0F)
     }
@@ -168,6 +174,7 @@ impl Header {
     /// in the header. The returned [`Flags`] type can be useful when you're
     /// working with all flags, rather than a single one, which can be easily
     /// obtained from the header directly.
+    #[must_use]
     pub fn flags(self) -> Flags {
         Flags {
             qr: self.qr(),
@@ -192,6 +199,7 @@ impl Header {
     }
 
     /// Returns whether the [AA](Flags::aa) bit is set.
+    #[must_use]
     pub fn aa(self) -> bool {
         self.get_bit(2, 2)
     }
@@ -202,6 +210,7 @@ impl Header {
     }
 
     /// Returns whether the [TC](Flags::tc) bit is set.
+    #[must_use]
     pub fn tc(self) -> bool {
         self.get_bit(2, 1)
     }
@@ -212,6 +221,7 @@ impl Header {
     }
 
     /// Returns whether the [RD](Flags::rd) bit is set.
+    #[must_use]
     pub fn rd(self) -> bool {
         self.get_bit(2, 0)
     }
@@ -222,6 +232,7 @@ impl Header {
     }
 
     /// Returns whether the [RA](Flags::ra) bit is set.
+    #[must_use]
     pub fn ra(self) -> bool {
         self.get_bit(3, 7)
     }
@@ -234,6 +245,7 @@ impl Header {
     /// Returns whether the reserved bit is set.
     ///
     /// This bit must be `false` in all queries and responses.
+    #[must_use]
     pub fn z(self) -> bool {
         self.get_bit(3, 6)
     }
@@ -244,6 +256,7 @@ impl Header {
     }
 
     /// Returns whether the [AD](Flags::ad) bit is set.
+    #[must_use]
     pub fn ad(self) -> bool {
         self.get_bit(3, 5)
     }
@@ -254,6 +267,7 @@ impl Header {
     }
 
     /// Returns whether the [CD](Flags::cd) bit is set.
+    #[must_use]
     pub fn cd(self) -> bool {
         self.get_bit(3, 4)
     }
@@ -270,6 +284,7 @@ impl Header {
     /// possible values and their meaning.
     ///
     /// [`Rcode`]: ../../iana/rcode/enum.Rcode.html
+    #[must_use]
     pub fn rcode(self) -> Rcode {
         Rcode::from_int(self.inner[3] & 0x0F)
     }
@@ -368,6 +383,7 @@ impl Flags {
     /// Creates new flags.
     ///
     /// All flags will be unset.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -473,6 +489,7 @@ pub struct HeaderCounts {
 ///
 impl HeaderCounts {
     /// Creates a new value with all counters set to zero.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -485,6 +502,7 @@ impl HeaderCounts {
     /// # Panics
     ///
     /// This function panics if the octets slice is shorter than 24 octets.
+    #[must_use]
     pub fn for_message_slice(message: &[u8]) -> &Self {
         assert!(message.len() >= mem::size_of::<HeaderSection>());
         unsafe {
@@ -510,6 +528,7 @@ impl HeaderCounts {
     }
 
     /// Returns a reference to the raw octets slice of the header counts.
+    #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         &self.inner
     }
@@ -534,6 +553,7 @@ impl HeaderCounts {
     ///
     /// This field contains the number of questions in the first
     /// section of the message, normally the question section.
+    #[must_use]
     pub fn qdcount(self) -> u16 {
         self.get_u16(0)
     }
@@ -572,6 +592,7 @@ impl HeaderCounts {
     ///
     /// This field contains the number of resource records in the second
     /// section of the message, normally the answer section.
+    #[must_use]
     pub fn ancount(self) -> u16 {
         self.get_u16(2)
     }
@@ -610,6 +631,7 @@ impl HeaderCounts {
     ///
     /// This field contains the number of resource records in the third
     /// section of the message, normally the authority section.
+    #[must_use]
     pub fn nscount(self) -> u16 {
         self.get_u16(4)
     }
@@ -648,6 +670,7 @@ impl HeaderCounts {
     ///
     /// This field contains the number of resource records in the fourth
     /// section of the message, normally the additional section.
+    #[must_use]
     pub fn arcount(self) -> u16 {
         self.get_u16(6)
     }
@@ -688,6 +711,7 @@ impl HeaderCounts {
     ///
     /// This is the same as the `qdcount()`. It is used in UPDATE queries
     /// where the first section is the zone section.
+    #[must_use]
     pub fn zocount(self) -> u16 {
         self.qdcount()
     }
@@ -701,6 +725,7 @@ impl HeaderCounts {
     ///
     /// This is the same as the `ancount()`. It is used in UPDATE queries
     /// where the first section is the prerequisite section.
+    #[must_use]
     pub fn prcount(self) -> u16 {
         self.ancount()
     }
@@ -714,6 +739,7 @@ impl HeaderCounts {
     ///
     /// This is the same as the `nscount()`. It is used in UPDATE queries
     /// where the first section is the update section.
+    #[must_use]
     pub fn upcount(self) -> u16 {
         self.nscount()
     }
@@ -727,6 +753,7 @@ impl HeaderCounts {
     ///
     /// This is the same as the `arcount()`. It is used in UPDATE queries
     /// where the first section is the additional section.
+    #[must_use]
     pub fn adcount(self) -> u16 {
         self.arcount()
     }
@@ -773,6 +800,7 @@ impl HeaderSection {
     ///
     /// The value will have all header and header counts fields set to zero
     /// or false.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -782,6 +810,7 @@ impl HeaderSection {
     /// # Panics
     ///
     /// This function panics if the octets slice is shorter than 12 octets.
+    #[must_use]
     pub fn for_message_slice(s: &[u8]) -> &HeaderSection {
         assert!(s.len() >= mem::size_of::<HeaderSection>());
         unsafe { &*(s.as_ptr() as *const HeaderSection) }
@@ -798,6 +827,7 @@ impl HeaderSection {
     }
 
     /// Returns a reference to the underlying octets slice.
+    #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         &self.inner
     }
@@ -807,6 +837,7 @@ impl HeaderSection {
 ///
 impl HeaderSection {
     /// Returns a reference to the header.
+    #[must_use]
     pub fn header(&self) -> &Header {
         Header::for_message_slice(&self.inner)
     }
@@ -817,6 +848,7 @@ impl HeaderSection {
     }
 
     /// Returns a reference to the header counts.
+    #[must_use]
     pub fn counts(&self) -> &HeaderCounts {
         HeaderCounts::for_message_slice(&self.inner)
     }

--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -22,6 +22,7 @@ macro_rules! int_enum {
 
         impl $ianatype {
             /// Returns a value from its raw integer value.
+            #[must_use]
             pub const fn from_int(value: $inttype) -> Self {
                 match value {
                     $( $value => $ianatype::$variant ),*,
@@ -30,6 +31,7 @@ macro_rules! int_enum {
             }
 
             /// Returns the raw integer value for a value.
+            #[must_use]
             pub const fn to_int(self) -> $inttype {
                 match self {
                     $( $ianatype::$variant => $value ),*,
@@ -38,6 +40,7 @@ macro_rules! int_enum {
             }
 
             /// Returns a value from a well-defined mnemonic.
+            #[must_use]
             pub fn from_mnemonic(m: &[u8]) -> Option<Self> {
                 $(
                     if m.eq_ignore_ascii_case($mnemonic) {
@@ -51,6 +54,7 @@ macro_rules! int_enum {
             ///
             /// This will also return a mnemonic if a well-defined variant
             /// is hidden in a `Int` variant.
+            #[must_use]
             pub const fn to_mnemonic(self) -> Option<&'static [u8]> {
                 match self {
                     $( $ianatype::$variant => Some($mnemonic) ),*,
@@ -224,6 +228,7 @@ macro_rules! int_enum_str_mnemonics_only {
 macro_rules! int_enum_str_decimal {
     ($ianatype:ident, $inttype:ident) => {
         impl $ianatype {
+            #[must_use]
             pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
                 core::str::from_utf8(bytes)
                     .ok()
@@ -284,6 +289,7 @@ macro_rules! int_enum_str_decimal {
 macro_rules! int_enum_str_with_decimal {
     ($ianatype:ident, $inttype:ident, $error:expr) => {
         impl $ianatype {
+            #[must_use]
             pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
                 $ianatype::from_mnemonic(bytes).or_else(|| {
                     core::str::from_utf8(bytes)
@@ -379,6 +385,7 @@ macro_rules! int_enum_str_with_prefix {
     ($ianatype:ident, $str_prefix:expr, $u8_prefix:expr, $inttype:ident,
      $error:expr) => {
         impl $ianatype {
+            #[must_use]
             pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
                 $ianatype::from_mnemonic(bytes).or_else(|| {
                     if bytes.len() <= $u8_prefix.len() {

--- a/src/base/iana/rcode.rs
+++ b/src/base/iana/rcode.rs
@@ -170,6 +170,7 @@ impl Rcode {
     /// Creates an rcode from an integer.
     ///
     /// Only the lower four bits of `value` are considered.
+    #[must_use]
     pub fn from_int(value: u8) -> Rcode {
         use self::Rcode::*;
 
@@ -190,6 +191,7 @@ impl Rcode {
     }
 
     /// Returns the integer value for this rcode.
+    #[must_use]
     pub fn to_int(self) -> u8 {
         use self::Rcode::*;
 
@@ -503,6 +505,7 @@ impl OptRcode {
     /// Creates an rcode from an integer.
     ///
     /// Only the lower twelve bits of `value` are considered.
+    #[must_use]
     pub fn from_int(value: u16) -> OptRcode {
         use self::OptRcode::*;
 
@@ -525,6 +528,7 @@ impl OptRcode {
     }
 
     /// Returns the integer value for this rcode.
+    #[must_use]
     pub fn to_int(self) -> u16 {
         use self::OptRcode::*;
 
@@ -547,22 +551,26 @@ impl OptRcode {
     }
 
     /// Creates an extended rcode value from its parts.
+    #[must_use]
     pub fn from_parts(rcode: Rcode, ext: u8) -> OptRcode {
         OptRcode::from_int(u16::from(ext) << 4 | u16::from(rcode.to_int()))
     }
 
     /// Returns the two parts of an extended rcode value.
+    #[must_use]
     pub fn to_parts(self) -> (Rcode, u8) {
         let res = self.to_int();
         (Rcode::from_int(res as u8), (res >> 8) as u8)
     }
 
     /// Returns the rcode part of the extended rcode.
+    #[must_use]
     pub fn rcode(self) -> Rcode {
         self.to_parts().0
     }
 
     /// Returns the extended octet of the extended rcode.
+    #[must_use]
     pub fn ext(self) -> u8 {
         self.to_parts().1
     }

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -729,6 +729,7 @@ impl<'a, Octs: Octets + ?Sized> QuestionSection<'a, Octs> {
     }
 
     /// Returns the current position relative to the beginning of the message.
+    #[must_use]
     pub fn pos(&self) -> usize {
         self.parser.pos()
     }
@@ -828,6 +829,7 @@ pub enum Section {
 
 impl Section {
     /// Returns the first section.
+    #[must_use]
     pub fn first() -> Self {
         Section::Answer
     }
@@ -908,6 +910,7 @@ impl<'a, Octs: Octets + ?Sized> RecordSection<'a, Octs> {
     }
 
     /// Returns the current position relative to the beginning of the message.
+    #[must_use]
     pub fn pos(&self) -> usize {
         self.parser.pos()
     }
@@ -927,6 +930,7 @@ impl<'a, Octs: Octets + ?Sized> RecordSection<'a, Octs> {
     /// [`ParseRecordData`]: ../rdata/trait.ParseRecordData.html
     /// [`ParsedDname`]: ../name/struct.ParsedDname.html
     /// [domain::rdata::parsed]: ../../rdata/parsed/index.html
+    #[must_use]
     pub fn limit_to<Data: ParseRecordData<'a, Octs>>(
         self,
     ) -> RecordIter<'a, Octs, Data> {
@@ -939,6 +943,7 @@ impl<'a, Octs: Octets + ?Sized> RecordSection<'a, Octs> {
     /// of class IN.
     ///
     /// [`limit_to`]: #method.limit_to
+    #[must_use]
     pub fn limit_to_in<Data: ParseRecordData<'a, Octs>>(
         self,
     ) -> RecordIter<'a, Octs, Data> {
@@ -1089,6 +1094,7 @@ where
     ///
     /// The returned iterator will continue right after the last record
     /// previously returned.
+    #[must_use]
     pub fn unwrap(self) -> RecordSection<'a, Octs> {
         self.section
     }

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -196,6 +196,7 @@ impl<Target: OctetsBuilder + Truncate> MessageBuilder<Target> {
 #[cfg(feature = "std")]
 impl MessageBuilder<Vec<u8>> {
     /// Creates a new message builder atop a `Vec<u8>`.
+    #[must_use]
     pub fn new_vec() -> Self {
         infallible(Self::from_target(Vec::new()))
     }
@@ -204,6 +205,7 @@ impl MessageBuilder<Vec<u8>> {
 #[cfg(feature = "std")]
 impl MessageBuilder<StreamTarget<Vec<u8>>> {
     /// Creates a new builder for a streamable message atop a `Vec<u8>`.
+    #[must_use]
     pub fn new_stream_vec() -> Self {
         Self::from_target(StreamTarget::new_vec()).unwrap()
     }
@@ -1577,6 +1579,7 @@ impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
     /// This field contains the largest UDP datagram the sender can accept.
     /// This is not the path MTU but really what the sender can work with
     /// internally.
+    #[must_use]
     pub fn udp_payload_size(&self) -> u16 {
         self.opt_header().udp_payload_size()
     }
@@ -1590,6 +1593,7 @@ impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
     ///
     /// The method assembles the rcode both from the message header and the
     /// OPT header.
+    #[must_use]
     pub fn rcode(&self) -> OptRcode {
         self.opt_header()
             .rcode(*Header::for_message_slice(self.target.as_ref()))
@@ -1607,6 +1611,7 @@ impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
     /// Returns the EDNS version of the OPT header.
     ///
     /// Only EDNS version 0 is currently defined.
+    #[must_use]
     pub fn version(&self) -> u8 {
         self.opt_header().version()
     }
@@ -1624,6 +1629,7 @@ impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
     /// [RFC 3225].
     ///
     /// [RFC 3225]: https://tools.ietf.org/html/rfc3225
+    #[must_use]
     pub fn dnssec_ok(&self) -> bool {
         self.opt_header().dnssec_ok()
     }
@@ -1681,6 +1687,7 @@ impl<Target: Composer> StreamTarget<Target> {
 #[cfg(feature = "std")]
 impl StreamTarget<Vec<u8>> {
     /// Creates a stream target atop an empty `Vec<u8>`.
+    #[must_use]
     pub fn new_vec() -> Self {
         infallible(Self::new(Vec::new()))
     }

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -58,6 +58,7 @@ impl<Builder> DnameBuilder<Builder> {
     }
 
     /// Creates a new, empty name builder.
+    #[must_use]
     pub fn new() -> Self
     where
         Builder: EmptyBuilder,
@@ -66,6 +67,7 @@ impl<Builder> DnameBuilder<Builder> {
     }
 
     /// Creates a new, empty builder with a given capacity.
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self
     where
         Builder: EmptyBuilder,
@@ -93,6 +95,7 @@ impl<Builder> DnameBuilder<Builder> {
 #[cfg(feature = "std")]
 impl DnameBuilder<Vec<u8>> {
     /// Creates an empty domain name builder atop a `Vec<u8>`.
+    #[must_use]
     pub fn new_vec() -> Self {
         Self::new()
     }
@@ -101,6 +104,7 @@ impl DnameBuilder<Vec<u8>> {
     ///
     /// Names are limited to a length of 255 octets, but you can provide any
     /// capacity you like here.
+    #[must_use]
     pub fn vec_with_capacity(capacity: usize) -> Self {
         Self::with_capacity(capacity)
     }

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -174,6 +174,7 @@ impl<Octs> Dname<Octs> {
     /// [`root_ref`]: #method.root_ref
     /// [`root_vec`]: #method.root_vec
     /// [`root_bytes`]: #method.root_bytes
+    #[must_use]
     pub fn root() -> Self
     where
         Octs: From<&'static [u8]>,
@@ -209,6 +210,7 @@ impl Dname<[u8]> {
     }
 
     /// Creates a domain name for the root label only atop an octets slice.
+    #[must_use]
     pub fn root_slice() -> &'static Self {
         unsafe { Self::from_slice_unchecked("\0".as_ref()) }
     }
@@ -238,6 +240,7 @@ impl Dname<[u8]> {
 
 impl Dname<&'static [u8]> {
     /// Creates a domain name for the root label only atop a slice reference.
+    #[must_use]
     pub fn root_ref() -> Self {
         Self::root()
     }
@@ -246,6 +249,7 @@ impl Dname<&'static [u8]> {
 #[cfg(feature = "std")]
 impl Dname<Vec<u8>> {
     /// Creates a domain name for the root label only atop a `Vec<u8>`.
+    #[must_use]
     pub fn root_vec() -> Self {
         Self::root()
     }

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -65,11 +65,13 @@ impl Label {
     /// Returns a static reference to the root label.
     ///
     /// The root label is an empty label.
+    #[must_use]
     pub fn root() -> &'static Self {
         unsafe { Self::from_slice_unchecked(b"") }
     }
 
     /// Returns a static reference to the wildcard label `"*"`.
+    #[must_use]
     pub fn wildcard() -> &'static Self {
         unsafe { Self::from_slice_unchecked(b"*") }
     }
@@ -196,11 +198,13 @@ impl Label {
     /// # Panics
     ///
     /// Panics if `start` is beyond the end of `slice`.
+    #[must_use]
     pub fn iter_slice(slice: &[u8], start: usize) -> SliceLabelsIter {
         SliceLabelsIter { slice, start }
     }
 
     /// Returns a reference to the underlying octets slice.
+    #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         unsafe { &*(self as *const Self as *const [u8]) }
     }
@@ -240,6 +244,7 @@ impl Label {
     /// Returns the label in canonical form.
     ///
     /// In this form, all ASCII letters are lowercase.
+    #[must_use]
     pub fn to_canonical(&self) -> OwnedLabel {
         let mut res = OwnedLabel::from_label(self);
         res.make_canonical();
@@ -247,6 +252,7 @@ impl Label {
     }
 
     /// Returns the composed label ordering.
+    #[must_use]
     pub fn composed_cmp(&self, other: &Self) -> cmp::Ordering {
         match self.0.len().cmp(&other.0.len()) {
             cmp::Ordering::Equal => {}
@@ -256,6 +262,7 @@ impl Label {
     }
 
     /// Returns the composed ordering with ASCII letters lowercased.
+    #[must_use]
     pub fn lowercase_composed_cmp(&self, other: &Self) -> cmp::Ordering {
         match self.0.len().cmp(&other.0.len()) {
             cmp::Ordering::Equal => {}
@@ -300,21 +307,25 @@ impl Label {
     ///
     /// This length is that of the label’s content only. It will _not_ contain
     /// the initial label length octet present in the wire format.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.as_slice().len()
     }
 
     /// Returns whether this is the empty label.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.as_slice().is_empty()
     }
 
     /// Returns whether the label is the root label.
+    #[must_use]
     pub fn is_root(&self) -> bool {
         self.is_empty()
     }
 
     /// Returns whether the label is the wildcard label.
+    #[must_use]
     pub fn is_wildcard(&self) -> bool {
         self.0.len() == 1 && self.0[0] == b'*'
     }
@@ -323,6 +334,7 @@ impl Label {
     ///
     /// This length is one more than the length of the label as their is a
     /// leading length octet.
+    #[must_use]
     pub fn compose_len(&self) -> u16 {
         u16::try_from(self.len()).expect("long label") + 1
     }
@@ -452,6 +464,7 @@ pub struct OwnedLabel([u8; 64]);
 
 impl OwnedLabel {
     /// Creates a new owned label from an existing label.
+    #[must_use]
     pub fn from_label(label: &Label) -> Self {
         let mut res = [0; 64];
         res[0] = label.len() as u8;
@@ -488,6 +501,7 @@ impl OwnedLabel {
     }
 
     /// Returns a reference to the label.
+    #[must_use]
     pub fn as_label(&self) -> &Label {
         unsafe {
             Label::from_slice_unchecked(&self.0[1..=(self.0[0] as usize)])
@@ -501,6 +515,7 @@ impl OwnedLabel {
     }
 
     /// Returns a slice that is the wire-representation of the label.
+    #[must_use]
     pub fn as_wire_slice(&self) -> &[u8] {
         let len = self.0[0] as usize;
         &self.0[..=len]

--- a/src/base/name/parsed.rs
+++ b/src/base/name/parsed.rs
@@ -104,6 +104,7 @@ impl<Octs> ParsedDname<Octs> {
 }
 
 impl<'a, Octs: Octets + ?Sized> ParsedDname<&'a Octs> {
+    #[must_use]
     pub fn deref_octets(&self) -> ParsedDname<Octs::Range<'a>> {
         ParsedDname {
             octets: self.octets.range(..),

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -73,6 +73,7 @@ impl<Octs> RelativeDname<Octs> {
     }
 
     /// Creates an empty relative domain name.
+    #[must_use]
     pub fn empty() -> Self
     where
         Octs: From<&'static [u8]>,
@@ -86,6 +87,7 @@ impl<Octs> RelativeDname<Octs> {
     /// rules for names with wildcard labels. Note that the comparison traits
     /// implemented for domain names do *not* consider wildcards and treat
     /// them as regular labels.
+    #[must_use]
     pub fn wildcard() -> Self
     where
         Octs: From<&'static [u8]>,
@@ -151,10 +153,12 @@ impl RelativeDname<[u8]> {
     }
 
     /// Returns an empty relative name atop a unsized slice.
+    #[must_use]
     pub fn empty_slice() -> &'static Self {
         unsafe { Self::from_slice_unchecked(b"") }
     }
 
+    #[must_use]
     pub fn wildcard_slice() -> &'static Self {
         unsafe { Self::from_slice_unchecked(b"\x01*") }
     }
@@ -179,11 +183,13 @@ impl RelativeDname<[u8]> {
 
 impl RelativeDname<&'static [u8]> {
     /// Creates an empty relative name atop a slice reference.
+    #[must_use]
     pub fn empty_ref() -> Self {
         Self::empty()
     }
 
     /// Creates a wildcard relative name atop a slice reference.
+    #[must_use]
     pub fn wildcard_ref() -> Self {
         Self::wildcard()
     }
@@ -192,11 +198,13 @@ impl RelativeDname<&'static [u8]> {
 #[cfg(feature = "std")]
 impl RelativeDname<Vec<u8>> {
     /// Creates an empty relative name atop a `Vec<u8>`.
+    #[must_use]
     pub fn empty_vec() -> Self {
         Self::empty()
     }
 
     /// Creates a wildcard relative name atop a `Vec<u8>`.
+    #[must_use]
     pub fn wildcard_vec() -> Self {
         Self::wildcard()
     }

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -45,6 +45,7 @@ impl<Octets> UncertainDname<Octets> {
     }
 
     /// Creates a new uncertain domain name containing the root label only.
+    #[must_use]
     pub fn root() -> Self
     where
         Octets: From<&'static [u8]>,
@@ -53,6 +54,7 @@ impl<Octets> UncertainDname<Octets> {
     }
 
     /// Creates a new uncertain yet empty domain name.
+    #[must_use]
     pub fn empty() -> Self
     where
         Octets: From<&'static [u8]>,
@@ -147,11 +149,13 @@ impl<Octets> UncertainDname<Octets> {
 
 impl UncertainDname<&'static [u8]> {
     /// Creates an empty relative name atop a slice reference.
+    #[must_use]
     pub fn empty_ref() -> Self {
         Self::empty()
     }
 
     /// Creates an absolute name that is the root label atop a slice reference.
+    #[must_use]
     pub fn root_ref() -> Self {
         Self::root()
     }
@@ -160,11 +164,13 @@ impl UncertainDname<&'static [u8]> {
 #[cfg(feature = "std")]
 impl UncertainDname<Vec<u8>> {
     /// Creates an empty relative name atop a `Vec<u8>`.
+    #[must_use]
     pub fn empty_vec() -> Self {
         Self::empty()
     }
 
     /// Creates an absolute name from the root label atop a `Vec<u8>`.
+    #[must_use]
     pub fn root_vec() -> Self {
         Self::root()
     }

--- a/src/base/opt/algsig.rs
+++ b/src/base/opt/algsig.rs
@@ -150,6 +150,7 @@ impl<Variant> Understood<Variant, [u8]> {
     ///
     /// The caller needs to make sure that the slice contains a sequence of
     /// 16 bit values that is no longer than 65,535 octets.
+    #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         &*(slice as *const [u8] as *const Self)
     }

--- a/src/base/opt/cookie.rs
+++ b/src/base/opt/cookie.rs
@@ -67,6 +67,7 @@ pub struct Cookie {
 
 impl Cookie {
     /// Creates a new cookie from client and optional server cookie.
+    #[must_use]
     pub fn new(
         client: ClientCookie,
         server: Option<ServerCookie>
@@ -75,11 +76,13 @@ impl Cookie {
     }
 
     /// Returns the client cookie.
+    #[must_use]
     pub fn client(&self) -> ClientCookie {
         self.client
     }
 
     /// Returns a reference to the server cookie if present.
+    #[must_use]
     pub fn server(&self) -> Option<&ServerCookie> {
         self.server.as_ref()
     }
@@ -128,6 +131,7 @@ impl Cookie {
 
     /// Creates a random client cookie for including in an initial request.
     #[cfg(feature = "rand")]
+    #[must_use]
     pub fn create_initial() -> Self {
         Self::new(ClientCookie::new_random(), None)
     }
@@ -265,17 +269,20 @@ pub struct ClientCookie([u8; 8]);
 
 impl ClientCookie {
     /// Creates a new client cookie from the given octets.
+    #[must_use]
     pub const fn from_octets(octets: [u8; 8]) -> Self {
         Self(octets)
     }
 
     /// Creates a new random client cookie.
     #[cfg(feature = "rand")]
+    #[must_use]
     pub fn new_random() -> Self {
         Self(rand::random())
     }
 
     /// Converts the cookie into its octets.
+    #[must_use]
     pub fn into_octets(self) -> [u8; 8] {
         self.0
     }
@@ -385,6 +392,7 @@ impl ServerCookie {
     ///
     /// The function panics if `octets` is shorter than 8 octets or longer
     /// than 32.
+    #[must_use]
     pub fn from_octets(slice: &[u8]) -> Self {
         assert!(slice.len() >= 8, "server cookie shorter than 8 octets");
         let mut res = Array::new();
@@ -428,6 +436,7 @@ impl ServerCookie {
     }
 
     /// Returns the length of the wire format of the cookie.
+    #[must_use]
     pub fn compose_len(&self) -> u16 {
         u16::try_from(self.0.len()).expect("long server cookie")
     }
@@ -496,6 +505,7 @@ pub struct StandardServerCookie(
 
 impl StandardServerCookie {
     /// Creates a new server cookie from the provided components.
+    #[must_use]
     pub fn new(
         version: u8,
         reserved: [u8; 3],
@@ -528,16 +538,19 @@ impl StandardServerCookie {
     }
 
     /// Returns the version field of the cookie.
+    #[must_use]
     pub fn version(self) -> u8 {
         self.0[0]
     }
 
     /// Returns the reserved field of the cookie.
+    #[must_use]
     pub fn reserved(self) -> [u8; 3] {
         TryFrom::try_from(&self.0[1..4]).expect("bad slicing")
     }
 
     /// Returns the timestamp field of the cookie.
+    #[must_use]
     pub fn timestamp(self) -> Serial {
         Serial::from_be_bytes(
             TryFrom::try_from(&self.0[4..8]).expect("bad slicing")
@@ -545,6 +558,7 @@ impl StandardServerCookie {
     }
 
     /// Returns the hash field of the cookie.
+    #[must_use]
     pub fn hash(self) -> [u8; 8] {
         TryFrom::try_from(&self.0[8..]).expect("bad slicing")
     }

--- a/src/base/opt/expire.rs
+++ b/src/base/opt/expire.rs
@@ -33,11 +33,13 @@ pub struct Expire(Option<u32>);
 
 impl Expire {
     /// Creates a new expire option with the given optional expire value.
+    #[must_use]
     pub fn new(expire: Option<u32>) -> Self {
         Expire(expire)
     }
 
     /// Returns the content of the optional expire value.
+    #[must_use]
     pub fn expire(self) -> Option<u32> {
         self.0
     }

--- a/src/base/opt/keepalive.rs
+++ b/src/base/opt/keepalive.rs
@@ -34,11 +34,13 @@ pub struct TcpKeepalive(Option<IdleTimeout>);
 
 impl TcpKeepalive {
     /// Creates a new value from an optional idle timeout.
+    #[must_use]
     pub fn new(timeout: Option<IdleTimeout>) -> Self {
         TcpKeepalive(timeout)
     }
 
     /// Returns the idle timeout.
+    #[must_use]
     pub fn timeout(self) -> Option<IdleTimeout> {
         self.0
     }

--- a/src/base/opt/keytag.rs
+++ b/src/base/opt/keytag.rs
@@ -81,6 +81,7 @@ impl KeyTag<[u8]> {
     /// The caller needs to ensure that `slice` contains a valid key tag. The
     /// length needs to be an even number of octets and no longer than
     /// 65,536 octets.
+    #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         &*(slice as *const [u8] as *const Self)
     }

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -305,6 +305,7 @@ pub struct OptHeader {
 
 impl OptHeader {
     /// Returns a reference to an OPT header pointing into a record’s octets.
+    #[must_use]
     pub fn for_record_slice(slice: &[u8]) -> &OptHeader {
         assert!(slice.len() >= mem::size_of::<Self>());
         unsafe { &*(slice.as_ptr() as *const OptHeader) }
@@ -323,6 +324,7 @@ impl OptHeader {
     /// This value refers to the abilities of the sender’s DNS implementation,
     /// not such things as network MTUs. Which means that the largest UDP
     /// payload that can actually be sent back to the sender may be smaller.
+    #[must_use]
     pub fn udp_payload_size(&self) -> u16 {
         u16::from_be_bytes(self.inner[3..5].try_into().unwrap())
     }
@@ -336,6 +338,7 @@ impl OptHeader {
     ///
     /// Some of the bits of the rcode are stored in the regular message
     /// header. Such a header needs to be passed to the method.
+    #[must_use]
     pub fn rcode(&self, header: Header) -> OptRcode {
         OptRcode::from_parts(header.rcode(), self.inner[5])
     }
@@ -351,6 +354,7 @@ impl OptHeader {
     /// Returns the EDNS version of the OPT header.
     ///
     /// Only EDNS version 0 is currently defined.
+    #[must_use]
     pub fn version(&self) -> u8 {
         self.inner[6]
     }
@@ -368,6 +372,7 @@ impl OptHeader {
     /// [RFC 3225].
     ///
     /// [RFC 3225]: https://tools.ietf.org/html/rfc3225
+    #[must_use]
     pub fn dnssec_ok(&self) -> bool {
         self.inner[7] & 0x80 != 0
     }
@@ -535,16 +540,19 @@ pub struct OptionHeader {
 #[allow(clippy::len_without_is_empty)]
 impl OptionHeader {
     /// Creates a new option header from code and length.
+    #[must_use]
     pub fn new(code: u16, len: u16) -> Self {
         OptionHeader { code, len }
     }
 
     /// Returns the option code.
+    #[must_use]
     pub fn code(self) -> u16 {
         self.code
     }
 
     /// Returns the length of the option data.
+    #[must_use]
     pub fn len(self) -> u16 {
         self.len
     }
@@ -817,6 +825,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for UnknownOptData<Octs> {
 pub struct LongOptData(());
 
 impl LongOptData {
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         "option data too long"
     }

--- a/src/base/opt/nsid.rs
+++ b/src/base/opt/nsid.rs
@@ -86,11 +86,13 @@ impl Nsid<[u8]> {
     ///
     /// The caller has to make sure that `octets` is no longer than 65,535
     /// octets.
+    #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         &*(slice as *const [u8] as *const Self)
     }
 
     /// Creates an empty NSID option value.
+    #[must_use]
     pub fn empty() -> &'static Self {
         unsafe { Self::from_slice_unchecked(b"") }
     }

--- a/src/base/opt/subnet.rs
+++ b/src/base/opt/subnet.rs
@@ -56,6 +56,7 @@ impl ClientSubnet {
     /// illegal values. That is, it limit the prefix lengths given to a number
     /// meaningful for the address family. It will also set all bits not
     /// covered by the source prefix length in the address to zero.
+    #[must_use]
     pub fn new(
         source_prefix_len: u8,
         scope_prefix_len: u8,
@@ -76,6 +77,7 @@ impl ClientSubnet {
     ///
     /// The source prefix length is the prefix length as specified by the
     /// client in a query.
+    #[must_use]
     pub fn source_prefix_len(&self) -> u8 {
         self.source_prefix_len
     }
@@ -84,11 +86,13 @@ impl ClientSubnet {
     ///
     /// The scope prefix length is the prefix length used by the server for
     /// its answer.
+    #[must_use]
     pub fn scope_prefix_len(&self) -> u8 {
         self.scope_prefix_len
     }
 
     /// Returns the address.
+    #[must_use]
     pub fn addr(&self) -> IpAddr {
         self.addr
     }

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -448,6 +448,7 @@ impl<Octs: AsRef<[u8]>> fmt::Debug for UnknownRecordData<Octs> {
 pub struct LongRecordData();
 
 impl LongRecordData {
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         "record data too long"
     }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -820,6 +820,7 @@ impl<'a, Octs: Octets + ?Sized> ParsedRecord<'a, Octs> {
     ///
     /// The record data is provided via a parser that is positioned at the
     /// first byte of the record data.
+    #[must_use]
     pub fn new(
         header: RecordHeader<ParsedDname<&'a Octs>>,
         data: Parser<'a, Octs>,
@@ -828,26 +829,31 @@ impl<'a, Octs: Octets + ?Sized> ParsedRecord<'a, Octs> {
     }
 
     /// Returns a reference to the owner of the record.
+    #[must_use]
     pub fn owner(&self) -> ParsedDname<&'a Octs> {
         *self.header.owner()
     }
 
     /// Returns the record type of the record.
+    #[must_use]
     pub fn rtype(&self) -> Rtype {
         self.header.rtype()
     }
 
     /// Returns the class of the record.
+    #[must_use]
     pub fn class(&self) -> Class {
         self.header.class()
     }
 
     /// Returns the TTL of the record.
+    #[must_use]
     pub fn ttl(&self) -> Ttl {
         self.header.ttl()
     }
 
     /// Returns the data length of the record.
+    #[must_use]
     pub fn rdlen(&self) -> u16 {
         self.header.rdlen()
     }

--- a/src/base/scan.rs
+++ b/src/base/scan.rs
@@ -577,6 +577,7 @@ impl Symbol {
     /// represent ASCII spaces, quotes, backslashes, and semicolons and the
     /// plain ASCII value for all other printable ASCII characters. Any other
     /// value is escaped using the decimal escape sequence.
+    #[must_use]
     pub fn from_octet(ch: u8) -> Self {
         if ch == b' ' || ch == b'"' || ch == b'\\' || ch == b';' {
             Symbol::SimpleEscape(ch)
@@ -666,6 +667,7 @@ impl Symbol {
     /// This is true for all symbols other than unescaped ASCII space and
     /// horizontal tabs, opening and closing parentheses, semicolon, and
     /// double quote.
+    #[must_use]
     pub fn is_word_char(self) -> bool {
         match self {
             Symbol::Char(ch) => {
@@ -1010,6 +1012,7 @@ pub(super) enum SymbolCharsEnum {
 
 impl SymbolCharsError {
     /// Returns a static description of the error.
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         match self.0 {
             SymbolCharsEnum::BadEscape => "illegale escape sequence",
@@ -1050,6 +1053,7 @@ enum SymbolOctetsEnum {
 }
 
 impl SymbolOctetsError {
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         match self.0 {
             SymbolOctetsEnum::BadUtf8 => "illegal UTF-8 sequence",
@@ -1093,6 +1097,7 @@ enum BadSymbolEnum {
 
 impl BadSymbol {
     /// Returns a static description of the error.
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         match self.0 {
             BadSymbolEnum::NonAscii => "non-ASCII symbol",

--- a/src/base/serial.rs
+++ b/src/base/serial.rs
@@ -53,6 +53,7 @@ pub struct Serial(pub u32);
 impl Serial {
     /// Returns a serial number for the current Unix time.
     #[cfg(feature = "std")]
+    #[must_use]
     pub fn now() -> Self {
         let now = SystemTime::now();
         let value = match now.duration_since(UNIX_EPOCH) {
@@ -63,11 +64,13 @@ impl Serial {
     }
 
     /// Creates a new serial number from its octets in big endian notation.
+    #[must_use]
     pub fn from_be_bytes(bytes: [u8; 4]) -> Self {
         Self(u32::from_be_bytes(bytes))
     }
 
     /// Returns the serial number as a raw integer.
+    #[must_use]
     pub fn into_int(self) -> u32 {
         self.0
     }
@@ -83,6 +86,7 @@ impl Serial {
     ///
     /// This method panics if `other` is greater than `2^31 - 1`.
     #[allow(clippy::should_implement_trait)]
+    #[must_use]
     pub fn add(self, other: u32) -> Self {
         assert!(other <= 0x7FFF_FFFF);
         Serial(self.0.wrapping_add(other))

--- a/src/base/wire.rs
+++ b/src/base/wire.rs
@@ -297,6 +297,7 @@ pub enum ParseError {
 
 impl ParseError {
     /// Creates a new parse error as a form error with the given message.
+    #[must_use]
     pub fn form_error(msg: &'static str) -> Self {
         FormError::new(msg).into()
     }
@@ -342,6 +343,7 @@ pub struct FormError(&'static str);
 
 impl FormError {
     /// Creates a new form error value with the given diagnostics string.
+    #[must_use]
     pub fn new(msg: &'static str) -> Self {
         FormError(msg)
     }

--- a/src/rdata/aaaa.rs
+++ b/src/rdata/aaaa.rs
@@ -26,10 +26,12 @@ pub struct Aaaa {
 }
 
 impl Aaaa {
+    #[must_use]
     pub fn new(addr: Ipv6Addr) -> Aaaa {
         Aaaa { addr }
     }
 
+    #[must_use]
     pub fn addr(&self) -> Ipv6Addr {
         self.addr
     }

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -1814,6 +1814,7 @@ impl<Octs> RtypeBitmap<Octs> {
         Ok(RtypeBitmap(octets))
     }
 
+    #[must_use]
     pub fn builder() -> RtypeBitmapBuilder<Octs::Builder>
     where
         Octs: FromBuilder,
@@ -2164,6 +2165,7 @@ pub struct RtypeBitmapBuilder<Builder> {
 }
 
 impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
+    #[must_use]
     pub fn new() -> Self
     where
         Builder: EmptyBuilder,
@@ -2181,6 +2183,7 @@ impl<Builder: OctetsBuilder> RtypeBitmapBuilder<Builder> {
 
 #[cfg(feature = "std")]
 impl RtypeBitmapBuilder<Vec<u8>> {
+    #[must_use]
     pub fn new_vec() -> Self {
         Self::new()
     }

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -704,6 +704,7 @@ impl Nsec3Salt<()> {
 
 impl<Octs: ?Sized> Nsec3Salt<Octs> {
     /// Creates an empty salt value.
+    #[must_use]
     pub fn empty() -> Self
     where
         Octs: From<&'static [u8]>,

--- a/src/rdata/rfc1035.rs
+++ b/src/rdata/rfc1035.rs
@@ -48,15 +48,18 @@ pub struct A {
 
 impl A {
     /// Creates a new A record data from an IPv4 address.
+    #[must_use]
     pub fn new(addr: Ipv4Addr) -> A {
         A { addr }
     }
 
     /// Creates a new A record from the IPv4 address components.
+    #[must_use]
     pub fn from_octets(a: u8, b: u8, c: u8, d: u8) -> A {
         A::new(Ipv4Addr::new(a, b, c, d))
     }
 
+    #[must_use]
     pub fn addr(&self) -> Ipv4Addr {
         self.addr
     }
@@ -975,6 +978,7 @@ impl Null<[u8]> {
     /// # Safety
     ///
     /// The caller has to ensure that `data` is at most 65,535 octets long.
+    #[must_use]
     pub unsafe fn from_slice_unchecked(data: &[u8]) -> &Self {
         &*(data as *const [u8] as *const Self)
     }
@@ -2105,6 +2109,7 @@ pub struct TxtBuilder<Builder> {
 }
 
 impl<Builder: OctetsBuilder + EmptyBuilder> TxtBuilder<Builder> {
+    #[must_use]
     pub fn new() -> Self {
         TxtBuilder {
             builder: Builder::empty(),
@@ -2220,6 +2225,7 @@ enum TxtErrorInner {
 }
 
 impl TxtError {
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         match self.0 {
             TxtErrorInner::Long(err) => err.as_str(),

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -125,6 +125,7 @@ impl SvcParams<[u8]> {
     ///
     /// The caller has to ensure that `slice` contains a properly formatted
     /// parameter sequence.
+    #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         &*(slice as *const [u8] as *const Self)
     }
@@ -658,6 +659,7 @@ pub struct SvcParamsBuilder<Octs> {
 
 impl<Octs> SvcParamsBuilder<Octs> {
     /// Creates an empty parameter builder.
+    #[must_use]
     pub fn empty() -> Self
     where Octs: EmptyBuilder {
         Self { octets: Octs::empty() }
@@ -871,6 +873,7 @@ impl From<SvcParamsError> for ParseError {
 pub struct LongSvcParam(());
 
 impl LongSvcParam {
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         "service parameter too long"
     }

--- a/src/rdata/svcb/value.rs
+++ b/src/rdata/svcb/value.rs
@@ -247,6 +247,7 @@ macro_rules! octets_wrapper {
             ///
             /// The caller has to ensure that `slice` contains a properly
             /// formated value of at most 65,535 octets.
+            #[must_use]
             pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
                 &*(slice as *const [u8] as *const Self)
             }
@@ -689,6 +690,7 @@ pub struct AlpnBuilder<Target> {
 
 impl<Target> AlpnBuilder<Target> {
     /// Creates a new, empty ALPN value builder.
+    #[must_use]
     pub fn empty() -> Self
     where
         Target: EmptyBuilder,
@@ -821,6 +823,7 @@ pub struct Port(u16);
 
 impl Port {
     /// Creates a new port value with the given port.
+    #[must_use]
     pub fn new(port: u16) -> Self {
         Port(port)
     }
@@ -833,6 +836,7 @@ impl Port {
     }
 
     /// Returns the port of this value.
+    #[must_use]
     pub fn port(self) -> u16 {
         self.0
     }
@@ -1639,7 +1643,7 @@ mod test {
         assert!(
             alpn.iter().eq(
                 [
-                    br#"f\oo,bar"#.as_ref(),
+                    br"f\oo,bar".as_ref(),
                     b"h2".as_ref(),
                 ].into_iter()
             )

--- a/src/rdata/tsig.rs
+++ b/src/rdata/tsig.rs
@@ -607,6 +607,7 @@ impl Time48 {
     /// too far in the future to fit into this type. For a correctly set
     /// clock, this will happen in December 8,921,556, so should be fine.
     #[cfg(feature = "std")]
+    #[must_use]
     pub fn now() -> Time48 {
         Self::from_u64(
             SystemTime::now()
@@ -620,6 +621,7 @@ impl Time48 {
     ///
     /// The upper 16 bits of the arument must be zero or else this function
     /// panics. This is also why we don’t implement `From`.
+    #[must_use]
     pub fn from_u64(value: u64) -> Self {
         assert!(value & 0xFFFF_0000_0000_0000 == 0);
         Time48(value)
@@ -647,6 +649,7 @@ impl Time48 {
     /// Converts a value into its wire format.
     ///
     /// Returns the octets of the encoded value in network byte order.
+    #[must_use]
     pub fn into_octets(self) -> [u8; 6] {
         let mut res = [0u8; 6];
         res[0] = (self.0 >> 40) as u8;
@@ -662,6 +665,7 @@ impl Time48 {
     ///
     /// Returns `true` iff `other` is at most `fudge` seconds before or after
     /// this value’s time.
+    #[must_use]
     pub fn eq_fudged(self, other: Self, fudge: u64) -> bool {
         self.0.saturating_sub(fudge) <= other.0
             && self.0.saturating_add(fudge) >= other.0

--- a/src/utils/base16.rs
+++ b/src/utils/base16.rs
@@ -194,6 +194,7 @@ pub struct Decoder<Builder> {
 
 impl<Builder: EmptyBuilder> Decoder<Builder> {
     /// Creates a new, empty decoder using the *base32hex* variant.
+    #[must_use]
     pub fn new() -> Self {
         Decoder {
             buf: None,
@@ -271,6 +272,7 @@ pub struct SymbolConverter {
 
 impl SymbolConverter {
     /// Creates a new symbol converter.
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }

--- a/src/utils/base32.rs
+++ b/src/utils/base32.rs
@@ -238,6 +238,7 @@ pub struct Decoder<Builder> {
 
 impl<Builder: EmptyBuilder> Decoder<Builder> {
     /// Creates a new, empty decoder using the *base32hex* variant.
+    #[must_use]
     pub fn new_hex() -> Self {
         Decoder {
             alphabet: &DECODE_HEX_ALPHABET,
@@ -396,6 +397,7 @@ impl Default for SymbolConverter {
 
 impl SymbolConverter {
     /// Creates a new symbol converter.
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }

--- a/src/utils/base64.rs
+++ b/src/utils/base64.rs
@@ -220,6 +220,7 @@ pub struct Decoder<Builder> {
 
 impl<Builder: EmptyBuilder> Decoder<Builder> {
     /// Creates a new empty decoder.
+    #[must_use]
     pub fn new() -> Self {
         Decoder {
             buf: [0; 4],
@@ -335,6 +336,7 @@ pub struct SymbolConverter {
 
 impl SymbolConverter {
     /// Creates a new symbol converter.
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }


### PR DESCRIPTION
This hint will make the compiler warn consumers of this library if they ever call one of these functions without using its return value.