### PR TITLE
fix a bug in dname scanning

### DIFF
--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -874,6 +874,9 @@ impl<'a> EntryScanner<'a> {
                             (*write - start - 1) as u8;
                         return Ok(Some(false));
                     } else {
+                        // There’s been nothing. Reset the write position
+                        // and return.
+                        *write = start;
                         return Ok(None);
                     }
                 }

--- a/test-data/zonefiles/unknown.yaml
+++ b/test-data/zonefiles/unknown.yaml
@@ -1,12 +1,12 @@
 origin: example.com.
 zonefile: |
-  example.com. 3600 IN TXT \# 3 66 6f 6f
+  example.com. 3600 IN TXT \# 4 03 66 6f 6f
 result:
   - owner: example.com.
     class: IN
     ttl: 3600
     data: !Unknown
       rtype: Txt
-      data: 666f6f
+      data: 03666f6f
 
 


### PR DESCRIPTION
A illegal octets was put into Dname, e.g. b"\x03com\x2e", with no check. Composing the name later results malformed message.

Also add a test to convert the zonefile record back and forth to wire format.