### PR TITLE
Fix `Display` impl for `Txt` and add `CharStr::display_quoted`.

### DIFF
--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -269,12 +269,20 @@ impl<Octs: AsRef<[u8]> + ?Sized> CharStr<Octs> {
     }
 }
 
-impl<Octets> CharStr<Octets> {
+impl<Octs> CharStr<Octs> {
     /// Scans the presentation format from a scanner.
-    pub fn scan<S: Scanner<Octets = Octets>>(
+    pub fn scan<S: Scanner<Octets = Octs>>(
         scanner: &mut S,
     ) -> Result<Self, S::Error> {
         scanner.scan_charstr()
+    }
+
+    /// Returns an object that displays the string always quoted.
+    pub fn display_quoted(&self) -> DisplayQuoted
+    where
+        Octs: AsRef<[u8]>,
+    {
+        DisplayQuoted(self.for_slice())
     }
 }
 
@@ -794,6 +802,24 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
+//------------ DisplayQuoted -------------------------------------------------
+
+/// Helper struct for display a character string surrounded by quotes.
+///
+/// A value of this type can be obtained via `CharStr::display_quoted`.
+#[derive(Clone, Copy, Debug)]
+pub struct DisplayQuoted<'a>(&'a CharStr<[u8]>);
+
+impl<'a> fmt::Display for DisplayQuoted<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("\"")?;
+        for &ch in self.0.as_ref() {
+            fmt::Display::fmt(&Symbol::from_quoted_octet(ch), f)?;
+        }
+        f.write_str("\"")
+    }
+}
+
 //============ Error Types ===================================================
 
 //------------ CharStrError --------------------------------------------------
@@ -1035,5 +1061,29 @@ mod test {
                 Token::Str("fo\\018"),
             ],
         );
+    }
+
+    #[test]
+    fn display() {
+        fn cmp(input: &[u8], normal: &str, quoted: &str) {
+            assert_eq!(
+                format!("{}", CharStr::from_octets(input).unwrap()),
+                normal
+            );
+            assert_eq!(
+                format!(
+                    "{}",
+                    CharStr::from_octets(input).unwrap().display_quoted()
+                ),
+                quoted
+            );
+        }
+
+        cmp(b"foo", "foo", "\"foo\"");
+        cmp(b"f oo", "f\\ oo", "\"f oo\"");
+        cmp(b"f\"oo", "f\\\"oo", "f\\\"oo\"");
+        cmp(b"f\\oo", "f\\ oo", "\"f\\\\oo\"");
+        cmp(b"f;oo", "f\\;oo", "\"f;oo\"");
+        cmp(b"f\noo", "f\\010oo", "\"f\\010oo\"");
     }
 }

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -1081,8 +1081,8 @@ mod test {
 
         cmp(b"foo", "foo", "\"foo\"");
         cmp(b"f oo", "f\\ oo", "\"f oo\"");
-        cmp(b"f\"oo", "f\\\"oo", "f\\\"oo\"");
-        cmp(b"f\\oo", "f\\ oo", "\"f\\\\oo\"");
+        cmp(b"f\"oo", "f\\\"oo", "\"f\\\"oo\"");
+        cmp(b"f\\oo", "f\\\\oo", "\"f\\\\oo\"");
         cmp(b"f;oo", "f\\;oo", "\"f;oo\"");
         cmp(b"f\noo", "f\\010oo", "\"f\\010oo\"");
     }

--- a/src/base/scan.rs
+++ b/src/base/scan.rs
@@ -594,7 +594,7 @@ impl Symbol {
     /// simple escape and all non-printable characters using decimal escapes.
     #[must_use]
     pub fn from_quoted_octet(ch: u8) -> Self {
-        if ch == b'"' {
+        if ch == b'"' || ch == b'\\' {
             Symbol::SimpleEscape(ch)
         } else if !(0x20..0x7F).contains(&ch) {
             Symbol::DecimalEscape(ch)

--- a/src/base/scan.rs
+++ b/src/base/scan.rs
@@ -588,6 +588,21 @@ impl Symbol {
         }
     }
 
+    /// Provides the best symbol for an octet inside a quoted string.
+    ///
+    /// The function will only escape a double quote and backslash using the
+    /// simple escape and all non-printable characters using decimal escapes.
+    #[must_use]
+    pub fn from_quoted_octet(ch: u8) -> Self {
+        if ch == b'"' {
+            Symbol::SimpleEscape(ch)
+        } else if !(0x20..0x7F).contains(&ch) {
+            Symbol::DecimalEscape(ch)
+        } else {
+            Symbol::Char(ch as char)
+        }
+    }
+
     /// Converts the symbol into an octet if it represents one.
     ///
     /// Both domain names and character strings operate on bytes instead of
@@ -698,7 +713,7 @@ impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Symbol::Char(ch) => write!(f, "{}", ch),
-            Symbol::SimpleEscape(ch) => write!(f, "\\{}", ch),
+            Symbol::SimpleEscape(ch) => write!(f, "\\{}", ch as char),
             Symbol::DecimalEscape(ch) => write!(f, "\\{:03}", ch),
         }
     }


### PR DESCRIPTION
This PR fixes the `Display` implementation for the `Txt` record data type. It now prints each character string separately and quoted. It uses the new `CharStr::display_quoted` method that prints the content of a character string quoted and with only necessary characters escaped.

Fixes #259.