### PR TITLE
Update `heapless` to 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain"
-version = "0.9.4-dev"
+version = "0.10.0-dev"
 rust-version = "1.67.0"
 edition = "2021"
 authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]
@@ -17,14 +17,14 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq         =  { version = "0.3.2", default-features = false }
+octseq         =  { version = "0.4.0-dev", default-features = false }
 time           =  { version = "0.3.1", default-features = false }
 
 rand           = { version = "0.8", optional = true }
 bytes          = { version = "1.0", optional = true, default-features = false }
 chrono         = { version = "0.4.6", optional = true, default-features = false }
 futures-util   = { version = "0.3", optional = true }
-heapless       = { version = "0.7", optional = true }
+heapless       = { version = "0.8", optional = true }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.17", optional = true }
 serde          = { version = "1.0.130", optional = true, features = ["derive"] }
@@ -84,3 +84,5 @@ required-features = ["resolv-sync"]
 name = "client"
 required-features = ["std", "rand"]
 
+[patch.crates-io]
+octseq = { git = "https://github.com/reitermarkus/octseq", branch = "heapless" }


### PR DESCRIPTION
Depends on https://github.com/NLnetLabs/octseq/pull/47.
