### PR TITLE
Introduce simplified message data types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ heapless       = { version = "0.8", optional = true }
 ring           = { version = "0.17", optional = true }
 serde          = { version = "1.0.130", optional = true, features = ["derive"] }
 siphasher      = { version = "1", optional = true }
-smallvec       = { version = "1", optional = true }
+smallvec       = { version = "1.3", optional = true }
 tokio          = { version = "1.33", optional = true, features = ["io-util", "macros", "net", "time", "sync", "rt-multi-thread" ] }
 tokio-rustls   = { version = "0.24", optional = true, features = [] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,15 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq         =  { version = "0.3.2", default-features = false }
-time           =  { version = "0.3.1", default-features = false }
+#octseq         =  { version = "0.3.2", default-features = false }
+octseq         = { git = "https://github.com/NLnetLabs/octseq.git", branch = "octets-from-for-str", default-features = false }
+time           = { version = "0.3.1", default-features = false }
 
 rand           = { version = "0.8", optional = true }
 bytes          = { version = "1.0", optional = true, default-features = false }
 chrono         = { version = "0.4.6", optional = true, default-features = false }
 futures-util   = { version = "0.3", optional = true }
-heapless       = { version = "0.7", optional = true }
+heapless       = { version = "0.8", optional = true }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.17", optional = true }
 serde          = { version = "1.0.130", optional = true, features = ["derive"] }
@@ -41,6 +42,7 @@ default     = ["std", "rand"]
 bytes       = ["dep:bytes", "octseq/bytes"]
 heapless    = ["dep:heapless", "octseq/heapless"]
 interop     = ["bytes", "ring"]
+plain       = ["bytes", "std"]
 resolv      = ["bytes", "futures-util", "smallvec", "std", "tokio", "libc", "rand"]
 resolv-sync = ["resolv", "tokio/rt"]
 serde       = ["dep:serde", "octseq/serde"]

--- a/examples/readzone.rs
+++ b/examples/readzone.rs
@@ -15,7 +15,7 @@ fn main() {
             start.elapsed().unwrap().as_secs_f32()
         );
         let mut i = 0;
-        while let Some(_) = zone.next_entry().unwrap() {
+        while zone.next_entry().unwrap().is_some() {
             i += 1;
             if i % 100_000_000 == 0 {
                 eprintln!(

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -494,6 +494,22 @@ impl HeaderCounts {
         Self::default()
     }
 
+    /// Creates a new value with the given four counts.
+    #[must_use]
+    pub fn from_counts(
+        qdcount: u16,
+        ancount: u16,
+        nscount: u16,
+        arcount: u16,
+    ) -> Self {
+        let mut res = Self::default();
+        res.set_qdcount(qdcount);
+        res.set_ancount(ancount);
+        res.set_nscount(nscount);
+        res.set_arcount(arcount);
+        res
+    }
+
     /// Creates a header counts reference from the octets slice of a message.
     ///
     /// The slice `message` mut be the whole message, i.e., start with the

--- a/src/base/opt/algsig.rs
+++ b/src/base/opt/algsig.rs
@@ -46,7 +46,7 @@ use core::marker::PhantomData;
 /// Once you have a value, you can iterate over the algorithms via the
 /// [`iter`][Understood::iter] method or use the `IntoIterator` implementation
 /// for a reference.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct Understood<Variant, Octs: ?Sized> {
     /// A marker for the variant.
     marker: PhantomData<Variant>,
@@ -391,6 +391,33 @@ where
         Ok(())
     }
 }
+
+//--- Debug
+
+impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<DauVariant, Octs> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Understood<DauVariant>")
+            .field(&format_args!("{}", self))
+            .finish()
+    }
+}
+
+impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<DhuVariant, Octs> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Understood<DhuVariant>")
+            .field(&format_args!("{}", self))
+            .finish()
+    }
+}
+
+impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<N3uVariant, Octs> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Understood<N3uVariant>")
+            .field(&format_args!("{}", self))
+            .finish()
+    }
+}
+
 
 //--- Extended Opt and OptBuilder
 

--- a/src/base/opt/chain.rs
+++ b/src/base/opt/chain.rs
@@ -29,7 +29,7 @@ use core::cmp::Ordering;
 /// point of the included records, i.e., the suffix of the queried name
 /// furthest away from the root to which the requesting resolver already has
 /// all necessary records.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct Chain<Name: ?Sized> {
     /// The start name AKA ‘closest trust point.’
     start: Name
@@ -163,11 +163,19 @@ impl<Name: ToDname> ComposeOptData for Chain<Name> {
     }
 }
 
-//--- Display
+//--- Display and Debug
 
 impl<Name: fmt::Display> fmt::Display for Chain<Name> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.start)
+    }
+}
+
+impl<Name: fmt::Display> fmt::Debug for Chain<Name> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Chain")
+            .field("start", &format_args!("{}", self.start))
+            .finish()
     }
 }
 

--- a/src/base/opt/cookie.rs
+++ b/src/base/opt/cookie.rs
@@ -156,6 +156,10 @@ impl Cookie {
             )
         )
     }
+
+    pub(crate) fn try_octets_from<E>(src: Self) -> Result<Self, E> {
+        Ok(src)
+    }
 }
 
 

