### PR TITLE
Remove interop and ci-test features and set interop tests to ignore.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     - if: matrix.rust == 'stable'
       run: rustup component add clippy
     - if: matrix.rust == 'stable'
-      run: cargo clippy --all-features --tests --examples -- -D warnings
+      run: cargo clippy --all-features --all-targets -- -D warnings
     - if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
       run: cargo fmt --all -- --check
-    - run: cargo check --tests --examples --no-default-features
+    - run: cargo check --no-default-features --all-targets
     - run: cargo test --all-features
     - if: matrix.rust == 'nightly'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,13 @@ jobs:
     - if: matrix.rust == 'stable'
       run: rustup component add clippy
     - if: matrix.rust == 'stable'
-      run: cargo clippy --all-features -- -D warnings
+      run: cargo clippy --all-features --tests --examples -- -D warnings
     - if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
       run: cargo fmt --all -- --check
-    - run: cargo build --tests --no-default-features --verbose
-    - run: cargo test --features=ci-test --verbose
+    - run: cargo check --tests --examples --no-default-features
+    - run: cargo test --all-features
     - if: matrix.rust == 'nightly'
       run: |
         cargo +nightly update -Z minimal-versions
-        cargo check --features=ci-test --verbose --all-targets
-        cargo test --features=ci-test
-      name: Check and test with minimal-versions
+        cargo check --all-features --all-targets
+      name: Check with minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ libc = { version = "0.2.71", default-features = false, optional = true }
 default     = ["std", "rand"]
 bytes       = ["dep:bytes", "octseq/bytes"]
 heapless    = ["dep:heapless", "octseq/heapless"]
-interop     = ["bytes", "ring"]
 resolv      = ["bytes", "futures-util", "smallvec", "std", "tokio", "libc", "rand"]
 resolv-sync = ["resolv", "tokio/rt"]
 serde       = ["dep:serde", "octseq/serde"]
@@ -50,10 +49,6 @@ std         = ["bytes?/std", "octseq/std", "time/std"]
 tsig        = ["bytes", "ring", "smallvec"]
 validate    = ["std", "ring"]
 zonefile    = ["bytes", "std"]
-
-# This feature should include all features that the CI should include for a
-# test run. Which is everything except interop.
-ci-test     = ["resolv", "resolv-sync", "sign", "std", "serde", "tsig", "validate", "zonefile"]
 
 [dev-dependencies]
 serde_test         = "1.0.130"

--- a/examples/readzone.rs
+++ b/examples/readzone.rs
@@ -15,7 +15,7 @@ fn main() {
             start.elapsed().unwrap().as_secs_f32()
         );
         let mut i = 0;
-        while let Some(_) = zone.next_entry().unwrap() {
+        while zone.next_entry().unwrap().is_some() {
             i += 1;
             if i % 100_000_000 == 0 {
                 eprintln!(

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -5,10 +5,9 @@
 //!
 //! The actual tests live with their respective modules in a sub-module called
 //! `interop`. Since they require additional software packages to be available
-//! and can be expensive, they are only run if the `"interop"` feature is
-//! given to `cargo test`.
+//! and can be expensive, they are tagged as ignored by default.
 //!
-#![cfg(all(test, feature = "interop"))]
+#![cfg(test)]
 
 pub mod cargo;
 pub mod nsd;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -7,7 +7,7 @@
 //! `interop`. Since they require additional software packages to be available
 //! and can be expensive, they are tagged as ignored by default.
 //!
-#![cfg(test)]
+#![cfg(all(test, feature = "bytes", feature = "std"))]
 
 pub mod cargo;
 pub mod nsd;

--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -1,5 +1,5 @@
 //! Tests the TSIG implementation.
-#![cfg(all(test, feature = "interop"))]
+#![cfg(test)]
 
 use crate::base::iana::{Rcode, Rtype};
 use crate::base::message::Message;
@@ -33,6 +33,7 @@ type TestAdditional = AdditionalBuilder<StreamTarget<Vec<u8>>>;
 ///
 /// Spins up an NSD serving example.com. and then tries to AXFR that.
 #[test]
+#[ignore]
 fn tsig_client_nsd() {
     // Set up and start NSD with example.org and a TSIG key for AXFRing it.
     let rng = SystemRandom::new();
@@ -120,6 +121,7 @@ fn tsig_client_nsd() {
 
 /// Tests the TSIG server implementation against drill as a client.
 #[test]
+#[ignore]
 fn tsig_server_drill() {
     let rng = SystemRandom::new();
     let (key, secret) = tsig::Key::generate(
@@ -183,6 +185,7 @@ fn tsig_server_drill() {
 
 /// Test the client sequence implementation against NSD.
 #[test]
+#[ignore]
 fn tsig_client_sequence_nsd() {
     let rng = SystemRandom::new();
 
@@ -268,6 +271,7 @@ fn tsig_client_sequence_nsd() {
 
 /// Tests the TSIG server sequence implementation against drill.
 #[test]
+#[ignore]
 fn tsig_server_sequence_drill() {
     let rng = SystemRandom::new();
     let (key, secret) = tsig::Key::generate(

--- a/src/utils/base64.rs
+++ b/src/utils/base64.rs
@@ -520,7 +520,7 @@ const EOF_MARKER: usize = 0xF0;
 
 //============ Test ==========================================================
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use super::*;
 
@@ -535,7 +535,6 @@ mod test {
         (b"foobar", "Zm9vYmFy"),
     ];
 
-    #[cfg(feature = "std")]
     #[test]
     fn decode_str() {
         fn decode(s: &str) -> Result<std::vec::Vec<u8>, DecodeError> {
@@ -562,7 +561,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn symbol_converter() {
         use crate::base::scan::Symbols;
@@ -590,7 +588,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn display_bytes() {
         use super::*;
 


### PR DESCRIPTION
This PR removes the interop and ci-test features which were used to gate tests that rely on additional software being installed on the test system. This was brittle as it required new features to be added to the ci-test feature or they would not be tested in the CI workflow. Instead, we now simply add the `#[ignore]` attribute to these tests and can use `--all-features` without issue.