### PR TITLE
Fix TXT record serialization.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq           =  { version = "0.5", default-features = false }
+octseq           =  { version = "0.5.1", default-features = false }
 pin-project-lite = "0.2"
 time             =  { version = "0.3.1", default-features = false }
 

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -95,8 +95,8 @@ use std::vec::Vec;
 /// # Serde support
 ///
 /// When the `serde` feature is enabled, the type supports serialization and
-/// deserialization. The format differs for human readable and non-human
-/// readable serialization formats.
+/// deserialization. The format differs for human readable and compact
+/// serialization formats.
 ///
 /// For human readable formats, character strings are serialized as a newtype
 /// `CharStr` wrapping a string with the content as an ASCII string.
@@ -113,7 +113,7 @@ use std::vec::Vec;
 /// When deserializing, escape sequences are excepted for all octets and
 /// translated. Non-ASCII characters are not accepted and lead to error.
 ///
-/// For non-human readable formats, character strings are serialized as a
+/// For compact formats, character strings are serialized as a
 /// newtype `CharStr` wrapping a byte array with the content as is.
 ///
 /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
@@ -295,6 +295,35 @@ impl CharStr<[u8]> {
             .map(|bytes| unsafe { Self::from_slice_unchecked(bytes) })
             .map_err(Into::into)
     }
+
+    /// Decodes the readable epresentation and appends it to a builder.
+    ///
+    /// This is a helper function used both by the `FromStr` impl and
+    /// deserialization. It reads the string in unquoted form and appends its
+    /// wire format to the builder. Note that this does _not_ contain the
+    /// length octet. The function does, however, return the value of the
+    /// length octet.
+    ///
+    /// The function is here on `CharStr<[u8]>` so that it can be called
+    /// simply via `CharStr::append_from_str` with providing a type argument.
+    fn append_from_str(
+        s: &str,
+        target: &mut impl OctetsBuilder,
+    ) -> Result<u8, FromStrError> {
+        let mut len = 0u8;
+        let mut chars = s.chars();
+        while let Some(symbol) = Symbol::from_chars(&mut chars)? {
+            // We have the max length but there’s another character. Error!
+            if len == u8::MAX {
+                return Err(FromStrError::LongString);
+            }
+            target
+                .append_slice(&[symbol.into_octet()?])
+                .map_err(Into::into)?;
+            len += 1;
+        }
+        Ok(len)
+    }
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> CharStr<Octs> {
@@ -410,13 +439,7 @@ where
             CharStrBuilder::<<Octets as FromBuilder>::Builder>::with_capacity(
                 s.len(),
             );
-        let mut chars = s.chars();
-        while let Some(symbol) = Symbol::from_chars(&mut chars)? {
-            if builder.len() == CharStr::MAX_LEN {
-                return Err(FromStrError::LongString);
-            }
-            builder.append_slice(&[symbol.into_octet()?])?
-        }
+        CharStr::append_from_str(s, &mut builder)?;
         Ok(builder.finish())
     }
 }
@@ -924,6 +947,138 @@ impl<'a> fmt::Display for DisplayUnquoted<'a> {
             fmt::Display::fmt(&Symbol::from_octet(ch), f)?;
         }
         Ok(())
