### PR TITLE
Add OctetsFrom and Debug impls for AllOptData.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain"
-version = "0.9.4-dev"
+version = "0.10.0-dev"
 rust-version = "1.67.0"
 edition = "2021"
 authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq           =  { version = "0.3.2", default-features = false }
+#octseq           =  { version = "0.3.2", default-features = false }
+octseq           = { git = "https://github.com/NLnetLabs/octseq.git", branch = "octets-from-for-str", default-features = false }
 pin-project-lite = "0.2"
 time             =  { version = "0.3.1", default-features = false }
 
@@ -25,7 +26,7 @@ rand           = { version = "0.8", optional = true }
 bytes          = { version = "1.0", optional = true, default-features = false }
 chrono         = { version = "0.4.6", optional = true, default-features = false }
 futures-util   = { version = "0.3", optional = true }
-heapless       = { version = "0.7", optional = true }
+heapless       = { version = "0.8", optional = true }
 #openssl       = { version = "0.10", optional = true }
 ring           = { version = "0.17", optional = true }
 serde          = { version = "1.0.130", optional = true, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ heapless       = { version = "0.8", optional = true }
 ring           = { version = "0.17", optional = true }
 serde          = { version = "1.0.130", optional = true, features = ["derive"] }
 siphasher      = { version = "1", optional = true }
-smallvec       = { version = "1", optional = true }
+smallvec       = { version = "1.3", optional = true }
 tokio          = { version = "1.33", optional = true, features = ["io-util", "macros", "net", "time", "sync", "rt-multi-thread" ] }
 tokio-rustls   = { version = "0.24", optional = true, features = [] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-#octseq           =  { version = "0.3.2", default-features = false }
-octseq           = { git = "https://github.com/NLnetLabs/octseq.git", branch = "octets-from-for-str", default-features = false }
+octseq           =  { version = "0.5", default-features = false }
 pin-project-lite = "0.2"
 time             =  { version = "0.3.1", default-features = false }
 

--- a/src/base/opt/algsig.rs
+++ b/src/base/opt/algsig.rs
@@ -46,7 +46,7 @@ use core::marker::PhantomData;
 /// Once you have a value, you can iterate over the algorithms via the
 /// [`iter`][Understood::iter] method or use the `IntoIterator` implementation
 /// for a reference.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct Understood<Variant, Octs: ?Sized> {
     /// A marker for the variant.
     marker: PhantomData<Variant>,
@@ -389,6 +389,32 @@ where
             }
         }
         Ok(())
+    }
+}
+
+//--- Debug
+
+impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<DauVariant, Octs> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Understood<DauVariant>")
+            .field(&format_args!("{}", self))
+            .finish()
+    }
+}
+
+impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<DhuVariant, Octs> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Understood<DhuVariant>")
+            .field(&format_args!("{}", self))
+            .finish()
+    }
+}
+
+impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<N3uVariant, Octs> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Understood<N3uVariant>")
+            .field(&format_args!("{}", self))
+            .finish()
     }
 }
 

--- a/src/base/opt/chain.rs
+++ b/src/base/opt/chain.rs
@@ -29,7 +29,7 @@ use core::cmp::Ordering;
 /// point of the included records, i.e., the suffix of the queried name
 /// furthest away from the root to which the requesting resolver already has
 /// all necessary records.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct Chain<Name: ?Sized> {
     /// The start name AKA ‘closest trust point.’
     start: Name
@@ -163,11 +163,19 @@ impl<Name: ToDname> ComposeOptData for Chain<Name> {
     }
 }
 
-//--- Display
+//--- Display and Debug
 
 impl<Name: fmt::Display> fmt::Display for Chain<Name> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.start)
+    }
+}
+
+impl<Name: fmt::Display> fmt::Debug for Chain<Name> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Chain")
+            .field("start", &format_args!("{}", self.start))
+            .finish()
     }
 }
 

--- a/src/base/opt/cookie.rs
+++ b/src/base/opt/cookie.rs
@@ -156,6 +156,13 @@ impl Cookie {
             )
         )
     }
+
+    /// Placeholder for unnecessary octets conversion.
+    ///
+    /// This method only exists for the `AllOptData` macro.
+    pub(super) fn try_octets_from<E>(src: Self) -> Result<Self, E> {
+        Ok(src)
+    }
 }
 
 

