### PR TITLE
Redesign `CharStr` formatting and serialization.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ unstable-client-transport = []
 [dev-dependencies]
 rustls             = { version = "0.21.9" }
 serde_test         = "1.0.130"
+serde_json         = "1.0.113"
 serde_yaml         = "0.9"
 tokio              = { version = "1", features = ["rt-multi-thread", "io-util", "net"] }
 tokio-test	   = "0.4"

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -55,12 +55,12 @@ use std::vec::Vec;
 ///
 /// The text representation of a character string comes in two flavors:
 /// Quoted and unquoted. In both cases, the content is interpreted as ASCII
-/// text and those octets that aren’t printable ASCII character as well as
-/// some special symbols are escaped.
+/// text and those octets that aren’t printable ASCII characters, as well as
+/// some special symbols, are escaped.
 ///
 /// There are two escaping mechanisms: octets that are printable ASCII
 /// characters but need to be escaped anyway use what we call a “simple
-/// escape” by precedes the character with an ASCII backslash. For all
+/// escape” that precedes the character with an ASCII backslash. For all
 /// non-printable octets “decimal escapes” are used: an ASCII backslash is
 /// followed by three decimal digits representing the decimal value of the
 /// octet. A consequence if this is that you cannot escape the digits 0, 1,

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -1150,7 +1150,7 @@ mod test {
         use serde_test::{assert_tokens, Configure, Token};
 
         assert_tokens(
-            &CharStr::from_octets(Vec::from(b"fo\x12 bar"))
+            &CharStr::from_octets(Vec::from(b"fo\x12 bar".as_ref()))
                 .unwrap()
                 .compact(),
             &[
@@ -1160,7 +1160,7 @@ mod test {
         );
 
         assert_tokens(
-            &CharStr::from_octets(Vec::from(b"fo\x12 bar"))
+            &CharStr::from_octets(Vec::from(b"fo\x12 bar".as_ref()))
                 .unwrap()
                 .readable(),
             &[

--- a/src/base/scan.rs
+++ b/src/base/scan.rs
@@ -590,11 +590,26 @@ impl Symbol {
 
     /// Provides the best symbol for an octet inside a quoted string.
     ///
-    /// The function will only escape a double quote and backslash using the
+    /// The function will only escape a double quote and backslash using a
     /// simple escape and all non-printable characters using decimal escapes.
     #[must_use]
-    pub fn from_quoted_octet(ch: u8) -> Self {
+    pub fn quoted_from_octet(ch: u8) -> Self {
         if ch == b'"' || ch == b'\\' {
+            Symbol::SimpleEscape(ch)
+        } else if !(0x20..0x7F).contains(&ch) {
+            Symbol::DecimalEscape(ch)
+        } else {
+            Symbol::Char(ch as char)
+        }
+    }
+
+    /// Provides the best symbol for an octet inside a `Display` impl.
+    ///
+    /// The function will only escape a backslash using a simple escape and
+    /// all non-printable characters using decimal escapes.
+    #[must_use]
+    pub fn display_from_octet(ch: u8) -> Self {
+        if ch == b'\\' {
             Symbol::SimpleEscape(ch)
         } else if !(0x20..0x7F).contains(&ch) {
             Symbol::DecimalEscape(ch)


### PR DESCRIPTION
This PR redesigns the conversion of `CharStr` from and to text formats.

It distinguishes between three text formats: quoted and unquoted representation format (i.e., what’s used in zonefiles) and a serialization format which is an unquoted format with only backslash and non-printable octets escaped. The latter will be used in serialization but also by default for `Display`. This makes it reversible with the `FromStr` implementation but avoids escaping white space. Methods for explicitly displaying in quoted and unquoted representation format are provided.

Serialization works mostly as before but uses the serialization format rather than the unquoted representation format in human-readable formats. It still uses the raw octets in binary formats.

The PR adds proper documentation for all of it to the type.

This is a breaking change. 