### PR TITLE
Fix displaying of chained domain names.

### DIFF
--- a/src/base/name/chain.rs
+++ b/src/base/name/chain.rs
@@ -604,7 +604,7 @@ mod test {
             assert_eq!(chain.fmt_with_dot().to_string(), dot_out);
         }
 
-        // An empty relativ name.
+        // An empty relative name.
         let empty = &RelativeDname::from_octets(b"".as_slice()).unwrap();
 
         // An empty relative name wrapped in an uncertain name.

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -1962,7 +1962,23 @@ pub(crate) mod test {
         assert_eq!(s1.finish(), s2.finish());
     }
 
-    // Scan and Display skipped for now.
+    // Scan skipped for now.
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn display() {
+        use std::string::ToString;
+
+        fn cmp(bytes: &[u8], fmt: &str, fmt_with_dot: &str) {
+            let name = Dname::from_octets(bytes).unwrap();
+            assert_eq!(name.to_string(), fmt);
+            assert_eq!(format!("{}", name.fmt_with_dot()), fmt_with_dot);
+        }
+
+        cmp(b"\0", ".", ".");
+        cmp(b"\x03com\0", "com", "com.");
+        cmp(b"\x07example\x03com\0", "example.com", "example.com.");
+    }
 
     #[cfg(all(feature = "serde", feature = "std"))]
     #[test]

--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -350,6 +350,12 @@ impl<Octs: AsRef<[u8]> + ?Sized> Dname<Octs> {
         self.0.as_ref().len()
     }
 
+    /// Returns an objects that displays the name with a final dot.
+    ///
+    /// The name itself displays without a final dot unless the name is the
+    /// root label only. Because this means you can’t just unconditionally
+    /// add a dot after the name, this method can be used to display the name
+    /// always ending in a single dot.
     pub fn fmt_with_dot(&self) -> impl fmt::Display + '_ {
         DisplayWithDot(self.for_slice())
     }

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -1708,7 +1708,20 @@ mod test {
         assert_eq!(s1.finish(), s2.finish());
     }
 
-    // Display and Debug skipped for now.
+    #[test]
+    #[cfg(feature = "std")]
+    fn display() {
+        use std::string::ToString;
+
+        fn cmp(bytes: &[u8], fmt: &str) {
+            let name = RelativeDname::from_octets(bytes).unwrap();
+            assert_eq!(name.to_string(), fmt);
+        }
+
+        cmp(b"", "");
+        cmp(b"\x03com", "com");
+        cmp(b"\x07example\x03com", "example.com");
+    }
 
     #[cfg(all(feature = "serde", feature = "std"))]
     #[test]


### PR DESCRIPTION
This PR fixes the `Display` implementation of `Chain<_,_>` so it considers all possible combinations of empty, non-empty, and root names. It now behaves similarly to the `Display` implementation of `Dname` in that it only adds a final dot to an absolute name if it is the root label only.  Similarly to `Dname`, it also adds `Chain::fmt_with_dot` which returns a temporary type that formats absolute names with a final dot.

Fixes #252.
