### PR TITLE
Upgrade minimum Rust version to 1.67.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "domain"
 version = "0.9.0"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 edition = "2021"
 authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]
 description = "A DNS library for Rust."


### PR DESCRIPTION
This PR upgrades the minimum Rust version to 1.67 due to some dependencies requiring that.