--- a/src/base/opt/expire.rs
+++ b/src/base/opt/expire.rs
@@ -45,7 +45,7 @@ impl Expire {
     }
 
     /// Parses a value from its wire format.
-    pub fn parse<Octs: AsRef<[u8]>>(
+    pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
         parser: &mut Parser<Octs>
     ) -> Result<Self, ParseError> {
         if parser.remaining() == 0 {
@@ -54,6 +54,10 @@ impl Expire {
         else {
             u32::parse(parser).map(|res| Expire::new(Some(res)))
         }
+    }
+
+    pub(crate) fn try_octets_from<E>(src: Self) -> Result<Self, E> {
+        Ok(src)
     }
 }
 

--- a/src/base/opt/exterr.rs
+++ b/src/base/opt/exterr.rs
@@ -14,7 +14,7 @@ use super::{
     BuildDataError, LongOptData, Opt, OptData, ComposeOptData, ParseOptData
 };
 use octseq::builder::OctetsBuilder;
-use octseq::octets::Octets;
+use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 use octseq::str::Str;
 use core::{fmt, hash, str};
@@ -143,6 +143,26 @@ where Octs: AsRef<[u8]> {
         (code, text): (ExtendedErrorCode, Str<Octs>)
     ) -> Result<Self, Self::Error> {
         Self::new(code, Some(text))
+    }
+}
+
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<ExtendedError<SrcOcts>> for ExtendedError<Octs>
+where
+    Octs: OctetsFrom<SrcOcts>
+{
+    type Error = Octs::Error;
+
+    fn try_octets_from(
+        source: ExtendedError<SrcOcts>
+    ) -> Result<Self, Self::Error> {
+        let text = match source.text {
+            Some(Ok(text)) => Some(Ok(Str::try_octets_from(text)?)),
+            Some(Err(octs)) => Some(Err(Octs::try_octets_from(octs)?)),
+            None => None,
+        };
+        Ok(Self { code: source.code, text })
     }
 }
 

--- a/src/base/opt/keepalive.rs
+++ b/src/base/opt/keepalive.rs
@@ -46,7 +46,7 @@ impl TcpKeepalive {
     }
 
     /// Parses an option data value from its wire format.
-    pub fn parse<Octs: AsRef<[u8]>>(
+    pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
         parser: &mut Parser<Octs>
     ) -> Result<Self, ParseError> {
         if parser.remaining() == 0 {
@@ -54,6 +54,10 @@ impl TcpKeepalive {
         } else {
             IdleTimeout::parse(parser).map(|v| Self::new(Some(v)))
         }
+    }
+
+    pub(crate) fn try_octets_from<E>(src: Self) -> Result<Self, E> {
+        Ok(src)
     }
 }
 
@@ -144,7 +148,7 @@ impl IdleTimeout {
     const COMPOSE_LEN: u16 = 2;
 
     /// Parses a value from its wire format.
-    fn parse<Octs: AsRef<[u8]>>(
+    fn parse<Octs: AsRef<[u8]> + ?Sized>(
         parser: &mut Parser<Octs>
     ) -> Result<Self, ParseError> {
         u16::parse(parser).map(Self)

--- a/src/base/opt/keytag.rs
+++ b/src/base/opt/keytag.rs
@@ -13,7 +13,7 @@ use super::super::message_builder::OptBuilder;
 use super::super::wire::{Composer, ParseError};
 use super::{Opt, OptData, ComposeOptData, ParseOptData};
 use octseq::builder::OctetsBuilder;
-use octseq::octets::Octets;
+use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 use core::{borrow, fmt, hash};
 use core::cmp::Ordering;
@@ -146,6 +146,19 @@ impl<Octs: ?Sized> KeyTag<Octs> {
     pub fn iter(&self) -> KeyTagIter
     where Octs: AsRef<[u8]> {
         KeyTagIter(self.octets.as_ref())
+    }
+}
+
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<KeyTag<SrcOcts>> for KeyTag<Octs>
+where Octs: OctetsFrom<SrcOcts> {
+    type Error = Octs::Error;
+
+    fn try_octets_from(src: KeyTag<SrcOcts>) -> Result<Self, Self::Error> {
+        Octs::try_octets_from(src.octets).map(|octets| unsafe {
+            Self::from_octets_unchecked(octets)
+        })
     }
 }
 

--- a/src/base/opt/nsid.rs
+++ b/src/base/opt/nsid.rs
@@ -14,7 +14,7 @@ use super::{
     BuildDataError, LongOptData, Opt, OptData, ComposeOptData, ParseOptData
 };
 use octseq::builder::OctetsBuilder;
-use octseq::octets::Octets;
+use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 use core::{borrow, fmt, hash, str};
 use core::cmp::Ordering;
@@ -126,6 +126,19 @@ impl<Octs: ?Sized> Nsid<Octs> {
         Octs: AsRef<[u8]>
     {
         unsafe { Nsid::from_slice_unchecked(self.octets.as_ref()) }
+    }
+}
+
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<Nsid<SrcOcts>> for Nsid<Octs>
+where Octs: OctetsFrom<SrcOcts> {
+    type Error = Octs::Error;
+
+    fn try_octets_from(src: Nsid<SrcOcts>) -> Result<Self, Self::Error> {
+        Octs::try_octets_from(src.octets).map(|octets| unsafe {
+            Self::from_octets_unchecked(octets)
+        })
     }
 }
 

--- a/src/base/opt/padding.rs
+++ b/src/base/opt/padding.rs
@@ -14,7 +14,7 @@ use super::super::message_builder::OptBuilder;
 use super::super::wire::{Compose, Composer, ParseError};
 use super::{LongOptData, OptData, ComposeOptData, ParseOptData};
 use octseq::builder::OctetsBuilder;
-use octseq::octets::Octets;
+use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 
 
@@ -88,6 +88,19 @@ impl<Octs: ?Sized> Padding<Octs> {
         Octs: AsRef<[u8]>,
     {
         self.octets.as_ref()
+    }
+}
+
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<Padding<SrcOcts>> for Padding<Octs>
+where Octs: OctetsFrom<SrcOcts> {
+    type Error = Octs::Error;
+
+    fn try_octets_from(src: Padding<SrcOcts>) -> Result<Self, Self::Error> {
+        Octs::try_octets_from(src.octets).map(|octets| unsafe {
+            Self::from_octets_unchecked(octets)
+        })
     }
 }
 

--- a/src/base/opt/subnet.rs
+++ b/src/base/opt/subnet.rs
@@ -98,7 +98,7 @@ impl ClientSubnet {
     }
 
     /// Parses a value from its wire format.
-    pub fn parse<Octs: AsRef<[u8]>>(
+    pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
         parser: &mut Parser<Octs>
     ) -> Result<Self, ParseError> {
         const ERR_ADDR_LEN: &str = "invalid address length in client \
@@ -168,6 +168,10 @@ impl ClientSubnet {
             scope_prefix_len,
             addr,
         })
+    }
+
+    pub(crate) fn try_octets_from<E>(src: Self) -> Result<Self, E> {
+        Ok(src)
     }
 }
 

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -152,7 +152,7 @@ impl<'a, T: ComposeRecordData> ComposeRecordData for &'a T {
     }
 }
 
