### PR TITLE
Introduce a `ComposeMessage` trait.

### DIFF
--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -274,7 +274,7 @@ impl<Target: Composer> MessageBuilder<Target> {
 
 /// # Access to the Message Header
 ///
-impl<Target: OctetsBuilder + AsRef<[u8]>> MessageBuilder<Target> {
+impl<Target: AsRef<[u8]>> MessageBuilder<Target> {
     /// Return the current value of the message header.
     pub fn header(&self) -> Header {
         *Header::for_message_slice(self.target.as_ref())
@@ -297,6 +297,16 @@ impl<Target: OctetsBuilder + AsMut<[u8]>> MessageBuilder<Target> {
         HeaderCounts::for_message_slice_mut(self.target.as_mut())
     }
 }
+
+/// # Access to the assembled sections
+///
+impl<Target: AsRef<[u8]>> MessageBuilder<Target> {
+    /// Returns an octets slice of all the data sections.
+    pub fn data_sections(&self) -> &[u8] {
+        &self.as_slice()[mem::size_of::<HeaderSection>()..]
+    }
+}
+
 
 /// # Conversions
 ///
@@ -449,8 +459,6 @@ where
 }
 
 //--- AsRef
-//
-// XXX Should we deref down to target?
 
 impl<Target> AsRef<Target> for MessageBuilder<Target> {
     fn as_ref(&self) -> &Target {
@@ -461,6 +469,12 @@ impl<Target> AsRef<Target> for MessageBuilder<Target> {
 impl<Target: AsRef<[u8]>> AsRef<[u8]> for MessageBuilder<Target> {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
+    }
+}
+
+impl<Target: AsRef<[u8]>> AsRef<Message<[u8]>> for MessageBuilder<Target> {
+    fn as_ref(&self) -> &Message<[u8]> {
+        unsafe { Message::from_slice_unchecked(self.target.as_ref()) }
     }
 }
 
@@ -687,6 +701,12 @@ impl<Target> AsRef<Target> for QuestionBuilder<Target> {
 impl<Target: AsRef<[u8]>> AsRef<[u8]> for QuestionBuilder<Target> {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
+    }
+}
+
+impl<Target: AsRef<[u8]>> AsRef<Message<[u8]>> for QuestionBuilder<Target> {
+    fn as_ref(&self) -> &Message<[u8]> {
+        unsafe { Message::from_slice_unchecked(self.as_target().as_ref()) }
     }
 }
 
@@ -934,6 +954,12 @@ impl<Target: AsRef<[u8]>> AsRef<[u8]> for AnswerBuilder<Target> {
     }
 }
 
+impl<Target: AsRef<[u8]>> AsRef<Message<[u8]>> for AnswerBuilder<Target> {
+    fn as_ref(&self) -> &Message<[u8]> {
+        unsafe { Message::from_slice_unchecked(self.as_target().as_ref()) }
+    }
+}
+
 //------------ AuthorityBuilder ----------------------------------------------
 
 /// Builds the authority section of a DNS message.
@@ -1176,6 +1202,12 @@ impl<Target> AsRef<Target> for AuthorityBuilder<Target> {
 impl<Target: AsRef<[u8]>> AsRef<[u8]> for AuthorityBuilder<Target> {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
+    }
+}
+
+impl<Target: AsRef<[u8]>> AsRef<Message<[u8]>> for AuthorityBuilder<Target> {
+    fn as_ref(&self) -> &Message<[u8]> {
+        unsafe { Message::from_slice_unchecked(self.as_target().as_ref()) }
     }
 }
 
@@ -1450,6 +1482,12 @@ impl<Target> AsRef<Target> for AdditionalBuilder<Target> {
 impl<Target: AsRef<[u8]>> AsRef<[u8]> for AdditionalBuilder<Target> {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
+    }
+}
+
+impl<Target: AsRef<[u8]>> AsRef<Message<[u8]>> for AdditionalBuilder<Target> {
+    fn as_ref(&self) -> &Message<[u8]> {
+        unsafe { Message::from_slice_unchecked(self.as_target().as_ref()) }
     }
 }
 


### PR DESCRIPTION
This PR proposes a more flexible way for handing request messages to the client transport layer (and probably other things as well). The new `ComposeMessage` has methods that provide separate access to those parts of a message that a transport needs to build its own final message around: the header and what it calls the data sections (i.e., the question section and the record sections).

This doesn’t provide a means to signal that there isn’t an OPT or TSIG record, but I think it’s fine to have that as an documented part of the contract rather than have separate types (I tried that and things get unwieldy real quick).

This PR doesn’t yet include a way for a client transport user to pass OPT options to the transport. I think we should do an inventory on the existing options and which are user-generated and which are transport-generated first. In addition, we should also consider that there might have to be TSIG (and SIG(0)?) shenanigans which, if we could support them as well, would be nice.

Perhaps we need an approach where there is a basic message from the user, then the transport builds its message around that, and finally hands that back to the user so they can turn it into the final message to be sent out. `ComposeMessage` could be used in all three steps, but maybe it needs dedicated OPT handling added?