### PR TITLE
Re-export octseq.

### DIFF
--- a/src/dep.rs
+++ b/src/dep.rs
@@ -1,0 +1,4 @@
+//! Re-exports of dependencies
+
+pub use octseq;
+

--- a/src/dep.rs
+++ b/src/dep.rs
@@ -1,4 +1,3 @@
 //! Re-exports of dependencies
 
 pub use octseq;
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@
 //!   Experimental reading and writing of zone files, i.e., the textual
 //!   representation of DNS data.
 //!
+//! Finally, the [dep] module contains re-exports of some important
+//! dependencies to help avoid issues with multiple versions of a crate.
 //!
 //! # Reference of Feature Flags
 //!
@@ -118,6 +120,7 @@ extern crate std;
 extern crate core;
 
 pub mod base;
+pub mod dep;
 pub mod rdata;
 pub mod resolv;
 pub mod sign;


### PR DESCRIPTION
This PR re-exports the octseq crate under the dep module.