### PR TITLE
Compile in `no_std` context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq         = "0.3"
-time           = "0.3.1"
+octseq         =  { version = "0.3", default-features = false }
+time           =  { version = "0.3.1", default-features = false }
 
 rand           = { version = "0.8", optional = true }
 bytes          = { version = "1.0", optional = true }
@@ -46,7 +46,7 @@ resolv-sync = ["resolv", "tokio/rt"]
 serde       = ["dep:serde", "octseq/serde"]
 sign        = ["std"]
 smallvec    = ["dep:smallvec", "octseq/smallvec"]
-std         = []
+std         = ["octseq/std", "time/std"]
 tsig        = ["bytes", "ring", "smallvec"]
 validate    = ["std", "ring"]
 zonefile    = ["bytes", "std"]


### PR DESCRIPTION
Previously, the crates didn't compile in `no_std` context because some dependencies required std by default.