--- a/src/base/opt/expire.rs
+++ b/src/base/opt/expire.rs
@@ -55,6 +55,13 @@ impl Expire {
             u32::parse(parser).map(|res| Expire::new(Some(res)))
         }
     }
+
+    /// Placeholder for unnecessary octets conversion.
+    ///
+    /// This method only exists for the `AllOptData` macro.
+    pub(super) fn try_octets_from<E>(src: Self) -> Result<Self, E> {
+        Ok(src)
+    }
 }
 
 //--- OptData

--- a/src/base/opt/exterr.rs
+++ b/src/base/opt/exterr.rs
@@ -14,7 +14,7 @@ use super::{
     BuildDataError, LongOptData, Opt, OptData, ComposeOptData, ParseOptData
 };
 use octseq::builder::OctetsBuilder;
-use octseq::octets::Octets;
+use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 use octseq::str::Str;
 use core::{fmt, hash, str};
@@ -146,6 +146,25 @@ where Octs: AsRef<[u8]> {
     }
 }
 
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<ExtendedError<SrcOcts>> for ExtendedError<Octs>
+where
+    Octs: OctetsFrom<SrcOcts>
+{
+    type Error = Octs::Error;
+
+    fn try_octets_from(
+        source: ExtendedError<SrcOcts>
+    ) -> Result<Self, Self::Error> {
+        let text = match source.text {
+            Some(Ok(text)) => Some(Ok(Str::try_octets_from(text)?)),
+            Some(Err(octs)) => Some(Err(Octs::try_octets_from(octs)?)),
+            None => None,
+        };
+        Ok(Self { code: source.code, text })
+    }
+}
 //--- OptData, ParseOptData, and ComposeOptData
 
 impl<Octs> OptData for ExtendedError<Octs> {

--- a/src/base/opt/keepalive.rs
+++ b/src/base/opt/keepalive.rs
@@ -55,6 +55,13 @@ impl TcpKeepalive {
             IdleTimeout::parse(parser).map(|v| Self::new(Some(v)))
         }
     }
+
+    /// Placeholder for unnecessary octets conversion.
+    ///
+    /// This method only exists for the `AllOptData` macro.
+    pub(super) fn try_octets_from<E>(src: Self) -> Result<Self, E> {
+        Ok(src)
+    }
 }
 
 //--- OptData
@@ -144,7 +151,7 @@ impl IdleTimeout {
     const COMPOSE_LEN: u16 = 2;
 
     /// Parses a value from its wire format.
-    fn parse<Octs: AsRef<[u8]>>(
+    fn parse<Octs: AsRef<[u8]> + ?Sized>(
         parser: &mut Parser<Octs>
     ) -> Result<Self, ParseError> {
         u16::parse(parser).map(Self)

--- a/src/base/opt/keytag.rs
+++ b/src/base/opt/keytag.rs
@@ -13,7 +13,7 @@ use super::super::message_builder::OptBuilder;
 use super::super::wire::{Composer, ParseError};
 use super::{Opt, OptData, ComposeOptData, ParseOptData};
 use octseq::builder::OctetsBuilder;
-use octseq::octets::Octets;
+use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 use core::{borrow, fmt, hash};
 use core::cmp::Ordering;
@@ -146,6 +146,19 @@ impl<Octs: ?Sized> KeyTag<Octs> {
     pub fn iter(&self) -> KeyTagIter
     where Octs: AsRef<[u8]> {
         KeyTagIter(self.octets.as_ref())
+    }
+}
+
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<KeyTag<SrcOcts>> for KeyTag<Octs>
+where Octs: OctetsFrom<SrcOcts> {
+    type Error = Octs::Error;
+
+    fn try_octets_from(src: KeyTag<SrcOcts>) -> Result<Self, Self::Error> {
+        Octs::try_octets_from(src.octets).map(|octets| unsafe {
+            Self::from_octets_unchecked(octets)
+        })
     }
 }
 

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -830,7 +830,7 @@ pub trait ComposeOptData: OptData {
 /// An OPT option in its raw form.
 ///
 /// This type accepts any option type via its option code and raw data.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct UnknownOptData<Octs> {
     /// The option code for the option.
     code: OptionCode,
@@ -888,6 +888,23 @@ impl<Octs> UnknownOptData<Octs> {
     }
 }
 
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<UnknownOptData<SrcOcts>>
+    for UnknownOptData<Octs>
+where
+    Octs: OctetsFrom<SrcOcts>,
+{
+    type Error = Octs::Error;
+
+    fn try_octets_from(
+        src: UnknownOptData<SrcOcts>,
+    ) -> Result<Self, Self::Error> {
+        Ok(unsafe {
+            Self::new_unchecked(src.code, Octs::try_octets_from(src.data)?)
+        })
+    }
+}
 //--- AsRef and AsMut
 
 impl<Octs> AsRef<Octs> for UnknownOptData<Octs> {
@@ -947,11 +964,20 @@ impl<Octs: AsRef<[u8]>> ComposeOptData for UnknownOptData<Octs> {
     }
 }
 
-//--- Display
+//--- Display and Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Display for UnknownOptData<Octs> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         base16::display(self.data.as_ref(), f)
+    }
+}
+
+impl<Octs: AsRef<[u8]>> fmt::Debug for UnknownOptData<Octs> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("UnknownOptData")
+            .field("code", &self.code)
+            .field("data", &format_args!("{}", self))
+            .finish()
     }
 }
 