-//------------ ParseRecordData -----------------------------------------------
+//------------ ParseRecordData and ParseAllRecordData ------------------------
 
 /// A record data type that can be parsed from a message.
 ///
@@ -169,7 +169,7 @@ pub trait ParseRecordData<'a, Octs: ?Sized>: RecordData + Sized {
     /// `Ok(None)` if it doesn’t.
     ///
     /// The `parser` is positioned at the beginning of the record data and is
-    /// is limited to the length of the data. The method only needs to parse
+    /// is limited to the length of the data. The function only needs to parse
     /// as much data as it needs. The caller has to make sure to deal with
     /// data remaining in the parser.
     ///
@@ -179,6 +179,32 @@ pub trait ParseRecordData<'a, Octs: ?Sized>: RecordData + Sized {
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError>;
+}
+
+/// A record data type that can parse and represent any type of record.
+///
+/// While [`ParseRecordData`] allows a type to signal that it doesn’t
+/// actually cover a certain record type, this trait is for types that cover
+/// everything.
+///
+/// When implementing a type for this trait, keep in mind that some record
+/// types – specifically those defined by [RFC 1035][crate::rdata::rfc1035] –
+/// can contain compressed domain names. This, this trait cannot be
+/// implemented by [`UnknownRecordData`] which just takes the raw data
+/// uninterpreted.
+pub trait ParseAnyRecordData<'a, Octs: ?Sized>: RecordData + Sized {
+    /// Parses the record data.
+    ///
+    /// The record data is for a record of type `rtype`.
+    ///
+    /// The `parser` is positioned at the beginning of the record data and is
+    /// is limited to the length of the data. The function only needs to parse
+    /// as much data as it needs. The caller has to make sure to deal with
+    /// data remaining in the parser.
+    fn parse_any_rdata(
+        rtype: Rtype,
+        parser: &mut Parser<'a, Octs>,
+    ) -> Result<Self, ParseError>;
 }
 
 //------------ UnknownRecordData ---------------------------------------------
@@ -304,6 +330,25 @@ impl<Octs> UnknownRecordData<Octs> {
         }
 
         Ok(UnknownRecordData { rtype, data })