+    }
+}
+
+//------------ DeserializeCharStrSeed ----------------------------------------
+
+/// A helper type to deserialize a character string into an octets builder.
+///
+/// This type can be used when deserializing a type that keeps a character
+/// string in wire format as part of a longer octets sequence. It uses the
+/// `DeserializeSeed` trait to append the content to an octets builder and
+/// returns `()` as the actual value.
+pub struct DeserializeCharStrSeed<'a, Builder> {
+    builder: &'a mut Builder,
+}
+
+impl<'a, Builder> DeserializeCharStrSeed<'a, Builder> {
+    /// Creates a new value wrapping a ref mut to the builder to append to.
+    pub fn new(builder: &'a mut Builder) -> Self {
+        Self { builder }
+    }
+}
+
+impl<'de, 'a, Builder> serde::de::DeserializeSeed<'de>
+    for DeserializeCharStrSeed<'a, Builder>
+where
+    Builder: OctetsBuilder + AsMut<[u8]>,
+{
+    // We don’t return anything but append the value to `self.builder`.
+    type Value = ();
+
+    fn deserialize<D: serde::de::Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        // Here’s how this all hangs together: CharStr serializes as a
+        // newtype, so we have a visitor for that. It dispatches to an
+        // inner vistor that differs for binary and human-readable formats.
+        // All of them just wrap around the `self` we’ve been given.
+
+        // Visitor for the outer newtype
+        struct NewtypeVisitor<'a, Builder>(
+            DeserializeCharStrSeed<'a, Builder>,
+        );
+
+        impl<'de, 'a, Builder> serde::de::Visitor<'de> for NewtypeVisitor<'a, Builder>
+        where
+            Builder: OctetsBuilder + AsMut<[u8]>,
+        {
+            type Value = ();
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a character string")
+            }
+
+            fn visit_newtype_struct<D: serde::Deserializer<'de>>(
+                self,
+                deserializer: D,
+            ) -> Result<Self::Value, D::Error> {
+                if deserializer.is_human_readable() {
+                    deserializer.deserialize_str(ReadableVisitor(self.0))
+                } else {
+                    deserializer.deserialize_bytes(BinaryVisitor(self.0))
+                }
+            }
+        }
+
+        // Visitor for a human readable inner value
+        struct ReadableVisitor<'a, Builder>(
+            DeserializeCharStrSeed<'a, Builder>,
+        );
+
+        impl<'de, 'a, Builder> serde::de::Visitor<'de>
+            for ReadableVisitor<'a, Builder>
+        where
+            Builder: OctetsBuilder + AsMut<[u8]>,
+        {
+            type Value = ();
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a character string")
+            }
+
+            fn visit_str<E: serde::de::Error>(
+                self,
+                value: &str,
+            ) -> Result<Self::Value, E> {
+                // Append a placeholder for the length octet, remember its
+                // index.
+                let start = self.0.builder.as_mut().len();
+                self.0
+                    .builder
+                    .append_slice(&[0])
+                    .map_err(|_| E::custom(ShortBuf))?;
+
+                // Decode and append the string.
+                let len = CharStr::append_from_str(value, self.0.builder)
+                    .map_err(E::custom)?;
+
+                // Update the length octet.
+                self.0.builder.as_mut()[start] = len;
+                Ok(())
+            }
+        }
+
+        // Visitor for a binary inner value
+        struct BinaryVisitor<'a, Builder>(
+            DeserializeCharStrSeed<'a, Builder>,
+        );
+
+        impl<'de, 'a, Builder> serde::de::Visitor<'de> for BinaryVisitor<'a, Builder>
+        where
+            Builder: OctetsBuilder,
+        {
+            type Value = ();
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a character string")
+            }
+
+            fn visit_bytes<E: serde::de::Error>(
+                self,
+                value: &[u8],
+            ) -> Result<Self::Value, E> {
+                CharStr::from_slice(value)
+                    .map_err(E::custom)?
+                    .compose(self.0.builder)
+                    .map_err(|_| E::custom(ShortBuf))
+            }
+        }
+
+        deserializer
+            .deserialize_newtype_struct("CharStr", NewtypeVisitor(self))
     }
 }
 

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -296,7 +296,7 @@ impl CharStr<[u8]> {
             .map_err(Into::into)
     }
 
-    /// Decodes the readable epresentation and appends it to a builder.
+    /// Decodes the readable presentation and appends it to a builder.
     ///
     /// This is a helper function used both by the `FromStr` impl and
     /// deserialization. It reads the string in unquoted form and appends its