--- a/src/base/opt/nsid.rs
+++ b/src/base/opt/nsid.rs
@@ -14,7 +14,7 @@ use super::{
     BuildDataError, LongOptData, Opt, OptData, ComposeOptData, ParseOptData
 };
 use octseq::builder::OctetsBuilder;
-use octseq::octets::Octets;
+use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 use core::{borrow, fmt, hash, str};
 use core::cmp::Ordering;
@@ -126,6 +126,19 @@ impl<Octs: ?Sized> Nsid<Octs> {
         Octs: AsRef<[u8]>
     {
         unsafe { Nsid::from_slice_unchecked(self.octets.as_ref()) }
+    }
+}
+
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<Nsid<SrcOcts>> for Nsid<Octs>
+where Octs: OctetsFrom<SrcOcts> {
+    type Error = Octs::Error;
+
+    fn try_octets_from(src: Nsid<SrcOcts>) -> Result<Self, Self::Error> {
+        Octs::try_octets_from(src.octets).map(|octets| unsafe {
+            Self::from_octets_unchecked(octets)
+        })
     }
 }
 

--- a/src/base/opt/padding.rs
+++ b/src/base/opt/padding.rs
@@ -14,7 +14,7 @@ use super::super::message_builder::OptBuilder;
 use super::super::wire::{Compose, Composer, ParseError};
 use super::{LongOptData, OptData, ComposeOptData, ParseOptData};
 use octseq::builder::OctetsBuilder;
-use octseq::octets::Octets;
+use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 
 
@@ -88,6 +88,19 @@ impl<Octs: ?Sized> Padding<Octs> {
         Octs: AsRef<[u8]>,
     {
         self.octets.as_ref()
+    }
+}
+
+//--- OctetsFrom
+
+impl<Octs, SrcOcts> OctetsFrom<Padding<SrcOcts>> for Padding<Octs>
+where Octs: OctetsFrom<SrcOcts> {
+    type Error = Octs::Error;
+
+    fn try_octets_from(src: Padding<SrcOcts>) -> Result<Self, Self::Error> {
+        Octs::try_octets_from(src.octets).map(|octets| unsafe {
+            Self::from_octets_unchecked(octets)
+        })
     }
 }
 

--- a/src/base/opt/subnet.rs
+++ b/src/base/opt/subnet.rs
@@ -169,6 +169,13 @@ impl ClientSubnet {
             addr,
         })
     }
+
+    /// Placeholder for unnecessary octets conversion.
+    ///
+    /// This method only exists for the `AllOptData` macro.
+    pub(super) fn try_octets_from<E>(src: Self) -> Result<Self, E> {
+        Ok(src)
+    }
 }
 
 //--- OptData


### PR DESCRIPTION
This PR adds implementation for `OctetsFrom` and `Debug` to `AllOptData`. As a consequence, this also adds these to some of the option data types and changes `Debug` for some of them to be available for all octets sequences.

This is a breaking change via a necessary breaking change in `octseq`.