### PR TITLE
Support not sized octets in ZoneRecordData and UnknownRecordData

### DIFF
--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -404,7 +404,7 @@ impl<Octs: AsRef<[u8]>> RecordData for UnknownRecordData<Octs> {
     }
 }
 
-impl<'a, Octs: Octets> ParseRecordData<'a, Octs>
+impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
     for UnknownRecordData<Octs::Range<'a>>
 {
     fn parse_rdata(

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -357,7 +357,7 @@ macro_rules! rdata_types {
             }
         }
 
-        impl<'a, Octs: octseq::octets::Octets>
+        impl<'a, Octs: octseq::octets::Octets + ?Sized>
         $crate::base::rdata::ParseRecordData<'a, Octs>
         for ZoneRecordData<Octs::Range<'a>, ParsedDname<Octs::Range<'a>>> {
             fn parse_rdata(


### PR DESCRIPTION
These two record data impls shall also support not sized octets like the other implementations of concrete record types.

To allow for trading the parsed record that is not sized for a resource record. For example:

```
let msg: &Message<[u8]>: ...
let answer = msg.answer()?;

for parsed_rr in answer.filter_map(|r| r.ok()) {
    if let Ok(Some(rr)) = parsed_rr.into_record::<ZoneRecordData<_, _>>() {
        ...
    }
}
```