@@ -305,7 +305,8 @@ impl CharStr<[u8]> {
     /// length octet.
     ///
     /// The function is here on `CharStr<[u8]>` so that it can be called
-    /// simply via `CharStr::append_from_str` with providing a type argument.
+    /// simply via `CharStr::append_from_str` without having to provide a
+    /// type argument.
     fn append_from_str(
         s: &str,
         target: &mut impl OctetsBuilder,

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -958,10 +958,12 @@ impl<'a> fmt::Display for DisplayUnquoted<'a> {
 /// string in wire format as part of a longer octets sequence. It uses the
 /// `DeserializeSeed` trait to append the content to an octets builder and
 /// returns `()` as the actual value.
+#[cfg(feature = "serde")]
 pub struct DeserializeCharStrSeed<'a, Builder> {
     builder: &'a mut Builder,
 }
 
+#[cfg(feature = "serde")]
 impl<'a, Builder> DeserializeCharStrSeed<'a, Builder> {
     /// Creates a new value wrapping a ref mut to the builder to append to.
     pub fn new(builder: &'a mut Builder) -> Self {
@@ -969,6 +971,7 @@ impl<'a, Builder> DeserializeCharStrSeed<'a, Builder> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, 'a, Builder> serde::de::DeserializeSeed<'de>
     for DeserializeCharStrSeed<'a, Builder>
 where

--- a/src/rdata/rfc1035/hinfo.rs
+++ b/src/rdata/rfc1035/hinfo.rs
@@ -10,8 +10,9 @@ use crate::base::rdata::{
 };
 use crate::base::scan::Scanner;
 use crate::base::wire::{Composer, ParseError};
-use core::{fmt, hash, str};
+use core::{fmt, hash};
 use core::cmp::Ordering;
+#[cfg(feature = "serde")]
 use octseq::builder::{EmptyBuilder, FromBuilder};
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;

--- a/src/rdata/rfc1035/minfo.rs
+++ b/src/rdata/rfc1035/minfo.rs
@@ -10,7 +10,7 @@ use crate::base::rdata::{
 };
 use crate::base::scan::Scanner;
 use crate::base::wire::{Composer, ParseError};
-use core::{fmt, str};
+use core::fmt;
 use core::cmp::Ordering;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;

--- a/src/rdata/rfc1035/mx.rs
+++ b/src/rdata/rfc1035/mx.rs
@@ -10,7 +10,7 @@ use crate::base::rdata::{
 };
 use crate::base::scan::{Scan, Scanner};
 use crate::base::wire::{Compose, Composer, Parse, ParseError};
-use core::{fmt, str};
+use core::fmt;
 use core::cmp::Ordering;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;

--- a/src/rdata/rfc1035/null.rs
+++ b/src/rdata/rfc1035/null.rs
@@ -8,7 +8,7 @@ use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData,
 };
 use crate::base::wire::{Composer, ParseError};
-use core::{fmt, hash, str};
+use core::{fmt, hash};
 use core::cmp::Ordering;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;

--- a/src/rdata/rfc1035/soa.rs
+++ b/src/rdata/rfc1035/soa.rs
@@ -12,7 +12,7 @@ use crate::base::record::Ttl;
 use crate::base::scan::{Scan, Scanner};
 use crate::base::serial::Serial;
 use crate::base::wire::{Compose, Composer, ParseError};
-use core::{fmt, str};
+use core::fmt;
 use core::cmp::Ordering;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;

--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -3,6 +3,8 @@
 //! This is a private module. It’s content is re-exported by the parent.
 
 use crate::base::charstr::CharStr;
+#[cfg(feature = "serde")]
+use crate::base::charstr::DeserializeCharStrSeed;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::rdata::{
@@ -28,23 +30,53 @@ use octseq::serde::{DeserializeOctets, SerializeOctets};
 
 //------------ Txt ----------------------------------------------------------
 
-/// Txt record data.
+/// TXT record data.
 ///
-/// Txt records hold descriptive text. While it may appear as a single text,
+/// TXT records hold descriptive text. While it may appear as a single text,
 /// it internally consists of a sequence of one or more [character
 /// strings][CharStr]. The type holds this sequence in its encoded form, i.e.,
 /// each character string is at most 255 octets long and preceded by an
 /// octet with its length.
 ///
 /// The type provides means to iterate over these strings, either as
-/// [`CharStr`s][CharStr] via [`iter_char_strs`][Self::iter_char_strs] or
-/// as plain octets slices via [`iter`]. There is a short cut for the most
-/// common case of there being exactly one character string in
+/// [`CharStr`s][CharStr] via [`iter_charstrs`][Self::iter_charstrs] or
+/// as plain octets slices via [`iter`][Self::iter]. There is a short cut for
+/// the most common case of there being exactly one character string in
 /// [`as_flat_slice`][Self::as_flat_slice]. Finally, the two methods
 /// [`text`][Self::text] and [`try_text`][Self::try_text] allow combining the
 /// content into one single octets sequence.
 ///
-/// The Txt record type is defined in RFC 1035, section 3.3.14.
+/// The TXT record type is defined in [RFC 1035], section 3.3.14.
+///
+/// # Presentation format
+///
+/// TXT record data appears in zone files as the white-space delimited
+/// sequence of its constituent [character strings][CharStr]. This means that
+/// if these strings are not quoted, each “word” results in a character string
+/// of its own. Thus, the quoted form of the character string’s presentation
+/// format is preferred.
+///
+/// # `Display`
+///
+/// The `Display` implementation prints the sequence of character strings in
+/// their quoted presentation format separated by a single space.
+///
+/// # Serde support
+///
+/// When the `serde` feature is enabled, the type supports serialization and
+/// deserialization. The format differs for human readable and compact
+/// serialization formats.
+///
+/// For human-readable formats, the type serializes into a newtype `Txt`
+/// wrapping a sequence of serialized [`CharStr`]s. The deserializer supports
+/// a single string instead of the sequence – but unfortunately not all
+/// format implementations support alternative deserialization based on the
+/// encountered type. In particular, _serde-json_ doesn’t.
+///
+/// For compact formats, the type serializes as a newtype `Txt` that contains
+/// a byte array of the wire format representation of the content.
+///
+/// [RFC 1035]: https://tools.ietf.org/html/rfc1035
 #[derive(Clone)]
 pub struct Txt<Octs: ?Sized>(Octs);
 
@@ -164,13 +196,13 @@ impl<Octs: AsRef<[u8]> + ?Sized> Txt<Octs> {
     ///
     /// The returned iterator will always return at least one octets slice.
     pub fn iter(&self) -> TxtIter {
-        TxtIter(self.iter_char_strs())
+        TxtIter(self.iter_charstrs())
     }
 
     /// Returns an iterator over the character strings.
     ///
     /// The returned iterator will always return at least one octets slice.
-    pub fn iter_char_strs(&self) -> TxtCharStrIter {
+    pub fn iter_charstrs(&self) -> TxtCharStrIter {
         TxtCharStrIter(Parser::from_ref(self.0.as_ref()))
     }
 
@@ -400,7 +432,7 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Txt<Octs> {
 impl<Octs: AsRef<[u8]>> fmt::Display for Txt<Octs> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut first = true;
-        for slice in self.iter_char_strs() {
+        for slice in self.iter_charstrs() {
             if !first {
                 f.write_str(" ")?;
             }
@@ -447,9 +479,8 @@ where
                 serializer: S,
             ) -> Result<S::Ok, S::Error> {
                 let mut serializer = serializer.serialize_seq(None)?;
-                for item in self.0.iter_char_strs() {
-                    serializer
-                        .serialize_element(&format_args!("{}", item))?;
+                for item in self.0.iter_charstrs() {
+                    serializer.serialize_element(item)?;
                 }
                 serializer.end()
             }
@@ -457,7 +488,8 @@ where
 
         if serializer.is_human_readable() {
             serializer.serialize_newtype_struct("Txt", &TxtSeq(self))
-        } else {
+        }
+        else {
             serializer.serialize_newtype_struct(
                 "Txt",
                 &self.0.as_serialized_octets(),
@@ -477,11 +509,40 @@ where
     ) -> Result<Self, D::Error> {
         use core::marker::PhantomData;
 
-        struct InnerVisitor<'de, T: DeserializeOctets<'de>>(T::Visitor);
+        struct NewtypeVisitor<T>(PhantomData<T>);
 
-        impl<'de, Octs> serde::de::Visitor<'de> for InnerVisitor<'de, Octs>
+        impl<'de, Octs> serde::de::Visitor<'de> for NewtypeVisitor<Octs>
         where
             Octs: FromBuilder + DeserializeOctets<'de>,
+            <Octs as FromBuilder>::Builder:
+                OctetsBuilder + EmptyBuilder + AsRef<[u8]> + AsMut<[u8]>,
+        {
+            type Value = Txt<Octs>;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("TXT record data")
+            }
+
+            fn visit_newtype_struct<D: serde::Deserializer<'de>>(
+                self,
+                deserializer: D,
+            ) -> Result<Self::Value, D::Error> {
+                if deserializer.is_human_readable() {
+                    deserializer.deserialize_seq(ReadableVisitor(PhantomData))
+                } else {
+                    Octs::deserialize_with_visitor(
+                        deserializer,
+                        CompactVisitor(Octs::visitor()),
+                    )
+                }
+            }
+        }
+
+        struct ReadableVisitor<Octs>(PhantomData<Octs>);
+
+        impl<'de, Octs> serde::de::Visitor<'de> for ReadableVisitor<Octs>
+        where
+            Octs: FromBuilder,
             <Octs as FromBuilder>::Builder:
                 OctetsBuilder + EmptyBuilder + AsRef<[u8]> + AsMut<[u8]>,
         {
@@ -514,12 +575,35 @@ where
                 self,
                 mut seq: A,
             ) -> Result<Self::Value, A::Error> {
-                let mut builder =
-                    TxtBuilder::<<Octs as FromBuilder>::Builder>::new();
-                while let Some(s) = seq.next_element::<&'de str>()? {
-                    builder.append_zone_char_str(s)?;
+                let mut builder = <Octs as FromBuilder>::Builder::empty();
+                while seq.next_element_seed(
+                    DeserializeCharStrSeed::new(&mut builder)
+                )?.is_some() {
+                    LongRecordData::check_len(
+                        builder.as_ref().len()
+                    ).map_err(serde::de::Error::custom)?;
                 }
-                builder.finish().map_err(serde::de::Error::custom)
+                if builder.as_ref().is_empty() {
+                    builder.append_slice(b"\0").map_err(|_| {
+                        serde::de::Error::custom(ShortBuf)
+                    })?;
+                }
+                Ok(Txt(builder.freeze()))
+            }
+        }
+
+        struct CompactVisitor<'de, T: DeserializeOctets<'de>>(T::Visitor);
+
+        impl<'de, Octs> serde::de::Visitor<'de> for CompactVisitor<'de, Octs>
+        where
+            Octs: FromBuilder + DeserializeOctets<'de>,
+            <Octs as FromBuilder>::Builder:
+                OctetsBuilder + EmptyBuilder + AsRef<[u8]> + AsMut<[u8]>,
+        {
+            type Value = Txt<Octs>;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("TXT record data")
             }
 
             fn visit_borrowed_bytes<E: serde::de::Error>(
@@ -542,41 +626,9 @@ where
             }
         }
 
-        struct NewtypeVisitor<T>(PhantomData<T>);
-
-        impl<'de, Octs> serde::de::Visitor<'de> for NewtypeVisitor<Octs>
-        where
-            Octs: FromBuilder + DeserializeOctets<'de>,
-            <Octs as FromBuilder>::Builder:
-                OctetsBuilder + EmptyBuilder + AsRef<[u8]> + AsMut<[u8]>,
-        {
-            type Value = Txt<Octs>;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("TXT record data")
-            }
-
-            fn visit_newtype_struct<D: serde::Deserializer<'de>>(
-                self,
-                deserializer: D,
-            ) -> Result<Self::Value, D::Error> {
-                deserializer.deserialize_any(InnerVisitor(Octs::visitor()))
-                /*
-                if deserializer.is_human_readable() {
-                    deserializer
-                        .deserialize_str(InnerVisitor(Octs::visitor()))
-                } else {
-                    Octs::deserialize_with_visitor(
-                        deserializer,
-                        InnerVisitor(Octs::visitor()),
-                    )
-                }
-                */
-            }
-        }
-
-        deserializer
-            .deserialize_newtype_struct("Txt", NewtypeVisitor(PhantomData))
+        deserializer.deserialize_newtype_struct(
+            "Txt", NewtypeVisitor(PhantomData)
+        )
     }
 }
 
@@ -672,7 +724,7 @@ impl<Builder: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>> TxtBuilder<Builder> {
     /// character strings where all but the last one are 255 octets long.
     ///
     /// You can force a character string break by calling
-    /// [`close_char_str`][Self::close_char_str].
+    /// [`close_charstr`][Self::close_charstr].
     ///
     /// The method will return an error if appending the slice would result
     /// in exceeding the record data length limit or the underlying builder
@@ -728,7 +780,7 @@ impl<Builder: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>> TxtBuilder<Builder> {
     pub fn append_charstr<Octs: AsRef<[u8]> + ?Sized>(
         &mut self, s: &CharStr<Octs>
     ) -> Result<(), TxtAppendError> {
-        self.close_char_str();
+        self.close_charstr();
         LongRecordData::check_append_len(
             self.builder.as_ref().len(),
             usize::from(s.compose_len())
@@ -737,40 +789,11 @@ impl<Builder: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>> TxtBuilder<Builder> {
         Ok(())
     }
 
-    /// Appends a character string in zone file format.
-    ///
-    /// This is used by the Serde deserializer.
-    #[cfg(feature = "serde")]
-    fn append_zone_char_str<E: serde::de::Error>(
-        &mut self,
-        s: &str,
-    ) -> Result<(), E> {
-        use crate::base::charstr::CharStrError;
-
-        self.close_char_str();
-        self.start = Some(self.builder.as_ref().len());
-        self.builder_append_slice(&[0]).map_err(E::custom)?;
-        let mut len = 0;
-        let mut chars = s.chars();
-        while let Some(sym) =
-            Symbol::from_chars(&mut chars).map_err(E::custom)?
-        {
-            if len == 255 {
-                return Err(E::custom(CharStrError));
-            }
-            let sym = sym.into_octet().map_err(E::custom)?;
-            self.builder_append_slice(&[sym]).map_err(E::custom)?;
-            len += 1;
-        }
-        self.close_char_str();
-        Ok(())
-    }
-
     /// Ends a character string.
     ///
     /// If a previous call to [`append_slice`][Self::append_slice] started a
     /// new character string, a call to this method will close it.
-    pub fn close_char_str(&mut self) {
+    pub fn close_charstr(&mut self) {
         if let Some(start) = self.start {
             let last_slice_len = self.builder.as_ref().len() - (start + 1);
             self.builder.as_mut()[start] = last_slice_len as u8;
@@ -787,7 +810,7 @@ impl<Builder: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>> TxtBuilder<Builder> {
     where
         Builder: FreezeBuilder,
     {
-        self.close_char_str();
+        self.close_charstr();
         if self.builder.as_ref().is_empty() {
             self.builder.append_slice(b"\0")?;
         }
@@ -1021,7 +1044,31 @@ mod test {
             &[
                 Token::NewtypeStruct { name: "Txt" },
                 Token::Seq { len: None },
+                Token::NewtypeStruct { name: "CharStr" },
                 Token::BorrowedStr("foo"),
+                Token::SeqEnd,
+            ],
+        );
+
+        let txt = Txt::from_octets(
+            Vec::from(b"\x03foo\x04\\bar".as_ref())
+        ).unwrap();
+        assert_tokens(
+            &txt.clone().compact(),
+            &[
+                Token::NewtypeStruct { name: "Txt" },
+                Token::ByteBuf(b"\x03foo\x04\\bar"),
+            ],
+        );
+        assert_tokens(
+            &txt.readable(),
+            &[
+                Token::NewtypeStruct { name: "Txt" },
+                Token::Seq { len: None },
+                Token::NewtypeStruct { name: "CharStr" },
+                Token::BorrowedStr("foo"),
+                Token::NewtypeStruct { name: "CharStr" },
+                Token::BorrowedStr("\\\\bar"),
                 Token::SeqEnd,
             ],
         );

--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -69,9 +69,11 @@ use octseq::serde::{DeserializeOctets, SerializeOctets};
 ///
 /// For human-readable formats, the type serializes into a newtype `Txt`
 /// wrapping a sequence of serialized [`CharStr`]s. The deserializer supports
-/// a single string instead of the sequence – but unfortunately not all
-/// format implementations support alternative deserialization based on the
-/// encountered type. In particular, _serde-json_ doesn’t.
+/// a non-canonical form as a single string instead of the sequence. In this
+/// case the string is broken up into chunks of 255 octets if it is longer.
+/// However, not all format implementations support alternative
+/// deserialization based on the encountered type. In particular,
+/// _serde-json_ doesn’t, so it will only accept sequences.
 ///
 /// For compact formats, the type serializes as a newtype `Txt` that contains
 /// a byte array of the wire format representation of the content.


### PR DESCRIPTION
This PR fixes TXT record data serialization for human-readable formats. TXT record data is now serialized as a sequence of character strings. It also deserializes from such a sequence. If supported by the format, it alternatively deserializes from a string that is broken up into 255 octet chunks if necessary.

It uses a newly added helper type `base::charstr::DeserializeCharStrSeed` that deserializes character strings by appending them to an octets builder. Since this may be useful for other cases, it has been made public.

This is a breaking change.

This fixes #268.