### PR TITLE
Fix example for `Dname::from_slice`.

### DIFF
--- a/src/base/name/dname.rs
+++ b/src/base/name/dname.rs
@@ -197,7 +197,7 @@ impl Dname<[u8]> {
     ///
     /// ```
     /// use domain::base::name::Dname;
-    /// Dname::from_slice(b"\x07example\x03com");
+    /// Dname::from_slice(b"\x07example\x03com\x00");
     /// ```
     ///
     /// # Errors


### PR DESCRIPTION
This PR fixes the usage example for `Dname::from_slice` which was using an illegal slice.

Fixes #263.