+    }
+
+    /// Parses any record type as unknown record data.
+    ///
+    /// This is an associated function rather than an impl of
+    /// [`ParseAnyRecordData`] because some record types must not be parsed
+    /// as unknown data as they can contain compressed domain names.
+    pub fn parse_any_rdata<'a, SrcOcts>(
+        rtype: Rtype,
+        parser: &mut Parser<'a, SrcOcts>,
+    ) -> Result<Self, ParseError>
+    where
+        SrcOcts: Octets<Range<'a> = Octs> + ?Sized + 'a,
+    {
+        let rdlen = parser.remaining();
+        parser
+            .parse_octets(rdlen)
+            .map(|data| Self { rtype, data })
+            .map_err(Into::into)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,20 @@
 //! * [rdata] contains types and implementations for a growing number of
 //!   record types.
 //!
-//! In addition to those two basic modules, there are a number of modules for
-//! more specific features that are not required in all applications. In order
-//! to keep the amount of code to be compiled and the number of dependencies
-//! small, these are hidden behind feature flags through which they can be
-//! enabled if required. The flags have the same names as the modules.
+//! These two modules have been designed with great flexibility in mind but
+//! can be a bit cumbersome to use. The module
+#![cfg_attr(feature = "plain", doc = "[plain]")]
+#![cfg_attr(not(feature = "plain"), doc = "_plain_")]
+//! (which needs to be enabled via the `plain` feature) provides simplified
+//! version that are more convenient to use but assume use cases that
+//! provide standard library support and multi-thread synchronization.
+//!
+//! In addition to those three basic modules, there are a number of modules
+//! for more specific features that are not required in all applications. In
+//! order to keep the amount of code to be compiled and the number of
+//! dependencies small, these are hidden behind feature flags through which
+//! they can be enabled if required. The flags have the same names as the
+//! modules.
 //!
 //! Currently, there are the following modules:
 //!
@@ -63,6 +72,10 @@
 //! * `interop`: Activate interoperability tests that rely on other software
 //!   to be installed in the system (currently NSD and dig) and will fail if
 //!   it isn’t. This feature is not meaningful for users of the crate.
+//! * `plain`: Enables the
+#![cfg_attr(feature = "plain", doc = "  [plain]")]
+#![cfg_attr(not(feature = "plain"), doc = "  plain")]
+//!   module.
 //! * `rand`: Enables a number of methods that rely on a random number
 //!   generator being available in the system.
 //! * `resolv`: Enables the asynchronous stub resolver via the
@@ -121,6 +134,7 @@ extern crate core;
 
 pub mod base;
 pub mod dep;
+pub mod plain;
 pub mod rdata;
 pub mod resolv;
 pub mod sign;

--- a/src/plain/message.rs
+++ b/src/plain/message.rs
@@ -1,0 +1,764 @@
+//! Convenient representations of DNS messages.
+#![allow(dead_code)]
+
+use super::{AllOptData, Question, Record};
+use crate::base;
+use crate::base::header::{Header, HeaderCounts};
+use crate::base::message;
+use crate::base::name::FlattenInto;
+use crate::base::opt::{ComposeOptData, OptData, OptHeader, OptRecord};
+use crate::base::wire::{Compose, Composer, ParseError};
+use crate::rdata::AllRecordData;
+use bytes::Bytes;
+use octseq::{Octets, OctetsFrom, OctetsInto};
+use std::convert::Infallible;
+use std::prelude::rust_2021::*;
+use std::{borrow, cmp, error, fmt, ops, slice, vec};
+
+//------------ Message -------------------------------------------------------
+
+/// A DNS message as a collection of questions and records.
+///
+/// This type deviates slightly from the normal definition of the message in
+/// that it considers the OPT record not as part of the additional section.
+/// Instead it keeps it separate. A consequence of this is that this type can
+/// not add any records after the OPT record either. In practice this would
+/// only ever be a TSIG record that needs to be synthesized after the message
+/// is complete, anyway, and shouldn’t be part of an easily modifiable
+/// message.
+///
+/// Another consequence is that this message will always have an OPT record.
+/// Since basically all messages in modern DNS should have an OPT record,
+/// this is likely an okay limitation.
+#[derive(Clone, Default)]
+pub struct Message {
+    /// The header of the message.
+    header: Header,
+
+    /// The question section.
+    question: QuestionSection,
+
+    /// The answer section.
+    answer: RecordSection,
+
+    /// The section.
+    authority: RecordSection,
+
+    /// The additional section.
+    ///
+    /// This section should not include the OPT record nor any records
+    /// coming after the OPT record, e.g., TSIG.
+    additional: AdditionalSection,
+
+    /// The OPT record.
+    opt: Opt,
+}
+
+impl Message {
+    /// Creates a new, empty message with a default header.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns a reference to the question section.
+    pub fn question(&self) -> &QuestionSection {
+        &self.question
+    }
+
+    /// Returns a mutable reference to the question section.
+    pub fn question_mut(&mut self) -> &mut QuestionSection {
+        &mut self.question
+    }
+
+    /// Returns a reference to the answer section.
+    pub fn answer(&self) -> &RecordSection {
+        &self.answer
+    }
+
+    /// Returns a mutable reference to the answer section.
+    pub fn answer_mut(&mut self) -> &mut RecordSection {
+        &mut self.answer
+    }
+
+    /// Returns a reference to the authority section.
+    pub fn authority(&self) -> &RecordSection {
+        &self.authority
+    }
+
+    /// Returns a mutable reference to the authority section.
+    pub fn authority_mut(&mut self) -> &mut RecordSection {
+        &mut self.authority
+    }
+
+    /// Returns a reference to the additional section.
+    ///
+    /// The authority section of this type of message does not contain the
+    /// OPT record or any records following the OPT record.
+    pub fn additional(&self) -> &AdditionalSection {
+        &self.additional
+    }
+
+    /// Returns a mutable reference to the additional section.
+    pub fn additional_mut(&mut self) -> &mut AdditionalSection {
+        &mut self.additional
+    }
+
+    /// Returns a reference to the OPT record.
+    pub fn opt(&self) -> &Opt {
+        &self.opt
+    }
+
+    /// Returns a mutable reference to the OPT record.
+    pub fn opt_mut(&mut self) -> &mut Opt {
+        &mut self.opt
+    }
+}
+
+/// # Conversion from and to base types.
+impl Message {
+    /// Creates a message from a base message.
+    pub fn from_base<Octs: Octets>(
+        msg: base::Message<Octs>,
+    ) -> Result<Self, ParseError>
+    where
+        Bytes: for<'a> OctetsFrom<Octs::Range<'a>, Error = Infallible>,
+    {
+        let header = msg.header();
+        let section = msg.question();
+        let question = QuestionSection::from_base(section)?;
+        let section = section.next_section()?;
+        let answer = RecordSection::from_base(section)?;
+        let section = section.next_section()?.unwrap();
+        let authority = RecordSection::from_base(section)?;
+        let section = section.next_section()?.unwrap();
+        let (opt, additional) = Section::additional_from_base(section)?;
+
+        Ok(Self {
+            header,
+            question,
+            answer,
+            authority,
+            additional,
+            opt,
+        })
+    }
+
+    /// Creates a base message.
+    pub fn compose<Target: Composer + ?Sized>(
+        &self,
+        target: &mut Target,
+    ) -> Result<(), Target::AppendError> {
+        target.append_slice(self.header.as_slice())?;
+        target.append_slice(
+            HeaderCounts::from_counts(
+                self.question.len_u16(),
+                self.answer.len_u16(),
+                self.authority.len_u16(),
+                self.additional.len_u16() + 1,
+            )
+            .as_slice(),
+        )?;
+        self.question.compose(target)?;
+        self.answer.compose(target)?;
+        self.authority.compose(target)?;
+        self.additional.compose(target)?;
+        Ok(())
+    }
+}
+
+//------------ Opt -----------------------------------------------------------
+
+/// The OPT record of a message.
+#[derive(Clone, Default)]
+pub struct Opt {
+    /// The UDP payload size field from the record header.
+    udp_payload_size: u16,
+
+    /// The extended rcode.
+    ext_rcode: u8,
+
+    /// The EDNS version.
+    version: u8,
+
+    /// The EDNS flags.
+    dnssec_ok: bool,
+
+    rdlen: u16,
+
+    data: Vec<AllOptData>,
+}
+
+impl Opt {
+    fn from_base(base: OptRecord<Bytes>) -> Result<Self, ParseError> {
+        let mut data = Vec::new();
+        let mut rdlen = 0;
+        for item in base.opt().iter_all() {
+            let item = item?;
+            rdlen += item.compose_len();
+            data.push(item.octets_into());
+        }
+        Ok(Opt {
+            udp_payload_size: base.udp_payload_size(),
+            ext_rcode: base.ext_rcode(),
+            version: base.version(),
+            dnssec_ok: base.dnssec_ok(),
+            rdlen,
+            data,
+        })
+    }
+
+    fn compose<Target: Composer + ?Sized>(
+        &self,
+        target: &mut Target,
+    ) -> Result<(), Target::AppendError> {
+        let mut header = OptHeader::default();
+        header.set_udp_payload_size(self.udp_payload_size);
+        header.set_ext_rcode(self.ext_rcode);
+        header.set_dnssec_ok(self.dnssec_ok);
+        target.append_slice(header.as_slice())?;
+        self.rdlen.compose(target)?;
+        self.data.iter().try_for_each(|data| {
+            data.code().compose(target)?;
+            data.compose_len().compose(target)?;
+            data.compose_option(target)
+        })
+    }
+}
+
+//------------ Section -------------------------------------------------------
+
+/// A collection of elements of one of the message sections.
+///
+/// This type behaves mostly like `Vec<T>`. However, since sections are
+/// limited to at most `N` elements, all methods that add additional
+/// elements to the section fail rather than panic if the section runs out of
+/// space.
+#[derive(Clone, Hash, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Section<T, const N: usize> {
+    elements: Vec<T>,
+}
+
+pub type QuestionSection = Section<Question, MAX_SECTION_LEN>;
+pub type RecordSection = Section<Record, MAX_SECTION_LEN>;
+pub type AdditionalSection = Section<Record, { MAX_SECTION_LEN - 1 }>;
+
+impl<T, const N: usize> Section<T, N> {
+    /// Creates a new, empty section.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Creates a section from a vec without checking the length.
+    fn from_vec_unchecked(elements: Vec<T>) -> Self {
+        Self { elements }
+    }
+
+    /// Creates a new, empty section with the given minimal capacity.
+    ///
+    /// The section will be able to hold at least `capacity` or 65,535
+    /// elements, whatever is smaller.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            elements: Vec::with_capacity(cmp::min(capacity, N)),
+        }
+    }
+}
+
+impl<const N: usize> Section<Question, N> {
+    pub fn from_base<Octs: Octets>(
+        base: message::QuestionSection<Octs>,
+    ) -> Result<Self, ParseError>
+    where
+        Bytes: for<'a> OctetsFrom<Octs::Range<'a>, Error = Infallible>,
+    {
+        let mut vec = Vec::new();
+        for item in base {
+            let item = item?;
+            vec.push(item.flatten_into());
+        }
+        Ok(Self::from_vec_unchecked(vec))
+    }
+
+    fn compose<Target: Composer + ?Sized>(
+        &self,
+        target: &mut Target,
+    ) -> Result<(), Target::AppendError> {
+        self.elements
+            .iter()
+            .try_for_each(|elem| elem.compose(target))
+    }
+}
+
+impl<const N: usize> Section<Record, N> {
+    pub fn from_base<Octs: Octets>(
+        base: message::RecordSection<Octs>,
+    ) -> Result<Self, ParseError>
+    where
+        Bytes: for<'a> OctetsFrom<Octs::Range<'a>, Error = Infallible>,
+    {
+        let mut vec = Vec::new();
+        for item in base.into_records::<AllRecordData<_, _>>() {
+            let item = item?;
+            vec.push(item.flatten_into());
+        }
+        Ok(Self::from_vec_unchecked(vec))
+    }
+
+    fn additional_from_base<Octs: Octets>(
+        base: message::RecordSection<Octs>,
+    ) -> Result<(Opt, Self), ParseError>
+    where
+        Bytes: for<'a> OctetsFrom<Octs::Range<'a>, Error = Infallible>,
+    {
+        let mut opt = None;
+        let mut vec = Vec::new();
+        for item in base.into_records::<AllRecordData<_, _>>() {
+            let item = item?;
+            match item.try_into_opt() {
+                Ok(opt_record) => {
+                    opt = Some(Opt::from_base(opt_record.octets_into())?);
+                    break;
+                }
+                Err(item) => vec.push(item.flatten_into()),
+            }
+        }
+        Ok((opt.unwrap_or_default(), Self::from_vec_unchecked(vec)))
+    }
+
+    fn compose<Target: Composer + ?Sized>(
+        &self,
+        target: &mut Target,
+    ) -> Result<(), Target::AppendError> {
+        self.elements
+            .iter()
+            .try_for_each(|elem| elem.compose(target))
+    }
+}
+
+impl<T, const N: usize> Section<T, N> {
+    /// Returns the capacity of the section.
+    pub fn capacity(&self) -> usize {
+        self.elements.capacity()
+    }
+
+    /// Reserves capacity for at least this many more elements.
+    ///
+    /// After this call, the section will have a capacity of at least
+    /// `self.len() + additional` elements or 65,535 elements, whatever is
+    /// smaller.
+    pub fn reserve(&mut self, additional: usize) {
+        self.elements
+            .reserve(cmp::min(additional, N.saturating_sub(self.len())))
+    }
+
+    /// Reserves capacity for exactly this many more elements.
+    ///
+    /// This is similar to [`reserve`][Self::reserve] but will not
+    /// deliberately over-allocate space.
+    ///
+    /// Note that because the number of elements can not exceed 65,535, the
+    /// method will actually reserve less space than requested.
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.elements
+            .reserve(cmp::min(additional, N.saturating_sub(self.len())))
+    }
+
+    /// Returns the number of elements in the section.
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Returns the number of elements in the section as an `u16`.
+    pub fn len_u16(&self) -> u16 {
+        u16::try_from(self.len()).expect("section too large")
+    }
+
+    /// Returns whether the section contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Shrinks the section’s capacity as much as possible.
+    pub fn shrink_to_fit(&mut self) {
+        self.elements.shrink_to_fit()
+    }
+
+    /// Returns a slice of the elements of the section.
+    pub fn as_slice(&self) -> &[T] {
+        self.elements.as_slice()
+    }
+
+    /// Returns a mutable slice of the elements of the section.
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.elements.as_mut_slice()
+    }
+}
+
+impl<T, const N: usize> Section<T, N> {
+    /// Checks that an additional _len_ number of elements can be added.
+    fn check_append_len(&self, other: usize) -> Result<(), Exhausted> {
+        // This also works safely with 16 bit pointer sizes.
+        match self.elements.len().checked_add(other) {
+            None => Err(Exhausted(())),
+            Some(len) if len > N => Err(Exhausted(())),
+            _ => Ok(()),
+        }
+    }
+
+    /// Appends an element to the end of the section.
+    ///
+    /// Returns an error if the element doesn’t fit.
+    pub fn push(&mut self, element: T) -> Result<(), Exhausted> {
+        self.check_append_len(1)?;
+        self.elements.push(element);
+        Ok(())
+    }
+
+    /// Inserts an element at the given index.
+    ///
+    /// The existing elements with an index equal or greater are shifted to
+    /// a position with an index incremented by one.
+    ///
+    /// Returns an error if no additional elements fit into the section.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    pub fn insert(
+        &mut self,
+        index: usize,
+        element: T,
+    ) -> Result<(), Exhausted> {
+        self.check_append_len(1)?;
+        self.elements.insert(index, element);
+        Ok(())
+    }
+
+    /// Moves all elements of `other` in `self`, leaving `other` empty.
+    ///
+    /// If adding all elements would exceed the size limit, returns an error
+    /// and does nothing.
+    pub fn append<const M: usize>(
+        &mut self,
+        other: &mut Section<T, M>,
+    ) -> Result<(), Exhausted> {
+        self.check_append_len(other.elements.len())?;
+        self.elements.append(&mut other.elements);
+        Ok(())
+    }
+
+    /// Clones and adds all elements in the given slice.
+    ///
+    /// Iterates over the slice, clones each element and appends it to the
+    /// section.
+    ///
+    /// If adding all elements would exceed the size limit, returns an error
+    /// and does nothing.
+    pub fn extend_from_slice(&mut self, other: &[T]) -> Result<(), Exhausted>
+    where
+        T: Clone,
+    {
+        self.check_append_len(other.len())?;
+        self.elements.extend_from_slice(other);
+        Ok(())
+    }
+}
+
+impl<T, const N: usize> Section<T, N> {
+    /// Removes the last element from the section and returns it.
+    ///
+    /// Returns `None` if the section is empty.
+    pub fn pop(&mut self) -> Option<T> {
+        self.elements.pop()
+    }
+
+    /// Removes an element and returns it.
+    ///
+    /// All elements with larger indexes are shifted to a position with a
+    /// index decremented by one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    pub fn remove(&mut self, index: usize) -> T {
+        self.elements.remove(index)
+    }
+
+    /// Removes an element, returns it, and replaces it with the last one.
+    ///
+    /// This changes the order but can be done in _O_(1).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    pub fn swap_remove(&mut self, index: usize) -> T {
+        self.elements.swap_remove(index)
+    }
+
+    /// Shortens the section to at most the given length.
+    ///
+    /// Keeps the first `len` elements and drops the rest. If the section
+    /// is already up to `len` elements long, does nothing.
+    pub fn truncate(&mut self, len: usize) {
+        self.elements.truncate(len)
+    }
+
+    /// Retains only the elements for which a predicate returns `true`.
+    pub fn retain<F: FnMut(&T) -> bool>(&mut self, f: F) {
+        self.elements.retain(f)
+    }
+
+    /// Retains only the elements for which a predicate returns `true`.
+    ///
+    /// This version allows manipulating the elements while examining them.
+    pub fn retain_mut<F: FnMut(&mut T) -> bool>(&mut self, f: F) {
+        self.elements.retain_mut(f)
+    }
+
+    /// Removes the given range and returns it as an iterator.
+    ///
+    /// The method removes the specified range of elements from the section
+    /// and returns them as an iterator.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the starting point is greater than the end point or if the
+    /// end point is greater than the length of the vector.
+    ///
+    /// # Leaking
+    ///
+    /// If the returned iterator goes out of scope without being dropped (due
+    /// to `mem::forget`, for example), the vector may have lost and leaked
+    /// elements arbitrarily, including elements outside the range.
+    pub fn drain<R: ops::RangeBounds<usize>>(
+        &mut self,
+        range: R,
+    ) -> impl Iterator<Item = T> + '_ {
+        self.elements.drain(range)
+    }
+
+    /// Removes all elements from the section.
+    pub fn clear(&mut self) {
+        self.elements.clear()
+    }
+
+    /// Splits the section at the given index.
+    ///
+    /// Returns a newly allocated section containing the elements starting
+    /// with and including the one at the given index. The section will
+    /// retain all other elements.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at` is out of bounds.
+    pub fn split_off(&mut self, at: usize) -> Self {
+        Self {
+            elements: self.elements.split_off(at),
+        }
+    }
+
+    /// Removes consecutive equal elements.
+    pub fn dedup(&mut self)
+    where
+        T: PartialEq,
+    {
+        self.elements.dedup()
+    }
+
+    /// Removes all duplicate elements.
+    ///
+    /// Does so without changing the order of elements.
+    pub fn dedup_all(&mut self)
+    where
+        T: PartialEq,
+    {
+        // XXX Surely there is a more efficient impl?
+        for i in (1..self.len()).rev() {
+            for j in 0..(i - 1) {
+                if self.elements[i] == self.elements[j] {
+                    self.elements.remove(i);
+                }
+            }
+        }
+    }
+}
+
+//--- Default
+
+impl<T, const N: usize> Default for Section<T, N> {
+    fn default() -> Self {
+        Self {
+            elements: Default::default(),
+        }
+    }
+}
+
+//--- From and TryFrom
+//
+// Because a section can become full, most of these are TryFrom impls where
+// Vec<T> actually has From impls.
+
+impl<T, const N: usize> TryFrom<Vec<T>> for Section<T, N> {
+    type Error = Exhausted;
+
+    fn try_from(src: Vec<T>) -> Result<Self, Self::Error> {
+        if src.len() > N {
+            Err(Exhausted(()))
+        } else {
+            Ok(Self::from_vec_unchecked(src))
+        }
+    }
+}
+
+impl<T: Clone, const N: usize> TryFrom<&[T]> for Section<T, N> {
+    type Error = Exhausted;
+
+    fn try_from(src: &[T]) -> Result<Self, Self::Error> {
+        if src.len() > N {
+            Err(Exhausted(()))
+        } else {
+            Ok(Self::from_vec_unchecked(src.into()))
+        }
+    }
+}
+
+/// Creates a section from an array.
+///
+/// # Panics
+///
+/// This will panic if `N` is larger than `u16::MAX`.
+impl<T, const M: usize, const N: usize> From<[T; M]> for Section<T, N> {
+    fn from(src: [T; M]) -> Self {
+        assert!(M <= N);
+        Self::from_vec_unchecked(src.into())
+    }
+}
+
+impl<T, const M: usize, const N: usize> TryFrom<Section<T, N>> for [T; M] {
+    type Error = Section<T, N>;
+
+    fn try_from(src: Section<T, N>) -> Result<Self, Self::Error> {
+        src.elements.try_into().map_err(Section::from_vec_unchecked)
+    }
+}
+
+//--- Deref and DerefMut, AsRef and AsRefMut, Borrow and BorrowMut
+
+impl<T, const N: usize> ops::Deref for Section<T, N> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T, const N: usize> ops::DerefMut for Section<T, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<T, const N: usize> AsRef<[T]> for Section<T, N> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T, const N: usize> AsMut<[T]> for Section<T, N> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T, const N: usize> borrow::Borrow<[T]> for Section<T, N> {
+    fn borrow(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T, const N: usize> borrow::BorrowMut<[T]> for Section<T, N> {
+    fn borrow_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+//--- Extend
+//
+// No extend because it never fails.
+
+//--- Index and IndexMut
+
+impl<T, const N: usize, I: slice::SliceIndex<[T]>> ops::Index<I>
+    for Section<T, N>
+{
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        self.elements.index(index)
+    }
+}
+
+impl<T, const N: usize, I: slice::SliceIndex<[T]>> ops::IndexMut<I>
+    for Section<T, N>
+{
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        self.elements.index_mut(index)
+    }
+}
+
+//--- IntoIterator
+
+impl<T, const N: usize> IntoIterator for Section<T, N> {
+    type Item = T;
+    type IntoIter = vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.into_iter()
+    }
+}
+
+impl<'a, T, const N: usize> IntoIterator for &'a Section<T, N> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter()
+    }
+}
+
+impl<'a, T, const N: usize> IntoIterator for &'a mut Section<T, N> {
+    type Item = &'a mut T;
+    type IntoIter = slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter_mut()
+    }
+}
+
+//============ Helpers =======================================================
+
+//------------ Constants -----------------------------------------------------
+
+/// The maximum number of elements in a sections.
+///
+/// This is u16::MAX, but we need it as a usize. Because `From::from` isn’t
+/// const, we need to use `as` here.
+const MAX_SECTION_LEN: usize = u16::MAX as usize;
+
+//============ Errors ========================================================
+
+//------------ Exhausted -----------------------------------------------------
+
+/// A section’s space is exhausted.
+#[derive(Clone, Copy, Debug)]
+pub struct Exhausted(());
+
+impl fmt::Display for Exhausted {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("section space exhausted")
+    }
+}
+
+impl error::Error for Exhausted {}

--- a/src/plain/mod.rs
+++ b/src/plain/mod.rs
@@ -1,0 +1,53 @@
+//! More convenient variations of the base types.
+//!
+//! This module provides variations of the fundamental types in the
+//! [`base`] and [`rdata`] modules that are more
+//! convenient to use but may result in less efficient code under some
+//! circumstances or aren’t usable in all cases.
+//!
+//! First of all, all types herein use `Bytes` and `BytesMut` as their
+//! octet sequence types. These types provide a good balance between being
+//! owned and relatively cheaply shareable.
+#![cfg(feature = "plain")]
+
+//------------ Sub-modules ---------------------------------------------------
+
+pub mod message;
+
+//------------ Type Aliases --------------------------------------------------
+
+use crate::{base, rdata};
+use bytes::Bytes;
+
+/// The content of a DNS character string.
+pub type CharStr = base::charstr::CharStr<Bytes>;
+
+/// An uncompressed, absolute domain name.
+pub type Dname = base::name::Dname<Bytes>;
+
+/// An uncompressed, relative domain name.
+pub type RelativeDname = base::name::RelativeDname<Bytes>;
+
+/// A domain name that may be absolute or relative.
+pub type UncertainDname = base::name::UncertainDname<Bytes>;
+
+/// A question in a DNS message.
+pub type Question = base::question::Question<Dname>;
+
+/// Record data for all record types.
+pub type AllRecordData = rdata::AllRecordData<Bytes, Dname>;
+
+/// Record data for all record types allowed in zonefiles.
+pub type ZoneRecordData = rdata::ZoneRecordData<Bytes, Dname>;
+
+/// Generic record data.
+pub type UnknownRecordData = base::rdata::UnknownRecordData<Bytes>;
+
+/// A resource record covering all record types.
+pub type Record = base::record::Record<Dname, AllRecordData>;
+
+/// A resource record covering all record types allowed in zonefiles.
+pub type ZoneRecord = base::record::Record<Dname, ZoneRecordData>;
+
+/// Option data for all option types.
+pub type AllOptData = base::opt::AllOptData<Bytes, Dname>;

--- a/src/rdata/svcb/mod.rs
+++ b/src/rdata/svcb/mod.rs
@@ -23,7 +23,7 @@
 //! sequence of service parameters further describing properties of the
 //! service. These parameters are represented by the [SvcParams] type.
 //! They consist of a sequence of different parameter values. Types for
-//! the defined values are available in the [_value_][self::value] sub-module.
+//! the defined values are available in the _[value]_ sub-module.
 //! A new sequence of values can be constructed using the [`SvcParamsBuilder`]
 //! type.
 //!


### PR DESCRIPTION
This PR introduces a set of types for representing messages without the somewhat tedious generic octets sequences. Instead, all the types use `Bytes` as a compromise. The new `Message` keeps the elements of the four sections in vecs for easier manipulation.

I’ve chosen the name `plain` for this module since the types don’t have any type arguments. This is just a proposal and I am very open for alternative names.

As a side effect, this PR adds additional trait implementations and methods here and there.

This PR is a breaking change via _octseq_ needing a breaking change.