### PR TITLE
Refactor IANA type variants into constants.

### DIFF
--- a/examples/client-transports.rs
+++ b/examples/client-transports.rs
@@ -1,7 +1,7 @@
 /// Using the `domain::net::client` module for sending a query.
 use domain::base::Dname;
 use domain::base::MessageBuilder;
-use domain::base::Rtype::Aaaa;
+use domain::base::Rtype;
 use domain::net::client::dgram;
 use domain::net::client::dgram_stream;
 use domain::net::client::multi_stream;
@@ -29,7 +29,7 @@ async fn main() {
     let mut msg = MessageBuilder::new_vec();
     msg.header_mut().set_rd(true);
     let mut msg = msg.question();
-    msg.push((Dname::vec_from_str("example.com").unwrap(), Aaaa))
+    msg.push((Dname::vec_from_str("example.com").unwrap(), Rtype::AAAA))
         .unwrap();
     let req = RequestMessage::new(msg);
 

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -286,7 +286,7 @@ impl Header {
     /// [`Rcode`]: ../../iana/rcode/enum.Rcode.html
     #[must_use]
     pub fn rcode(self) -> Rcode {
-        Rcode::from_int(self.inner[3] & 0x0F)
+        Rcode::saturating_from_int(self.inner[3])
     }
 
     /// Sets the value of the RCODE field.
@@ -1010,7 +1010,7 @@ mod test {
     fn header() {
         test_field!(id, set_id, 0, 0x1234);
         test_field!(qr, set_qr, false, true, false);
-        test_field!(opcode, set_opcode, Opcode::Query, Opcode::Notify);
+        test_field!(opcode, set_opcode, Opcode::QUERY, Opcode::NOTIFY);
         test_field!(
             flags,
             set_flags,
@@ -1027,7 +1027,7 @@ mod test {
         test_field!(z, set_z, false, true, false);
         test_field!(ad, set_ad, false, true, false);
         test_field!(cd, set_cd, false, true, false);
-        test_field!(rcode, set_rcode, Rcode::NoError, Rcode::Refused);
+        test_field!(rcode, set_rcode, Rcode::NOERROR, Rcode::REFUSED);
     }
 
     #[test]

--- a/src/base/iana/class.rs
+++ b/src/base/iana/class.rs
@@ -30,30 +30,30 @@ int_enum! {
     ///
     /// This class is defined in RFC 1035 and really the only one relevant
     /// at all.
-    (In => 1, b"IN")
+    (IN => 1, b"IN")
 
     /// Chaosnet (CH).
     ///
     /// A network protocol developed at MIT in the 1970s. Reused by BIND for
     /// built-in server information zones.",
-    (Ch => 3, b"CH")
+    (CH => 3, b"CH")
 
     /// Hesiod (HS).
     ///
     /// A system information protocol part of MIT's Project Athena.",
-    (Hs => 4, b"HS")
+    (HS => 4, b"HS")
 
     /// Query class None.
     ///
     /// Defined in RFC 2136, this class is used in UPDATE queries to
     /// require that an RRset does not exist prior to the update.",
-    (None => 0xFE, b"NONE")
+    (NONE => 0xFE, b"NONE")
 
     /// Query class * (ANY).
     ///
     /// This class can be used in a query to indicate that records for the
     /// given name from any class are requested.",
-    (Any => 0xFF, b"*")
+    (ANY => 0xFF, b"*")
 }
 
 int_enum_str_with_prefix!(Class, "CLASS", b"CLASS", u16, "unknown class");
@@ -68,9 +68,9 @@ mod test {
         use super::Class;
         use serde_test::{assert_tokens, Configure, Token};
 
-        assert_tokens(&Class::In.readable(), &[Token::Str("IN")]);
-        assert_tokens(&Class::Int(5).readable(), &[Token::Str("CLASS5")]);
-        assert_tokens(&Class::In.compact(), &[Token::U16(1)]);
-        assert_tokens(&Class::Int(5).compact(), &[Token::U16(5)]);
+        assert_tokens(&Class::IN.readable(), &[Token::Str("IN")]);
+        assert_tokens(&Class(5).readable(), &[Token::Str("CLASS5")]);
+        assert_tokens(&Class::IN.compact(), &[Token::U16(1)]);
+        assert_tokens(&Class(5).compact(), &[Token::U16(5)]);
     }
 }

--- a/src/base/iana/digestalg.rs
+++ b/src/base/iana/digestalg.rs
@@ -18,12 +18,12 @@ int_enum! {
     /// Specifies that the SHA-1 hash function is used.
     ///
     /// Implementation of this function is currently mandatory.
-    (Sha1 => 1, b"SHA-1")
+    (SHA1 => 1, b"SHA-1")
 
     /// Specifies that the SHA-256 hash function is used.
     ///
     /// Implementation of this function is currently mandatory.
-    (Sha256 => 2, b"SHA-256")
+    (SHA256 => 2, b"SHA-256")
 
     /// Specifies that the GOST R 34.11-94 hash function is used.
     ///
@@ -31,7 +31,7 @@ int_enum! {
     /// the function is optional.
     ///
     /// [RFC 5933]: https://tools.ietf.org/html/rfc5933
-    (Gost => 3, b"GOST R 34.11-94")
+    (GOST => 3, b"GOST R 34.11-94")
 
     /// Specifies that the SHA-384 hash function is used.
     ///
@@ -39,7 +39,7 @@ int_enum! {
     /// the function is optional.
     ///
     /// [RFC 6605]: https://tools.ietf.org/html/rfc6605
-    (Sha384 => 4, b"SHA-384")
+    (SHA384 => 4, b"SHA-384")
 }
 
 int_enum_str_decimal!(DigestAlg, u8);
@@ -54,7 +54,7 @@ mod test {
         use super::DigestAlg;
         use serde_test::{assert_tokens, Token};
 
-        assert_tokens(&DigestAlg::Sha384, &[Token::U8(4)]);
-        assert_tokens(&DigestAlg::Int(100), &[Token::U8(100)]);
+        assert_tokens(&DigestAlg::SHA384, &[Token::U8(4)]);
+        assert_tokens(&DigestAlg(100), &[Token::U8(100)]);
     }
 }

--- a/src/base/iana/exterr.rs
+++ b/src/base/iana/exterr.rs
@@ -1,6 +1,6 @@
 //! Extended DNS Error
 
-//------------ Extended Error Code ---------------------------------------------------------
+//------------ Extended Error Code -------------------------------------------
 
 int_enum! {
     /// Extended DNS error codes.
@@ -19,15 +19,15 @@ int_enum! {
     /// match known extended error codes. Implementations SHOULD
     /// include an EXTRA-TEXT value to augment this error code with
     /// additional information.
-    (Other => 0, b"Other Error")
+    (OTHER => 0, b"Other Error")
 
     /// The resolver attempted to perform DNSSEC validation, but a DNSKEY
     /// RRset contained only unsupported DNSSEC algorithms.
-    (UnsupportedDnskeyAlgorithm => 1, b"Unsupported DNSKEY Algorithm")
+    (UNSUPPORTED_DNSKEY_ALGORITHM => 1, b"Unsupported DNSKEY Algorithm")
 
     /// The resolver attempted to perform DNSSEC validation, but a DS
     /// RRset contained only unsupported Digest Types.
-    (UnsupportedDsDigestType => 2, b"Unsupported DS Digest Type")
+    (UNSUPPORTED_DS_DIGEST_TYPE => 2, b"Unsupported DS Digest Type")
 
     /// The resolver was unable to resolve the answer within its time
     /// limits and decided to answer with previously cached data
@@ -35,7 +35,7 @@ int_enum! {
     /// by problems communicating with an authoritative server,
     /// possibly as result of a denial of service (DoS) attack against
     /// another network. (See also Code 19.)
-    (StaleAnswer => 3, b"Stale Answer")
+    (STALE_ANSWER => 3, b"Stale Answer")
 
     /// For policy reasons (legal obligation or malware filtering, for
     /// instance), an answer was forged. Note that this should be
@@ -43,58 +43,58 @@ int_enum! {
     /// codes are returned instead. See Blocked (15), Censored
     /// (16), and Filtered (17) for use when returning other
     /// response codes.
-    (ForgedAnswer => 4, b"Forged Answer")
+    (FORGED_ANSWER => 4, b"Forged Answer")
 
     /// The resolver attempted to perform DNSSEC validation, but
     /// validation ended in the Indeterminate state [RFC 4035].
     ///
     /// [RFC 4035]: https://tools.ietf.org/html/rfc4035
-    (DnssecIndeterminate => 5, b"DNSSEC Indeterminate")
+    (DNSSEC_INDETERMINATE => 5, b"DNSSEC Indeterminate")
 
     /// The resolver attempted to perform DNSSEC validation, but
     /// validation ended in the Bogus state.
-    (DnssecBogus => 6, b"DNSSEC Bogus")
+    (DNSSEC_BOGUS => 6, b"DNSSEC Bogus")
 
     /// The resolver attempted to perform DNSSEC validation, but no
     /// signatures are presently valid and some (often all) are
     /// expired.
-    (SignatureExpired => 7, b"Signature Expired")
+    (SIGNATURE_EXPIRED => 7, b"Signature Expired")
 
     /// The resolver attempted to perform DNSSEC validation, but no
     /// signatures are presently valid and at least some are not yet
     /// valid.
-    (SignatureNotYetValid => 8, b"Signature Not Yet Valid")
+    (SIGNATURE_NOT_YET_VALID => 8, b"Signature Not Yet Valid")
 
     /// A DS record existed at a parent, but no supported matching
     /// DNSKEY record could be found for the child.
-    (DnskeyMissing => 9, b"DNSKEY Missing")
+    (DNSKEY_MISSING => 9, b"DNSKEY Missing")
 
     /// The resolver attempted to perform DNSSEC validation, but no
     /// RRSIGs could be found for at least one RRset where RRSIGs were
     /// expected.
-    (RrsigsMissing => 10, b"RRSIGs Missing")
+    (RRSIGS_MISSING => 10, b"RRSIGs Missing")
 
     /// The resolver attempted to perform DNSSEC validation, but no
     /// Zone Key Bit was set in a DNSKEY.
-    (NoZoneKeyBitSet => 11, b"No Zone Key Bit Set")
+    (NO_ZONE_KEY_BIT_SET => 11, b"No Zone Key Bit Set")
 
     /// The resolver attempted to perform DNSSEC validation, but the
     /// requested data was missing and a covering NSEC or NSEC3 was
     /// not provided.
-    (NsecMissing => 12, b"NSEC Missing")
+    (NSEC_MISSING => 12, b"NSEC Missing")
 
     /// The resolver is returning the SERVFAIL RCODE from its cache.
-    (CachedError => 13, b"Cached Error")
+    (CACHED_ERROR => 13, b"Cached Error")
 
     /// The server is unable to answer the query, as it was not fully
     /// functional when the query was received.
-    (NotReady => 14, b"Not Ready")
+    (NOT_READY => 14, b"Not Ready")
 
     /// The server is unable to respond to the request because the
     /// domain is on a blocklist due to an internal security policy
     /// imposed by the operator of the server resolving or forwarding
     /// the query.
-    (Blocked => 15, b"Blocked")
+    (BLOCKED => 15, b"Blocked")
 
     /// The server is unable to respond to the request because the
     /// domain is on a blocklist due to an external requirement
@@ -102,20 +102,20 @@ int_enum! {
     /// resolving or forwarding the query. Note that how the imposed
     /// policy is applied is irrelevant (in-band DNS filtering, court
     /// order, etc.).
-    (Censored => 16, b"Censored")
+    (CENSORED => 16, b"Censored")
 
     /// The server is unable to respond to the request because the
     /// domain is on a blocklist as requested by the client.
     /// Functionally, this amounts to "you requested that we filter
     /// domains like this one."
-    (Filtered => 17, b"Filtered")
+    (FILTERED => 17, b"Filtered")
 
     /// An authoritative server or recursive resolver that receives a
     /// query from an "unauthorized" client can annotate its REFUSED
     /// message with this code. Examples of "unauthorized" clients are
     /// recursive queries from IP addresses outside the network,
     /// blocklisted IP addresses, local policy, etc.
-    (Prohibited => 18, b"Prohibited")
+    (PROHIBITED => 18, b"Prohibited")
 
     /// The resolver was unable to resolve an answer within its
     /// configured time limits and decided to answer with a previously
@@ -124,7 +124,7 @@ int_enum! {
     /// with an authoritative server, possibly as result of a denial
     /// of service (DoS) attack against another network. (See also
     /// Code 3.)
-    (StaleNxdomainAnswer => 19, b"Stale NXDomain Answer")
+    (STALE_NXDOMAIN_ANSWER => 19, b"Stale NXDomain Answer")
 
     /// An authoritative server that receives a query with the
     /// Recursion Desired (RD) bit clear, or when it is not configured
@@ -132,23 +132,23 @@ int_enum! {
     /// SHOULD include this EDE code in the REFUSED response. A
     /// resolver that receives a query with the RD bit clear SHOULD
     /// include this EDE code in the REFUSED response.
-    (NotAuthoritative => 20, b"Not Authoritative")
+    (NOT_AUTHORITATIVE => 20, b"Not Authoritative")
 
     /// The requested operation or query is not supported.
-    (NotSupported => 21, b"Not Supported")
+    (NOT_SUPPORTED => 21, b"Not Supported")
 
     /// The resolver could not reach any of the authoritative name
     /// servers (or they potentially refused to reply).
-    (NoReachableAuthority => 22, b"No Reachable Authority")
+    (NO_REACHABLE_AUTHORITY => 22, b"No Reachable Authority")
 
     /// An unrecoverable error occurred while communicating with
     /// another server.
-    (NetworkError => 23, b"Network Error")
+    (NETWORK_ERROR => 23, b"Network Error")
 
     /// The authoritative server cannot answer with data for a zone it
     /// is otherwise configured to support. Examples of this include
     /// its most recent zone being too old or having expired.
-    (InvalidData => 24, b"Invalid Data")
+    (INVALID_DATA => 24, b"Invalid Data")
 }
 
 /// Start of the private range for EDE codes.

--- a/src/base/iana/nsec3.rs
+++ b/src/base/iana/nsec3.rs
@@ -17,7 +17,7 @@ int_enum! {
     Nsec3HashAlg, u8;
 
     /// Specifies that the SHA-1 hash function is used.
-    (Sha1 => 1, b"SHA-1")
+    (SHA1 => 1, b"SHA-1")
 }
 
 int_enum_str_decimal!(Nsec3HashAlg, u8);

--- a/src/base/iana/opcode.rs
+++ b/src/base/iana/opcode.rs
@@ -25,7 +25,7 @@ int_enum! {
     /// This value is defined in [RFC 1035].
     ///
     /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
-    (Query => 0, b"QUERY")
+    (QUERY => 0, b"QUERY")
 
     /// An inverse query (IQUERY) (1, obsolete).
     ///
@@ -38,7 +38,7 @@ int_enum! {
     ///
     /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
     /// [RFC 3425]: https://tools.ietf.org/html/rfc3425
-    (IQuery => 1, b"IQUERY")
+    (IQUERY => 1, b"IQUERY")
 
     /// A server status request (2).
     ///
@@ -48,7 +48,7 @@ int_enum! {
     ///
     /// [RFC 1034]: https://tools.ietf.org/html/rfc1034
     /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
-    (Status => 2, b"STATUS")
+    (STATUS => 2, b"STATUS")
 
     /// A NOTIFY query (4).
     ///
@@ -58,7 +58,7 @@ int_enum! {
     /// This value and the NOTIFY query are defined in [RFC 1996].
     ///
     /// [RFC 1996]: https://tools.ietf.org/html/rfc1996
-    (Notify => 4, b"NOTIFY")
+    (NOTIFY => 4, b"NOTIFY")
 
     /// An UPDATE query (5).
     ///
@@ -68,7 +68,7 @@ int_enum! {
     /// This value and the UPDATE query are defined in [RFC 2136].
     ///
     /// [RFC 2136]: https://tools.ietf.org/html/rfc2136
-    (Update => 5, b"UPDATE")
+    (UPDATE => 5, b"UPDATE")
 
     /// DNS Stateful operations (DSO) (6).
     ///
@@ -78,7 +78,7 @@ int_enum! {
     /// This value and the DOS query are defined in [RFC 8490].
     ///
     /// [RFC 8490]: https://tools.ietf.org/html/rfc8490
-    (Dso => 6, b"DSO")
+    (DSO => 6, b"DSO")
 }
 
 int_enum_str_with_decimal!(Opcode, u8, "unknown opcode");

--- a/src/base/iana/opt.rs
+++ b/src/base/iana/opt.rs
@@ -27,7 +27,7 @@ int_enum! {
     /// currently [draft-sekar-dns-llq].
     ///
     /// [draft-sekar-dns-llq]: https://datatracker.ietf.org/doc/draft-sekar-dns-llq/
-    (Llq => 1, b"LLQ")
+    (LLQ => 1, b"LLQ")
 
     /// Update lease (UL, 2).
     ///
@@ -36,7 +36,7 @@ int_enum! {
     /// has since expired. The code is considered ‘on hold.’
     ///
     /// [draft-sekar-dns-ul]: http://files.dns-sd.org/draft-sekar-dns-ul.txt
-    (Ul => 2, b"UL")
+    (UL => 2, b"UL")
 
     /// Name server identifier (NSID, 3).
     ///
@@ -44,7 +44,7 @@ int_enum! {
     /// answer for diagnostic purposes. The options in defined in [RFC 5001].
     ///
     /// [RFC 5001]: https://tools.ietf.org/html/rfc5001
-    (Nsid => 3, b"NSID")
+    (NSID => 3, b"NSID")
 
     /// DNSSEC algorithm understood (DAU, 5).
     ///
@@ -53,7 +53,7 @@ int_enum! {
     /// in [RFC 6975].
     ///
     /// [RFC 6075]: https://tools.ietf.org/html/rfc6975
-    (Dau => 5, b"DAU")
+    (DAU => 5, b"DAU")
 
     /// DS hash understood (DHU, 6).
     ///
@@ -62,7 +62,7 @@ int_enum! {
     /// in [RFC 6975].
     ///
     /// [RFC 6075]: https://tools.ietf.org/html/rfc6975
-    (Dhu => 6, b"DHU")
+    (DHU => 6, b"DHU")
 
     /// NSEC3 hash understood (N3U, 7).
     ///
@@ -71,7 +71,7 @@ int_enum! {
     /// in [RFC 6975].
     ///
     /// [RFC 6075]: https://tools.ietf.org/html/rfc6975
-    (N3u => 7, b"N3U")
+    (N3U => 7, b"N3U")
 
     /// EDNS client subnet (8),
     ///
@@ -80,7 +80,7 @@ int_enum! {
     /// answer. This option is defined in [RFC 7871].
     ///
     /// [RFC 7871]: https://tools.ietf.org/html/rfc7871
-    (ClientSubnet => 8, b"edns-client-subnet")
+    (CLIENT_SUBNET => 8, b"edns-client-subnet")
 
     /// Expire (9).
     ///
@@ -89,7 +89,7 @@ int_enum! {
     /// primary. The option is defined in [RFC 7314].
     ///
     /// [RFC 7314]: https://tools.ietf.org/html/rfc7314
-    (Expire => 9, b"EDNS EXPIRE")
+    (EXPIRE => 9, b"EDNS EXPIRE")
 
     /// DNS Cookie (10).
     ///
@@ -98,7 +98,7 @@ int_enum! {
     /// amplification attacks. The option is defined in [RFC 7873].
     ///
     /// [RFC 7873]: https://tools.ietf.org/html/rfc7873
-    (Cookie => 10, b"COOKIE")
+    (COOKIE => 10, b"COOKIE")
 
     /// edns-tcp-keepalive (11).
     ///
@@ -106,7 +106,7 @@ int_enum! {
     /// may hold open a TCP connection. The option is defined in [RFC 7828].
     ///
     /// [RFC 7828]: https://tools.ietf.org/html/rfc7828
-    (TcpKeepalive => 11, b"edns-tcp-keepalive")
+    (TCP_KEEPALIVE => 11, b"edns-tcp-keepalive")
 
     /// Padding (12).
     ///
@@ -115,7 +115,7 @@ int_enum! {
     /// The option is defined in [RFC 7830].
     ///
     /// [RFC 7830]: https://tools.ietf.org/html/rfc7830
-    (Padding => 12, b"Padding")
+    (PADDING => 12, b"Padding")
 
     /// CHAIN query requests (13).
     ///
@@ -124,7 +124,7 @@ int_enum! {
     /// the answer. The option is defined in [RFC 7901].
     ///
     /// [RFC 7901]: https://tools.ietf.org/html/rfc7901
-    (Chain => 13, b"CHAIN")
+    (CHAIN => 13, b"CHAIN")
 
     /// EDNS key tag (14).
     ///
@@ -133,7 +133,7 @@ int_enum! {
     /// [RFC 8145].
     ///
     /// [RFC 8145]: https://tools.ietf.org/html/rfc8145
-    (KeyTag => 14, b"edns-key-tag")
+    (KEY_TAG => 14, b"edns-key-tag")
 
     /// Extended DNS Error (15).
     ///
@@ -142,7 +142,7 @@ int_enum! {
     /// processing of RCODEs. The option is defined in [RFC 8914].
     ///
     /// [RFC 8914]: https://tools.ietf.org/html/rfc8914
-    (ExtendedError => 15, b"Extended DNS Error")
+    (EXTENDED_ERROR => 15, b"Extended DNS Error")
 
     /// EDNS client tag (16).
     ///
@@ -151,7 +151,7 @@ int_enum! {
     /// [draft-bellis-dnsop-edns-tags].
     ///
     /// [draft-bellis-dnsop-edns-tags]: https://datatracker.ietf.org/doc/draft-bellis-dnsop-edns-tags/
-    (ClientTag => 16, b"EDNS-Client-Tag")
+    (CLIENT_TAG => 16, b"EDNS-Client-Tag")
 
     /// EDNS server tag (16).
     ///
@@ -160,14 +160,14 @@ int_enum! {
     /// [draft-bellis-dnsop-edns-tags].
     ///
     /// [draft-bellis-dnsop-edns-tags]: https://datatracker.ietf.org/doc/draft-bellis-dnsop-edns-tags/
-    (ServerTag => 17, b"EDNS-Server-Tag")
+    (SERVER_TAG => 17, b"EDNS-Server-Tag")
 
     /// DeviceID (26946).
     ///
     /// Ths option is used by the [Cisco Umbrella network device API].
     ///
     /// [Cisco Umbrella network device API]: https://docs.umbrella.com/developer/networkdevices-api/identifying-dns-traffic2
-    (DeviceId => 26946, b"DeviceId")
+    (DEVICE_ID => 26946, b"DeviceId")
 }
 
 int_enum_str_with_decimal!(OptionCode, u16, "unknown option code");
@@ -183,17 +183,11 @@ mod test {
         use serde_test::{assert_tokens, Configure, Token};
 
         assert_tokens(
-            &OptionCode::ServerTag.readable(),
+            &OptionCode::SERVER_TAG.readable(),
             &[Token::Str("EDNS-Server-Tag")],
         );
-        assert_tokens(
-            &OptionCode::Int(10_000).readable(),
-            &[Token::U16(10_000)],
-        );
-        assert_tokens(&OptionCode::ServerTag.compact(), &[Token::U16(17)]);
-        assert_tokens(
-            &OptionCode::Int(10_000).compact(),
-            &[Token::U16(10_000)],
-        );
+        assert_tokens(&OptionCode(10_000).readable(), &[Token::U16(10_000)]);
+        assert_tokens(&OptionCode::SERVER_TAG.compact(), &[Token::U16(17)]);
+        assert_tokens(&OptionCode(10_000).compact(), &[Token::U16(10_000)]);
     }
 }

--- a/src/base/iana/rtype.rs
+++ b/src/base/iana/rtype.rs
@@ -27,71 +27,71 @@ int_enum! {
     (A => 1, b"A")
 
     /// An authoritative name server.
-    (Ns => 2, b"NS")
+    (NS => 2, b"NS")
 
     /// A mail destination.
     ///
     /// (Obsolete – use MX)
-    (Md => 3, b"MD")
+    (MD => 3, b"MD")
 
     /// A mail forwarder.
     ///
     /// (Obsolete – use MX)
-    (Mf => 4, b"MF")
+    (MF => 4, b"MF")
 
     /// The canonical name for an alias
-    (Cname => 5, b"CNAME")
+    (CNAME => 5, b"CNAME")
 
     /// Marks the start of a zone of authority.
-    (Soa => 6, b"SOA")
+    (SOA => 6, b"SOA")
 
     /// A mailbox domain name.
     ///
     /// (Experimental.)
-    (Mb =>  7, b"MB")
+    (MB =>  7, b"MB")
 
     /// A mail group member
     ///
     /// (Experimental.)
-    (Mg => 8, b"MG")
+    (MG => 8, b"MG")
 
     /// A mail rename domain name.
     ///
     /// (Experimental.)
-    (Mr => 9, b"MR")
+    (MR => 9, b"MR")
 
     /// A null resource record.
     ///
     /// (Experimental.)
-    (Null =>  10, b"NULL")
+    (NULL =>  10, b"NULL")
 
     /// A well known service description.
-    (Wks => 11, b"WKS")
+    (WKS => 11, b"WKS")
 
     /// A domain name pointer.
-    (Ptr => 12, b"PTR")
+    (PTR => 12, b"PTR")
 
     /// Host information.
-    (Hinfo => 13, b"HINFO")
+    (HINFO => 13, b"HINFO")
 
     /// Mailbox or mail list information.
-    (Minfo => 14, b"MINFO")
+    (MINFO => 14, b"MINFO")
 
     /// Mail exchange.
-    (Mx => 15, b"MX")
+    (MX => 15, b"MX")
 
     /// Text strings.
-    (Txt => 16, b"TXT")
+    (TXT => 16, b"TXT")
 
     /// For Responsible Person.
     ///
     /// See RFC 1183
-    (Rp => 17, b"RP")
+    (RP => 17, b"RP")
 
     /// For AFS Data Base location.
     ///
     /// See RFC 1183 and RFC 5864.
-    (Afsdb => 18, b"AFSDB")
+    (AFSDB => 18, b"AFSDB")
 
     /// For X.25 PSDN address.
     ///
@@ -101,84 +101,84 @@ int_enum! {
     /// For ISDN address.
     ///
     /// See RFC 1183.
-    (Isdn => 20, b"ISDN")
+    (ISDN => 20, b"ISDN")
 
     /// For Route Through.
     ///
     /// See RFC 1183
-    (Rt => 21, b"RT")
+    (RT => 21, b"RT")
 
     /// For SNAP address, NSAP style A record.
     ///
     /// See RFC 1706.
-    (Nsap => 22, b"NSAP")
+    (NSAP => 22, b"NSAP")
 
     /// For domain name pointer, NSAP style.
     ///
     /// See RFC 1348, RFC 1637, RFC 1706.
-    (Nsapptr => 23, b"NSAPPTR")
+    (NSAPPTR => 23, b"NSAPPTR")
 
     /// For security signature.
-    (Sig => 24, b"SIG")
+    (SIG => 24, b"SIG")
 
     /// For security key.
-    (Key => 25, b"KEY")
+    (KEY => 25, b"KEY")
 
     /// X.400 mail mapping information.
     ///
     /// See RFC 2163.
-    (Px => 26, b"PX")
+    (PX => 26, b"PX")
 
     /// Geographical position.
     ///
     /// See RFC 1712
-    (Gpos => 27, b"GPOS")
+    (GPOS => 27, b"GPOS")
 
     /// IPv6 address.
     ///
     /// See RFC 3596.
-    (Aaaa =>  28, b"AAAA")
+    (AAAA =>  28, b"AAAA")
 
     /// Location information.
     ///
     /// See RFC 1876.
-    (Loc => 29, b"LOC")
+    (LOC => 29, b"LOC")
 
     /// Next domain.
     ///
     /// (Obsolete.)
     ///
     /// See RFC 3755 and RFC 2535.
-    (Nxt => 30, b"NXT")
+    (NXT => 30, b"NXT")
 
     /// Endpoint identifier.
-    (Eid => 31, b"EID")
+    (EID => 31, b"EID")
 
     /// Nimrod locator.
-    (Nimloc => 32, b"NIMLOC")
+    (NIMLOC => 32, b"NIMLOC")
 
     /// Server selection.
     ///
     /// See RFC 2782.
-    (Srv => 33, b"SRV")
+    (SRV => 33, b"SRV")
 
     /// ATM address.
-    (Atma => 34, b"ATMA")
+    (ATMA => 34, b"ATMA")
 
     /// Naming authority pointer.
     ///
     /// See RFC 2915, RFC 2168, and RFC 3403.
-    (Naptr => 35, b"NAPTR")
+    (NAPTR => 35, b"NAPTR")
 
     /// Key exchanger.
     ///
     /// See RFC 2230.
-    (Kx => 36, b"KX")
+    (KX => 36, b"KX")
 
     /// CERT
     ///
     /// See RFC 4398.
-    (Cert => 37, b"CERT")
+    (CERT => 37, b"CERT")
 
     /// A6.
     ///
@@ -190,154 +190,154 @@ int_enum! {
     /// DNAME.
     ///
     /// See RFC 6672.
-    (Dname => 39, b"DNAME")
+    (DNAME => 39, b"DNAME")
 
     /// SINK.
-    (Sink => 40, b"SINK")
+    (SINK => 40, b"SINK")
 
     /// OPT.
     ///
     /// See RFC 6891 and RFC 3225.
-    (Opt => 41, b"OPT")
+    (OPT => 41, b"OPT")
 
     /// APL.
     ///
     /// See RFC 3123.
-    (Apl => 42, b"APL")
+    (APL => 42, b"APL")
 
     /// Delegation signer.
     ///
     /// See RFC 4034 and RFC 3658.
-    (Ds => 43, b"DS")
+    (DS => 43, b"DS")
 
     /// SSH key fingerprint.
     ///
     /// See RFC 4255.
-    (Sshfp => 44, b"SSHFP")
+    (SSHFP => 44, b"SSHFP")
 
     /// IPSECKEY
     ///
     /// See RFC 4255.
-    (Ipseckey => 45, b"IPSECKEY")
+    (IPSECKEY => 45, b"IPSECKEY")
 
     /// RRSIG.
     ///
     /// See RFC 4034 and RFC 3755.
-    (Rrsig => 46, b"RRSIG")
+    (RRSIG => 46, b"RRSIG")
 
     /// NSEC.
     ///
     /// See RFC 4034 and RFC 3755.
-    (Nsec => 47, b"NSEC")
+    (NSEC => 47, b"NSEC")
 
     /// DNSKEY.
     ///
     /// See RFC 4034 and RFC 3755.
-    (Dnskey => 48, b"DNSKEY")
+    (DNSKEY => 48, b"DNSKEY")
 
     /// DHCID.
     ///
     /// See RFC 4701.
-    (Dhcid => 49, b"DHCID")
+    (DHCID => 49, b"DHCID")
 
     /// NSEC3
     ///
     /// See RFC 5155.
-    (Nsec3 => 50, b"NSEC3")
+    (NSEC3 => 50, b"NSEC3")
 
     /// NSEC3PARAM.
     ///
     /// See RFC 5155.
-    (Nsec3param => 51, b"NSEC3PARAM")
+    (NSEC3PARAM => 51, b"NSEC3PARAM")
 
     /// TLSA.
     ///
     /// See RFC 6698.
-    (Tlsa => 52, b"TLSA")
+    (TLSA => 52, b"TLSA")
 
     /// S/MIME cert association.
     ///
     /// See draft-ietf-dane-smime.
-    (Smimea => 53, b"SMIMEA")
+    (SMIMEA => 53, b"SMIMEA")
 
     /// Host Identity Protocol.
     ///
     /// See RFC 5205.
-    (Hip => 55, b"HIP")
+    (HIP => 55, b"HIP")
 
     /// NINFO.
-    (Ninfo => 56, b"NINFO")
+    (NINFO => 56, b"NINFO")
 
     /// RKEY.
-    (Rkey => 57, b"RKEY")
+    (RKEY => 57, b"RKEY")
 
     /// Trust Anchor Link
-    (Talink => 58, b"TALINK")
+    (TALINK => 58, b"TALINK")
 
     /// Child DS.
     ///
     /// See RFC 7344.
-    (Cds => 59, b"CDS")
+    (CDS => 59, b"CDS")
 
     /// DNSKEY(s) the child wants reflected in DS.
     ///
     /// See RFC 7344.
-    (Cdnskey => 60, b"CDNSKEY")
+    (CDNSKEY => 60, b"CDNSKEY")
 
     /// OpenPGP key.
     ///
     /// See draft-ietf-dane-openpgpkey.
-    (Openpgpkey => 61, b"OPENPGPKEY")
+    (OPENPGPKEY => 61, b"OPENPGPKEY")
 
     /// Child-to-parent synchronization.
     ///
     /// See RFC 7477.
-    (Csync => 62, b"CSYNC")
+    (CSYNC => 62, b"CSYNC")
 
     /// Message digest for DNS zone.
     ///
     /// See draft-wessels-dns-zone-digest.
-    (Zonemd => 63, b"ZONEMD")
+    (ZONEMD => 63, b"ZONEMD")
 
     /// General Purpose Service Endpoints.
     ///
     /// See draft-ietf-dnsop-svcb-httpssvc
-    (Svcb => 64, b"SVCB")
+    (SVCB => 64, b"SVCB")
 
     /// HTTPS Specific Service Endpoints.
     ///
     /// See draft-ietf-dnsop-svcb-httpssvc
-    (Https => 65, b"HTTPS")
+    (HTTPS => 65, b"HTTPS")
 
     /// SPF.
     ///
     /// RFC 7208.
-    (Spf => 99, b"SPF")
+    (SPF => 99, b"SPF")
 
     /// UINFO.
     ///
     /// IANA-Reserved.
-    (Uinfo => 100, b"UINFO")
+    (UINFO => 100, b"UINFO")
 
     /// UID.
     ///
     /// IANA-Reserved.
-    (Uid => 101, b"UID")
+    (UID => 101, b"UID")
 
     /// GID.
     ///
     /// IANA-Reserved.
-    (Gid => 102, b"GID")
+    (GID => 102, b"GID")
 
     /// UNSPEC.
     ///
     /// IANA-Reserved.
-    (Unspec => 103, b"UNSPEC")
+    (UNSPEC => 103, b"UNSPEC")
 
     /// NID.
     ///
     /// See RFC 6742.
-    (Nid => 104, b"NID")
+    (NID => 104, b"NID")
 
     /// L32.
     ///
@@ -352,76 +352,76 @@ int_enum! {
     /// LP.
     ///
     /// See RFC 6742.
-    (Lp => 107, b"LP")
+    (LP => 107, b"LP")
 
     /// An EUI-48 address.
     ///
     /// See RFC 7043.
-    (Eui48 => 108, b"EUI48")
+    (EUI48 => 108, b"EUI48")
 
     /// An EUI-64 address.
     ///
     /// See RFC 7043.
-    (Eui64 => 109, b"EUI64")
+    (EUI64 => 109, b"EUI64")
 
     /// Transaction key.
     ///
     /// See RFC 2930.
-    (Tkey => 249, b"TKEY")
+    (TKEY => 249, b"TKEY")
 
     /// Transaction signature.
     ///
     /// See RFC 2845.
-    (Tsig => 250, b"TSIG")
+    (TSIG => 250, b"TSIG")
 
     /// Incremental transfer.
     ///
     /// See RFC 1995.
-    (Ixfr => 251, b"IXFR")
+    (IXFR => 251, b"IXFR")
 
     /// Transfer of entire zone.
     ///
     /// See RFC 1035 and RFC 5936.
-    (Axfr => 252, b"AXFR")
+    (AXFR => 252, b"AXFR")
 
     /// Mailbox-related RRs (MB, MG, or MR).
-    (Mailb => 253, b"MAILB")
+    (MAILB => 253, b"MAILB")
 
     /// Mail agent RRS.
     ///
     /// (Obsolete – see MX.)
-    (Maila => 254, b"MAILA")
+    (MAILA => 254, b"MAILA")
 
     /// A request for all records the server/cache has available.
     ///
     /// See RFC 1035 and RFC 6895.
-    (Any => 255, b"ANY")
+    (ANY => 255, b"ANY")
 
     /// URI.
     ///
     /// See RFC 7553.
-    (Uri => 256, b"URI")
+    (URI => 256, b"URI")
 
     /// Certification Authority Restriction.
     ///
     /// See RFC 6844.
-    (Caa => 257, b"CAA")
+    (CAA => 257, b"CAA")
 
     /// Application visibility and control.
-    (Avc => 258, b"AVC")
+    (AVC => 258, b"AVC")
 
     /// Digital Object Architecture
     ///
     /// See draft-durand-doa-over-dns.
-    (Doa => 259, b"DOA")
+    (DOA => 259, b"DOA")
 
     /// DNSSEC trust authorities.
-    (Ta => 32768, b"TA")
+    (TA => 32768, b"TA")
 
     /// DNSSEC lookaside validation.
     ///
     /// See RFC 4431
-    (Dlv => 32769, b"DLV")
+    (DLV => 32769, b"DLV")
 }
 
 int_enum_str_with_prefix!(Rtype, "TYPE", b"TYPE", u16, "unknown record type");

--- a/src/base/iana/secalg.rs
+++ b/src/base/iana/secalg.rs
@@ -18,7 +18,7 @@ int_enum! {
     /// This algorithm is used in RFC 8087 to signal to the parent that a
     /// certain DS record should be deleted. It is _not_ an actual algorithm
     /// and can neither be used in zone nor transaction signing.
-    (DeleteDs => 0, b"DELETE")
+    (DELETE => 0, b"DELETE")
 
     /// RSA/MD5
     ///
@@ -28,92 +28,92 @@ int_enum! {
     ///
     /// This algorithm may not be used for zone signing but may be used
     /// for transaction security.
-    (RsaMd5 => 1, b"RSAMD5")
+    (RSAMD5 => 1, b"RSAMD5")
 
     /// Diffie-Hellman
     ///
     /// This algorithm is described in RFC 2539 for storing Diffie-Hellman
     /// (DH) keys in DNS resource records. It can not be used for zone
     /// signing but only for transaction security.
-    (Dh => 2, b"DH")
+    (DH => 2, b"DH")
 
     /// DSA/SHA1
     ///
     /// This algorithm is described in RFC 2536. It may be used both for
     /// zone signing and transaction security.
-    (Dsa => 3, b"DSA")
+    (DSA => 3, b"DSA")
 
     /// RSA/SHA-1
     ///
     /// This algorithm is described in RFC 3110. It may be used both for
     /// zone signing and transaction security. It is mandatory for DNSSEC
     /// implementations.
-    (RsaSha1 => 5, b"RSASHA1")
+    (RSASHA1 => 5, b"RSASHA1")
 
     /// DSA-NSEC3-SHA1
     ///
     /// This value is an alias for `Dsa` for use within NSEC3 records.
-    (DsaNsec3Sha1 => 6, b"DSA-NSEC3-SHA1")
+    (DSA_NSEC3_SHA1 => 6, b"DSA-NSEC3-SHA1")
 
     /// RSASHA1-NSEC3-SHA1
     ///
     /// This value is an alias for `RsaSha1` for use within NSEC3 records.
-    (RsaSha1Nsec3Sha1 => 7, b"RSASHA1-NSEC3-SHA1")
+    (RSASHA1_NSEC3_SHA1 => 7, b"RSASHA1-NSEC3-SHA1")
 
     /// RSA/SHA-256
     ///
     /// This algorithm is described in RFC 5702. It may be used for zone
     /// signing only.
-    (RsaSha256 => 8, b"RSASHA256")
+    (RSASHA256 => 8, b"RSASHA256")
 
     /// RSA/SHA-512
     ///
     /// This algorithm is described in RFC 5702. It may be used for zone
     /// signing only.
-    (RsaSha512 => 10, b"RSASHA512")
+    (RSASHA512 => 10, b"RSASHA512")
 
     /// GOST R 34.10-2001
     ///
     /// This algorithm is described in RFC 5933. It may be used for zone
     /// signing only.
-    (EccGost => 12, b"ECC-GOST")
+    (ECC_GOST => 12, b"ECC-GOST")
 
     /// ECDSA Curve P-256 with SHA-256
     ///
     /// This algorithm is described in RFC 6605. It may be used for zone
     /// signing only.
-    (EcdsaP256Sha256 => 13, b"ECDSAP256SHA256")
+    (ECDSAP256SHA256 => 13, b"ECDSAP256SHA256")
 
     /// ECDSA Curve P-384 with SHA-384
     ///
     /// This algorithm is described in RFC 6605. It may be used for zone
     /// signing only.
-    (EcdsaP384Sha384 => 14, b"ECDSAP384SHA384")
+    (ECDSAP384SHA384 => 14, b"ECDSAP384SHA384")
 
     /// ED25519
     ///
     /// This algorithm is described in RFC 8080.
-    (Ed25519 => 15, b"ED25519")
+    (ED25519 => 15, b"ED25519")
 
     /// ED448
     ///
     /// This algorithm is described in RFC 8080.
-    (Ed448 => 16, b"ED448")
+    (ED448 => 16, b"ED448")
 
     /// Reserved for Indirect Keys
     ///
     /// This value is reserved by RFC 4034.
-    (Indirect => 252, b"INDIRECT")
+    (INDIRECT => 252, b"INDIRECT")
 
     /// A private algorithm identified by a domain name.
     ///
     /// This value is defined in RFC 4034.
-    (PrivateDns => 253, b"PRIVATEDNS")
+    (PRIVATEDNS => 253, b"PRIVATEDNS")
 
     /// A private algorithm identified by a ISO OID.
     ///
     /// This value is defined in RFC 4034.
-    (PrivateOid => 254, b"PRIVATEOID")
+    (PRIVATEOID => 254, b"PRIVATEOID")
 }
 
 int_enum_str_with_decimal!(SecAlg, u8, "unknown algorithm");

--- a/src/base/iana/svcb.rs
+++ b/src/base/iana/svcb.rs
@@ -1,41 +1,25 @@
 //! Service Binding (SVCB) Parameter Registry
 
-use core::fmt;
-
 int_enum! {
     =>
     SvcParamKey, u16;
 
-    (Mandatory => 0, b"Mandatory keys in this RR")
-    (Alpn => 1, b"Additional supported protocols")
-    (NoDefaultAlpn => 2, b"Additional supported protocols")
-    (Port => 3, b"Port for alternative endpoint")
-    (Ipv4Hint => 4, b"IPv4 address hints")
+    (MANDATORY => 0, b"Mandatory keys in this RR")
+    (ALPN => 1, b"Additional supported protocols")
+    (NO_DEFAULT_ALPN => 2, b"Additional supported protocols")
+    (PORT => 3, b"Port for alternative endpoint")
+    (IPV4HINT => 4, b"IPv4 address hints")
     // https://datatracker.ietf.org/doc/draft-ietf-tls-esni/
-    (Ech => 5, b"Encrypted ClientHello info")
-    (Ipv6Hint => 6, b"IPv6 address hints")
+    (ECH => 5, b"Encrypted ClientHello info")
+    (IPV6HINT => 6, b"IPv6 address hints")
     // https://datatracker.ietf.org/doc/draft-ietf-add-svcb-dns/
-    (DohPath => 7, b"DNS over HTTPS path template")
+    (DOHPATH => 7, b"DNS over HTTPS path template")
 }
 
-pub const SVC_PARAM_KEY_PRIVATE_RANGE_BEGIN: u16 = 65280;
-pub const SVC_PARAM_KEY_PRIVATE_RANGE_END: u16 = 65534;
-pub const SVC_PARAM_KEY_INVALID: u16 = 65535;
+int_enum_str_with_prefix!(SvcParamKey, "key", b"key", u16, "unknown key");
 
-impl fmt::Display for SvcParamKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = match self {
-            Self::Mandatory => "mandatory",
-            Self::Alpn => "alpn",
-            Self::NoDefaultAlpn => "nodefaultalpn",
-            Self::Port => "port",
-            Self::Ipv4Hint => "ipv4hint",
-            Self::Ech => "ech",
-            Self::Ipv6Hint => "ipv6hint",
-            Self::DohPath => "dohpath",
-            Self::Int(n) => return write!(f, "key{}", n),
-        };
-
-        f.write_str(s)
-    }
+impl SvcParamKey {
+    pub const PRIVATE_RANGE_BEGIN: u16 = 65280;
+    pub const PRIVATE_RANGE_END: u16 = 65534;
+    pub const INVALID: Self = Self(65535);
 }

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -298,12 +298,12 @@ impl<Octs: AsRef<[u8]> + ?Sized> Message<Octs> {
 
     /// Returns whether the rcode of the header is NoError.
     pub fn no_error(&self) -> bool {
-        self.header().rcode() == Rcode::NoError
+        self.header().rcode() == Rcode::NOERROR
     }
 
     /// Returns whether the rcode of the header is one of the error values.
     pub fn is_error(&self) -> bool {
-        self.header().rcode() != Rcode::NoError
+        self.header().rcode() != Rcode::NOERROR
     }
 }
 
@@ -1165,7 +1165,7 @@ where
                 Some(Err(err)) => return Some(Err(err)),
                 None => return None,
             };
-            if self.in_only && record.class() != Class::In {
+            if self.in_only && record.class() != Class::IN {
                 continue;
             }
             match record.into_record() {
@@ -1436,7 +1436,7 @@ mod test {
             if let Ok(Some(rr)) =
                 rr.into_record::<AllRecordData<_, ParsedDname<_>>>()
             {
-                if rr.rtype() == Rtype::Cname {
+                if rr.rtype() == Rtype::CNAME {
                     return Some(rr);
                 }
             }

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -267,7 +267,7 @@ impl<Target: Composer> MessageBuilder<Target> {
     ) -> Result<AnswerBuilder<Target>, PushError> {
         self.header_mut().set_random_id();
         let mut builder = self.question();
-        builder.push((apex, Rtype::Axfr))?;
+        builder.push((apex, Rtype::AXFR))?;
         Ok(builder.answer())
     }
 }
@@ -2376,12 +2376,12 @@ mod test {
         T::AppendError: fmt::Debug,
     {
         let mut msg = MessageBuilder::from_target(target).unwrap().question();
-        msg.header_mut().set_rcode(Rcode::NXDomain);
+        msg.header_mut().set_rcode(Rcode::NXDOMAIN);
         msg.header_mut().set_rd(true);
         msg.header_mut().set_ra(true);
         msg.header_mut().set_qr(true);
 
-        msg.push((&"example".parse::<Dname<Vec<u8>>>().unwrap(), Rtype::Ns))
+        msg.push((&"example".parse::<Dname<Vec<u8>>>().unwrap(), Rtype::NS))
             .unwrap();
         let mut msg = msg.authority();
 

--- a/src/base/opt/algsig.rs
+++ b/src/base/opt/algsig.rs
@@ -217,6 +217,18 @@ impl<Variant, Octs: ?Sized> Understood<Variant, Octs> {
     }
 }
 
+impl Understood<DauVariant, ()> {
+    pub(super) const CODE: OptionCode = OptionCode::DAU;
+}
+
+impl Understood<DhuVariant, ()> {
+    pub(super) const CODE: OptionCode = OptionCode::DHU;
+}
+
+impl Understood<N3uVariant, ()> {
+    pub(super) const CODE: OptionCode = OptionCode::N3U;
+}
+
 //--- OctetsFrom
 
 impl<Variant, O, OO> OctetsFrom<Understood<Variant, O>>
@@ -280,19 +292,19 @@ impl<Variant, Octs: AsRef<[u8]>> hash::Hash for Understood<Variant, Octs> {
 
 impl<Octs: ?Sized> OptData for Understood<DauVariant, Octs> {
     fn code(&self) -> OptionCode {
-        OptionCode::Dau
+        OptionCode::DAU
     }
 }
 
 impl<Octs: ?Sized> OptData for Understood<DhuVariant, Octs> {
     fn code(&self) -> OptionCode {
-        OptionCode::Dhu
+        OptionCode::DHU
     }
 }
 
 impl<Octs: ?Sized> OptData for Understood<N3uVariant, Octs> {
     fn code(&self) -> OptionCode {
-        OptionCode::N3u
+        OptionCode::N3U
     }
 }
 
@@ -302,7 +314,7 @@ for Understood<DauVariant, Octs::Range<'a>> {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::Dau {
+        if code == OptionCode::DAU {
             Self::parse(parser).map(Some)
         }
         else {
@@ -317,7 +329,7 @@ for Understood<DhuVariant, Octs::Range<'a>> {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::Dhu {
+        if code == OptionCode::DHU {
             Self::parse(parser).map(Some)
         }
         else {
@@ -332,7 +344,7 @@ for Understood<N3uVariant, Octs::Range<'a>> {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::N3u {
+        if code == OptionCode::N3U {
             Self::parse(parser).map(Some)
         }
         else {
@@ -453,7 +465,7 @@ impl<'a, Target: Composer> OptBuilder<'a, Target> {
         &mut self, algs: &impl AsRef<[SecAlg]>,
     ) -> Result<(), BuildDataError> {
         Ok(self.push_raw_option(
-            OptionCode::Dau,
+            OptionCode::DAU,
             u16::try_from(
                 algs.as_ref().len() * usize::from(SecAlg::COMPOSE_LEN)
             ).map_err(|_| BuildDataError::LongOptData)?,
@@ -470,7 +482,7 @@ impl<'a, Target: Composer> OptBuilder<'a, Target> {
         &mut self, algs: &impl AsRef<[SecAlg]>,
     ) -> Result<(), BuildDataError> {
         Ok(self.push_raw_option(
-            OptionCode::Dhu,
+            OptionCode::DHU,
             u16::try_from(
                 algs.as_ref().len() * usize::from(SecAlg::COMPOSE_LEN)
             ).map_err(|_| BuildDataError::LongOptData)?,
@@ -487,7 +499,7 @@ impl<'a, Target: Composer> OptBuilder<'a, Target> {
         &mut self, algs: &impl AsRef<[SecAlg]>,
     ) -> Result<(), BuildDataError> {
         Ok(self.push_raw_option(
-            OptionCode::N3u,
+            OptionCode::N3U,
             u16::try_from(
                 algs.as_ref().len() * usize::from(SecAlg::COMPOSE_LEN)
             ).map_err(|_| BuildDataError::LongOptData)?,

--- a/src/base/opt/chain.rs
+++ b/src/base/opt/chain.rs
@@ -35,7 +35,13 @@ pub struct Chain<Name: ?Sized> {
     start: Name
 }
 
+impl Chain<()> {
+    /// The option code for this option.
+    pub(super) const CODE: OptionCode = OptionCode::CHAIN;
+}
+
 impl<Name: ?Sized> Chain<Name> {
+    
     /// Creates new CHAIN option data using the given name as the start.
     pub fn new(start: Name) -> Self
     where
@@ -132,7 +138,7 @@ impl<Name: hash::Hash> hash::Hash for Chain<Name> {
 
 impl<Name> OptData for Chain<Name> {
     fn code(&self) -> OptionCode {
-        OptionCode::Chain
+        OptionCode::CHAIN
     }
 }
 
@@ -142,7 +148,7 @@ where Octs: Octets {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::Chain {
+        if code == OptionCode::CHAIN {
             Self::parse(parser).map(Some)
         }
         else {

--- a/src/base/opt/cookie.rs
+++ b/src/base/opt/cookie.rs
@@ -66,6 +66,9 @@ pub struct Cookie {
 }
 
 impl Cookie {
+    /// The option code for this option.
+    pub(super) const CODE: OptionCode = OptionCode::COOKIE;
+
     /// Creates a new cookie from client and optional server cookie.
     #[must_use]
     pub fn new(
@@ -170,7 +173,7 @@ impl Cookie {
 
 impl OptData for Cookie {
     fn code(&self) -> OptionCode {
-        OptionCode::Cookie
+        OptionCode::COOKIE
     }
 }
 
@@ -179,7 +182,7 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> ParseOptData<'a, Octs> for Cookie {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::Cookie {
+        if code == OptionCode::COOKIE {
             Self::parse(parser).map(Some)
         }
         else {

--- a/src/base/opt/expire.rs
+++ b/src/base/opt/expire.rs
@@ -32,6 +32,9 @@ use octseq::parse::Parser;
 pub struct Expire(Option<u32>);
 
 impl Expire {
+    /// The option code for this option.
+    pub(super) const CODE: OptionCode = OptionCode::EXPIRE;
+    
     /// Creates a new expire option with the given optional expire value.
     #[must_use]
     pub fn new(expire: Option<u32>) -> Self {
@@ -68,7 +71,7 @@ impl Expire {
 
 impl OptData for Expire {
     fn code(&self) -> OptionCode {
-        OptionCode::Expire
+        OptionCode::EXPIRE
     }
 }
 
@@ -77,7 +80,7 @@ impl<'a, Octs: AsRef<[u8]>> ParseOptData<'a, Octs> for Expire {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::Expire {
+        if code == OptionCode::EXPIRE {
             Self::parse(parser).map(Some)
         }
         else {

--- a/src/base/opt/exterr.rs
+++ b/src/base/opt/exterr.rs
@@ -38,6 +38,11 @@ pub struct ExtendedError<Octs> {
     text: Option<Result<Str<Octs>, Octs>>,
 }
 
+impl ExtendedError<()> {
+    /// The option code for this option.
+    pub(super) const CODE: OptionCode = OptionCode::EXTENDED_ERROR;
+}
+
 impl<Octs> ExtendedError<Octs> {
     /// Creates a new value from a code and optional text.
     ///
@@ -169,7 +174,7 @@ where
 
 impl<Octs> OptData for ExtendedError<Octs> {
     fn code(&self) -> OptionCode {
-        OptionCode::ExtendedError
+        OptionCode::EXTENDED_ERROR
     }
 }
 
@@ -179,7 +184,7 @@ where Octs: Octets + ?Sized {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::ExtendedError {
+        if code == OptionCode::EXTENDED_ERROR {
             Self::parse(parser).map(Some)
         }
         else {
@@ -336,7 +341,7 @@ mod tests {
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn nsid_compose_parse() {
         let ede = ExtendedError::new(
-            ExtendedErrorCode::StaleAnswer,
+            ExtendedErrorCode::STALE_ANSWER,
             Some(Str::from_string("some text".into()))
         ).unwrap();
         test_option_compose_parse(
@@ -347,7 +352,7 @@ mod tests {
 
     #[test]
     fn private() {
-        let ede: ExtendedError<&[u8]> = ExtendedErrorCode::DnssecBogus.into();
+        let ede: ExtendedError<&[u8]> = ExtendedErrorCode::DNSSEC_BOGUS.into();
         assert!(!ede.is_private());
 
         let ede: ExtendedError<&[u8]> = EDE_PRIVATE_RANGE_BEGIN.into();

--- a/src/base/opt/keepalive.rs
+++ b/src/base/opt/keepalive.rs
@@ -33,6 +33,9 @@ use octseq::parse::Parser;
 pub struct TcpKeepalive(Option<IdleTimeout>);
 
 impl TcpKeepalive {
+    /// The option code for this option.
+    pub(super) const CODE: OptionCode = OptionCode::TCP_KEEPALIVE;
+    
     /// Creates a new value from an optional idle timeout.
     #[must_use]
     pub fn new(timeout: Option<IdleTimeout>) -> Self {
@@ -68,7 +71,7 @@ impl TcpKeepalive {
 
 impl OptData for TcpKeepalive {
     fn code(&self) -> OptionCode {
-        OptionCode::TcpKeepalive
+        OptionCode::TCP_KEEPALIVE
     }
 }
 
@@ -77,7 +80,7 @@ impl<'a, Octs: AsRef<[u8]>> ParseOptData<'a, Octs> for TcpKeepalive {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::TcpKeepalive {
+        if code == OptionCode::TCP_KEEPALIVE {
             Self::parse(parser).map(Some)
         }
         else {

--- a/src/base/opt/keytag.rs
+++ b/src/base/opt/keytag.rs
@@ -32,6 +32,11 @@ pub struct KeyTag<Octs: ?Sized> {
     octets: Octs,
 }
 
+impl KeyTag<()> {
+    /// The option code for this option.
+    pub(super) const CODE: OptionCode = OptionCode::KEY_TAG;
+}
+    
 impl<Octs> KeyTag<Octs> {
     /// Creates a new value from its content in wire format.
     ///
@@ -195,7 +200,7 @@ where
 
 impl<Octs: ?Sized> OptData for KeyTag<Octs> {
     fn code(&self) -> OptionCode {
-        OptionCode::KeyTag
+        OptionCode::KEY_TAG
     }
 }
 
@@ -204,7 +209,7 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for KeyTag<Octs::Range<'a>> {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::KeyTag {
+        if code == OptionCode::KEY_TAG {
             Self::parse(parser).map(Some)
         }
         else {

--- a/src/base/opt/macros.rs
+++ b/src/base/opt/macros.rs
@@ -75,7 +75,7 @@ macro_rules! opt_types {
             fn code(&self) -> OptionCode {
                 match *self {
                     $( $(
-                        AllOptData::$opt(_) => OptionCode::$opt,
+                        AllOptData::$opt(_) => $module::$opt::CODE,
                     )* )*
                     AllOptData::Other(ref inner) => inner.code(),
                 }
@@ -90,7 +90,7 @@ macro_rules! opt_types {
             ) -> Result<Option<Self>, ParseError> {
                 match code {
                     $( $(
-                        OptionCode::$opt => {
+                        $module::$opt::CODE => {
                             Ok(Some(AllOptData::$opt(
                                 $opt::parse(parser)?
                             )))

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -76,6 +76,11 @@ pub struct Opt<Octs: ?Sized> {
     octets: Octs,
 }
 
+impl Opt<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::OPT;
+}
+
 impl<Octs: EmptyBuilder> Opt<Octs> {
     /// Creates empty OPT record data.
     pub fn empty() -> Self {
@@ -284,7 +289,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> hash::Hash for Opt<Octs> {
 
 impl<Octs: ?Sized> RecordData for Opt<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Opt
+        Rtype::OPT
     }
 }
 
@@ -296,7 +301,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Opt {
+        if rtype == Rtype::OPT {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -512,7 +517,7 @@ impl<Octs> OptRecord<Octs> {
     {
         Record::new(
             Dname::root_slice(),
-            Class::Int(self.udp_payload_size),
+            Class::from_int(self.udp_payload_size),
             Ttl::from_secs(
                 u32::from(self.ext_rcode) << 24
                     | u32::from(self.version) << 16
@@ -1098,7 +1103,7 @@ pub(super) mod test {
     fn opt_record_header() {
         let mut header = OptHeader::default();
         header.set_udp_payload_size(0x1234);
-        header.set_rcode(OptRcode::BadVers);
+        header.set_rcode(OptRcode::BADVERS);
         header.set_version(0xbd);
         header.set_dnssec_ok(true);
         let mut buf = Vec::with_capacity(11);
@@ -1112,7 +1117,7 @@ pub(super) mod test {
             .unwrap();
         let record = OptRecord::from_record(record);
         assert_eq!(record.udp_payload_size(), 0x1234);
-        assert_eq!(record.ext_rcode, OptRcode::BadVers.ext());
+        assert_eq!(record.ext_rcode, OptRcode::BADVERS.ext());
         assert_eq!(record.version(), 0xbd);
         assert!(record.dnssec_ok());
     }

--- a/src/base/opt/nsid.rs
+++ b/src/base/opt/nsid.rs
@@ -37,6 +37,11 @@ pub struct Nsid<Octs: ?Sized> {
     octets: Octs,
 }
 
+impl Nsid<()> {
+    /// The option code for this option.
+    pub(super) const CODE: OptionCode = OptionCode::NSID;
+}
+    
 impl<Octs> Nsid<Octs> {
     /// Creates a value from the ocets of the name server identifier.
     ///
@@ -160,7 +165,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> borrow::Borrow<[u8]> for Nsid<Octs> {
 
 impl<Octs: ?Sized> OptData for Nsid<Octs> {
     fn code(&self) -> OptionCode {
-        OptionCode::Nsid
+        OptionCode::NSID
     }
 }
 
@@ -169,7 +174,7 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for Nsid<Octs::Range<'a>> {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::Nsid {
+        if code == OptionCode::NSID {
             Self::parse(parser).map(Some)
         }
         else {

--- a/src/base/opt/padding.rs
+++ b/src/base/opt/padding.rs
@@ -36,6 +36,11 @@ pub struct Padding<Octs: ?Sized> {
     octets: Octs,
 }
 
+impl Padding<()> {
+    /// The option code for this option.
+    pub const CODE: OptionCode = OptionCode::PADDING;
+}
+
 impl<Octs> Padding<Octs> {
     /// Creates a value from the padding octets.
     ///
@@ -122,7 +127,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> borrow::Borrow<[u8]> for Padding<Octs> {
 
 impl<Octs> OptData for Padding<Octs> {
     fn code(&self) -> OptionCode {
-        OptionCode::Padding
+        OptionCode::PADDING
     }
 }
 
@@ -131,7 +136,7 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for Padding<Octs::Range<'a>> {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::Padding {
+        if code == OptionCode::PADDING {
             Self::parse(parser).map(Some)
         }
         else {
@@ -177,7 +182,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Padding<Octs> {
 impl<'a, Target: Composer> OptBuilder<'a, Target> {
     pub fn padding( &mut self, len: u16) -> Result<(), Target::AppendError> {
         self.push_raw_option(
-            OptionCode::Padding,
+            OptionCode::PADDING,
             len,
             |target| {
                 for _ in 0..len {
@@ -193,7 +198,7 @@ impl<'a, Target: Composer> OptBuilder<'a, Target> {
         &mut self, len: u16
     ) -> Result<(), Target::AppendError> {
         self.push_raw_option(
-            OptionCode::Padding,
+            OptionCode::PADDING,
             len,
             |target| {
                 for _ in 0..len {

--- a/src/base/opt/subnet.rs
+++ b/src/base/opt/subnet.rs
@@ -50,6 +50,9 @@ pub struct ClientSubnet {
 }
 
 impl ClientSubnet {
+    /// The option code for this option.
+    pub(super) const CODE: OptionCode = OptionCode::CLIENT_SUBNET;
+    
     /// Creates a new client subnet value.
     ///
     /// The function is very forgiving regarding the arguments and corrects
@@ -182,7 +185,7 @@ impl ClientSubnet {
 
 impl OptData for ClientSubnet {
     fn code(&self) -> OptionCode {
-        OptionCode::ClientSubnet
+        OptionCode::CLIENT_SUBNET
     }
 }
 
@@ -191,7 +194,7 @@ impl<'a, Octs: AsRef<[u8]>> ParseOptData<'a, Octs> for ClientSubnet {
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if code == OptionCode::ClientSubnet {
+        if code == OptionCode::CLIENT_SUBNET {
             Self::parse(parser).map(Some)
         }
         else {

--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -57,7 +57,7 @@ impl<N> Question<N> {
         Question {
             qname,
             qtype,
-            qclass: Class::In,
+            qclass: Class::IN,
         }
     }
 
@@ -121,7 +121,7 @@ impl<N: ToDname> From<(N, Rtype, Class)> for Question<N> {
 
 impl<N: ToDname> From<(N, Rtype)> for Question<N> {
     fn from((name, rtype): (N, Rtype)) -> Self {
-        Question::new(name, rtype, Class::In)
+        Question::new(name, rtype, Class::IN)
     }
 }
 
@@ -297,6 +297,6 @@ impl<Name: ToDname> ComposeQuestion for (Name, Rtype) {
         &self,
         target: &mut Target,
     ) -> Result<(), Target::AppendError> {
-        Question::new(&self.0, self.1, Class::In).compose(target)
+        Question::new(&self.0, self.1, Class::IN).compose(target)
     }
 }

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -240,7 +240,7 @@ impl<N, D> From<(N, Class, Ttl, D)> for Record<N, D> {
 
 impl<N, D> From<(N, u32, D)> for Record<N, D> {
     fn from((owner, ttl, data): (N, u32, D)) -> Self {
-        Self::new(owner, Class::In, Ttl::from_secs(ttl), data)
+        Self::new(owner, Class::IN, Ttl::from_secs(ttl), data)
     }
 }
 
@@ -504,7 +504,7 @@ where
         &self,
         target: &mut Target,
     ) -> Result<(), Target::AppendError> {
-        Record::new(&self.0, Class::In, Ttl::from_secs(self.1), &self.2)
+        Record::new(&self.0, Class::IN, Ttl::from_secs(self.1), &self.2)
             .compose(target)
     }
 }
@@ -518,7 +518,7 @@ where
         &self,
         target: &mut Target,
     ) -> Result<(), Target::AppendError> {
-        Record::new(&self.0, Class::In, self.1, &self.2).compose(target)
+        Record::new(&self.0, Class::IN, self.1, &self.2).compose(target)
     }
 }
 
@@ -1585,12 +1585,12 @@ mod test {
 
         let ds: Record<Dname<&[u8]>, Ds<&[u8]>> = Record::new(
             Dname::from_octets(b"\x01a\x07example\0".as_ref()).unwrap(),
-            Class::In,
+            Class::IN,
             Ttl::from_secs(86400),
             Ds::new(
                 12,
-                SecAlg::RsaSha256,
-                DigestAlg::Sha256,
+                SecAlg::RSASHA256,
+                DigestAlg::SHA256,
                 b"something".as_ref(),
             )
             .unwrap(),

--- a/src/net/client/redundant.rs
+++ b/src/net/client/redundant.rs
@@ -734,12 +734,12 @@ fn skip<Octs: Octets>(msg: &Message<Octs>, config: &Config) -> bool {
 
     let opt_rcode = get_opt_rcode(msg);
     // OptRcode needs PartialEq
-    if let OptRcode::Refused = opt_rcode {
+    if let OptRcode::REFUSED = opt_rcode {
         if config.defer_refused {
             return true;
         }
     }
-    if let OptRcode::ServFail = opt_rcode {
+    if let OptRcode::SERVFAIL = opt_rcode {
         if config.defer_servfail {
             return true;
         }
@@ -753,10 +753,6 @@ fn get_opt_rcode<Octs: Octets>(msg: &Message<Octs>) -> OptRcode {
     let opt = msg.opt();
     match opt {
         Some(opt) => opt.rcode(msg.header()),
-        None => {
-            // Convert Rcode to OptRcode, this should be part of
-            // OptRcode
-            OptRcode::from_int(msg.header().rcode().to_int() as u16)
-        }
+        None => msg.header().rcode().into(),
     }
 }

--- a/src/net/client/request.rs
+++ b/src/net/client/request.rs
@@ -155,7 +155,7 @@ impl<Octs: AsRef<[u8]> + Debug + Octets> RequestMessage<Octs> {
         let mut target = target.additional();
         for rr in source {
             let rr = rr?;
-            if rr.rtype() != Rtype::Opt {
+            if rr.rtype() != Rtype::OPT {
                 let rr = rr
                     .into_record::<AllRecordData<_, ParsedDname<_>>>()?
                     .expect("record expected");
@@ -237,7 +237,7 @@ impl<Octs: AsRef<[u8]> + Clone + Debug + Octets + Send + Sync + 'static>
 
         // If the result is an error, then the question section can be empty.
         // In that case we require all other sections to be empty as well.
-        if answer_header.rcode() != Rcode::NoError
+        if answer_header.rcode() != Rcode::NOERROR
             && answer_hcounts.qdcount() == 0
             && answer_hcounts.ancount() == 0
             && answer_hcounts.nscount() == 0

--- a/src/rdata/aaaa.rs
+++ b/src/rdata/aaaa.rs
@@ -26,6 +26,11 @@ pub struct Aaaa {
 }
 
 impl Aaaa {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::AAAA;
+}
+
+impl Aaaa {
     #[must_use]
     pub fn new(addr: Ipv6Addr) -> Aaaa {
         Aaaa { addr }
@@ -106,7 +111,7 @@ impl CanonicalOrd for Aaaa {
 
 impl RecordData for Aaaa {
     fn rtype(&self) -> Rtype {
-        Rtype::Aaaa
+        Aaaa::RTYPE
     }
 }
 
@@ -115,7 +120,7 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> ParseRecordData<'a, Octs> for Aaaa {
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Aaaa {
+        if rtype == Aaaa::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/cds.rs
+++ b/src/rdata/cds.rs
@@ -45,6 +45,11 @@ pub struct Cdnskey<Octs> {
     public_key: Octs,
 }
 
+impl Cdnskey<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::CDNSKEY;
+}
+
 impl<Octs> Cdnskey<Octs> {
     pub fn new(
         flags: u16,
@@ -242,7 +247,7 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Cdnskey<Octs> {
 
 impl<Octs> RecordData for Cdnskey<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Cdnskey
+        Cdnskey::RTYPE
     }
 }
 
@@ -254,7 +259,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Cdnskey {
+        if rtype == Cdnskey::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -343,6 +348,11 @@ pub struct Cds<Octs> {
         serde(with = "crate::utils::base64::serde")
     )]
     digest: Octs,
+}
+
+impl Cds<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::CDS;
 }
 
 impl<Octs> Cds<Octs> {
@@ -556,7 +566,7 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Cds<Octs> {
 
 impl<Octs> RecordData for Cds<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Cds
+        Cds::RTYPE
     }
 }
 
@@ -568,7 +578,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Cds {
+        if rtype == Cds::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -657,7 +667,7 @@ mod test {
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn cdnskey_compose_parse_scan() {
-        let rdata = Cdnskey::new(10, 11, SecAlg::RsaSha1, b"key").unwrap();
+        let rdata = Cdnskey::new(10, 11, SecAlg::RSASHA1, b"key").unwrap();
         test_rdlen(&rdata);
         test_compose_parse(&rdata, |parser| Cdnskey::parse(parser));
         test_scan(&["10", "11", "RSASHA1", "a2V5"], Cdnskey::scan, &rdata);
@@ -669,7 +679,7 @@ mod test {
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn cds_compose_parse_scan() {
         let rdata = Cds::new(
-            10, SecAlg::RsaSha1, DigestAlg::Sha256, b"key"
+            10, SecAlg::RSASHA1, DigestAlg::SHA256, b"key"
         ).unwrap();
         test_rdlen(&rdata);
         test_compose_parse(&rdata, |parser| Cds::parse(parser));

--- a/src/rdata/dname.rs
+++ b/src/rdata/dname.rs
@@ -16,7 +16,7 @@ dname_type_canonical! {
     /// name tree in the DNS.
     ///
     /// The DNAME type is defined in RFC 6672.
-    (Dname, Dname, dname, into_dname)
+    (Dname, DNAME, dname, into_dname)
 }
 
 //============ Testing ======================================================

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -56,6 +56,11 @@ pub struct Dnskey<Octs> {
     public_key: Octs,
 }
 
+impl Dnskey<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::DNSKEY;
+}
+
 impl<Octs> Dnskey<Octs> {
     pub fn new(
         flags: u16,
@@ -169,7 +174,7 @@ impl<Octs> Dnskey<Octs> {
     where
         Octs: AsRef<[u8]>,
     {
-        if self.algorithm == SecAlg::RsaMd5 {
+        if self.algorithm == SecAlg::RSAMD5 {
             // The key tag is third-to-last and second-to-last octets of the
             // key as a big-endian u16. If we don’t have enough octets in the
             // key, we return 0.
@@ -350,7 +355,7 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Dnskey<Octs> {
 
 impl<Octs> RecordData for Dnskey<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Dnskey
+        Dnskey::RTYPE
     }
 }
 
@@ -362,7 +367,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Dnskey {
+        if rtype == Dnskey::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -604,6 +609,11 @@ pub struct Rrsig<Octs, Name> {
         serde(with = "crate::utils::base64::serde")
     )]
     signature: Octs,
+}
+
+impl Rrsig<(), ()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::RRSIG;
 }
 
 impl<Octs, Name> Rrsig<Octs, Name> {
@@ -1009,7 +1019,7 @@ impl<O: AsRef<[u8]>, N: hash::Hash> hash::Hash for Rrsig<O, N> {
 
 impl<Octs, Name> RecordData for Rrsig<Octs, Name> {
     fn rtype(&self) -> Rtype {
-        Rtype::Rrsig
+        Rrsig::RTYPE
     }
 }
 
@@ -1020,7 +1030,7 @@ impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Rrsig {
+        if rtype == Rrsig::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -1154,6 +1164,11 @@ where
 pub struct Nsec<Octs, Name> {
     next_name: Name,
     types: RtypeBitmap<Octs>,
+}
+
+impl Nsec<(), ()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::NSEC;
 }
 
 impl<Octs, Name> Nsec<Octs, Name> {
@@ -1331,7 +1346,7 @@ impl<Octs: AsRef<[u8]>, Name: hash::Hash> hash::Hash for Nsec<Octs, Name> {
 
 impl<Octs, Name> RecordData for Nsec<Octs, Name> {
     fn rtype(&self) -> Rtype {
-        Rtype::Nsec
+        Nsec::RTYPE
     }
 }
 
@@ -1342,7 +1357,7 @@ impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Nsec {
+        if rtype == Nsec::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -1435,6 +1450,11 @@ pub struct Ds<Octs> {
         serde(with = "crate::utils::base64::serde")
     )]
     digest: Octs,
+}
+
+impl Ds<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::DS;
 }
 
 impl<Octs> Ds<Octs> {
@@ -1657,7 +1677,7 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Ds<Octs> {
 
 impl<Octs> RecordData for Ds<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Ds
+        Ds::RTYPE
     }
 }
 
@@ -1669,7 +1689,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Ds {
+        if rtype == Ds::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -2401,7 +2421,7 @@ mod test {
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn dnskey_compose_parse_scan() {
-        let rdata = Dnskey::new(10, 11, SecAlg::RsaSha1, b"key0").unwrap();
+        let rdata = Dnskey::new(10, 11, SecAlg::RSASHA1, b"key0").unwrap();
         test_rdlen(&rdata);
         test_compose_parse(&rdata, |parser| Dnskey::parse(parser));
         test_scan(&["10", "11", "RSASHA1", "a2V5MA=="], Dnskey::scan, &rdata);
@@ -2414,7 +2434,7 @@ mod test {
     fn rrsig_compose_parse_scan() {
         let rdata = Rrsig::new(
             Rtype::A,
-            SecAlg::RsaSha1,
+            SecAlg::RSASHA1,
             3,
             Ttl::from_secs(12),
             Serial::from(13),
@@ -2450,7 +2470,7 @@ mod test {
     fn nsec_compose_parse_scan() {
         let mut rtype = RtypeBitmapBuilder::new_vec();
         rtype.add(Rtype::A).unwrap();
-        rtype.add(Rtype::Srv).unwrap();
+        rtype.add(Rtype::SRV).unwrap();
         let rdata = Nsec::new(
             Dname::<Vec<u8>>::from_str("example.com.").unwrap(),
             rtype.finalize(),
@@ -2466,7 +2486,7 @@ mod test {
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn ds_compose_parse_scan() {
         let rdata =
-            Ds::new(10, SecAlg::RsaSha1, DigestAlg::Sha256, b"key").unwrap();
+            Ds::new(10, SecAlg::RSASHA1, DigestAlg::SHA256, b"key").unwrap();
         test_rdlen(&rdata);
         test_compose_parse(&rdata, |parser| Ds::parse(parser));
         test_scan(&["10", "RSASHA1", "2", "6b6579"], Ds::scan, &rdata);
@@ -2477,15 +2497,15 @@ mod test {
     #[test]
     fn rtype_split() {
         assert_eq!(split_rtype(Rtype::A), (0, 0, 0b01000000));
-        assert_eq!(split_rtype(Rtype::Ns), (0, 0, 0b00100000));
-        assert_eq!(split_rtype(Rtype::Caa), (1, 0, 0b01000000));
+        assert_eq!(split_rtype(Rtype::NS), (0, 0, 0b00100000));
+        assert_eq!(split_rtype(Rtype::CAA), (1, 0, 0b01000000));
     }
 
     #[test]
     fn rtype_bitmap_read_window() {
         let mut builder = RtypeBitmapBuilder::new_vec();
         builder.add(Rtype::A).unwrap();
-        builder.add(Rtype::Caa).unwrap();
+        builder.add(Rtype::CAA).unwrap();
         let bitmap = builder.finalize();
 
         let ((n, window), data) = read_window(bitmap.as_slice()).unwrap();
@@ -2499,11 +2519,11 @@ mod test {
     #[test]
     fn rtype_bitmap_builder() {
         let mut builder = RtypeBitmapBuilder::new_vec();
-        builder.add(Rtype::Int(1234)).unwrap(); // 0x04D2
+        builder.add(Rtype::from_int(1234)).unwrap(); // 0x04D2
         builder.add(Rtype::A).unwrap(); // 0x0001
-        builder.add(Rtype::Mx).unwrap(); // 0x000F
-        builder.add(Rtype::Rrsig).unwrap(); // 0x002E
-        builder.add(Rtype::Nsec).unwrap(); // 0x002F
+        builder.add(Rtype::MX).unwrap(); // 0x000F
+        builder.add(Rtype::RRSIG).unwrap(); // 0x002E
+        builder.add(Rtype::NSEC).unwrap(); // 0x002F
         let bitmap = builder.finalize();
         assert_eq!(
             bitmap.as_slice(),
@@ -2515,12 +2535,12 @@ mod test {
         );
 
         assert!(bitmap.contains(Rtype::A));
-        assert!(bitmap.contains(Rtype::Mx));
-        assert!(bitmap.contains(Rtype::Rrsig));
-        assert!(bitmap.contains(Rtype::Nsec));
-        assert!(bitmap.contains(Rtype::Int(1234)));
-        assert!(!bitmap.contains(Rtype::Int(1235)));
-        assert!(!bitmap.contains(Rtype::Ns));
+        assert!(bitmap.contains(Rtype::MX));
+        assert!(bitmap.contains(Rtype::RRSIG));
+        assert!(bitmap.contains(Rtype::NSEC));
+        assert!(bitmap.contains(Rtype::from(1234)));
+        assert!(!bitmap.contains(Rtype::from(1235)));
+        assert!(!bitmap.contains(Rtype::NS));
     }
 
     #[test]
@@ -2529,15 +2549,15 @@ mod test {
 
         let mut builder = RtypeBitmapBuilder::new_vec();
         let types = vec![
-            Rtype::Ns,
-            Rtype::Soa,
-            Rtype::Mx,
-            Rtype::Txt,
-            Rtype::Rrsig,
-            Rtype::Dnskey,
-            Rtype::Nsec3param,
-            Rtype::Spf,
-            Rtype::Caa,
+            Rtype::NS,
+            Rtype::SOA,
+            Rtype::MX,
+            Rtype::TXT,
+            Rtype::RRSIG,
+            Rtype::DNSKEY,
+            Rtype::NSEC3PARAM,
+            Rtype::SPF,
+            Rtype::CAA,
         ];
         for t in types.iter() {
             builder.add(*t).unwrap();
@@ -2554,7 +2574,7 @@ mod test {
             Dnskey::new(
                 256,
                 3,
-                SecAlg::RsaSha256,
+                SecAlg::RSASHA256,
                 base64::decode::<Vec<u8>>(
                     "AwEAAcTQyaIe6nt3xSPOG2L/YfwBkOVTJN6mlnZ249O5Rtt3ZSRQHxQS\
                      W61AODYw6bvgxrrGq8eeOuenFjcSYgNAMcBYoEYYmKDW6e9EryW4ZaT/\
@@ -2573,7 +2593,7 @@ mod test {
             Dnskey::new(
                 257,
                 3,
-                SecAlg::RsaSha256,
+                SecAlg::RSASHA256,
                 base64::decode::<Vec<u8>>(
                     "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTO\
                     iW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN\
@@ -2594,7 +2614,7 @@ mod test {
             Dnskey::new(
                 257,
                 3,
-                SecAlg::RsaMd5,
+                SecAlg::RSAMD5,
                 base64::decode::<Vec<u8>>(
                     "AwEAAcVaA4jSBIGRrSzpecoJELvKE9+OMuFnL8mmUBsY\
                     lB6epN1CqX7NzwjDpi6VySiEXr0C4uTYkU/L1uMv2mHE\
@@ -2612,7 +2632,7 @@ mod test {
     #[test]
     fn dnskey_flags() {
         let dnskey =
-            Dnskey::new(257, 3, SecAlg::RsaSha256, bytes::Bytes::new())
+            Dnskey::new(257, 3, SecAlg::RSASHA256, bytes::Bytes::new())
                 .unwrap();
         assert!(dnskey.is_zsk());
         assert!(dnskey.is_secure_entry_point());

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -104,7 +104,7 @@ macro_rules! rdata_types {
                 else {
                     match rtype {
                         $( $( $(
-                            Rtype::$mtype => {
+                            $mtype::RTYPE => {
                                 $mtype::scan(
                                     scanner
                                 ).map(ZoneRecordData::$mtype)
@@ -331,7 +331,7 @@ macro_rules! rdata_types {
                 match *self {
                     $( $( $(
                         ZoneRecordData::$mtype(ref inner) => {
-                            Rtype::$mtype.hash(state);
+                            $mtype::RTYPE.hash(state);
                             inner.hash(state)
                         }
                     )* )* )*
@@ -360,7 +360,7 @@ macro_rules! rdata_types {
             ) -> Result<Option<Self>, ParseError> {
                 match rtype {
                     $( $( $(
-                        Rtype::$mtype => {
+                        $mtype::RTYPE => {
                             Ok(Some(ZoneRecordData::$mtype(
                                 $mtype::parse(parser)?
                             )))
@@ -505,7 +505,7 @@ macro_rules! rdata_types {
                         }
                     )* )* )*
 
-                    AllRecordData::Opt(_) => Rtype::Opt,
+                    AllRecordData::Opt(_) => Rtype::OPT,
                     AllRecordData::Unknown(ref inner) => inner.rtype(),
                 }
             }
@@ -753,20 +753,20 @@ macro_rules! rdata_types {
             ) -> Result<Self, ParseError> {
                 match rtype {
                     $( $( $(
-                        Rtype::$mtype => {
+                        $mtype::RTYPE => {
                             Ok(AllRecordData::$mtype(
                                 $mtype::parse(parser)?
                             ))
                         }
                     )* )* )*
                     $( $( $(
-                        Rtype::$ptype => {
+                        $ptype::RTYPE => {
                             Ok(AllRecordData::$ptype(
                                 $ptype::parse(parser)?
                             ))
                         }
                     )* )* )*
-                    $crate::base::iana::Rtype::Opt => {
+                    Opt::RTYPE => {
                         Ok(AllRecordData::Opt(
                             Opt::parse(parser)?
                         ))
@@ -957,6 +957,12 @@ macro_rules! dname_type_base {
             $field: N
         }
 
+        impl $target<()> {
+            /// The rtype of this record data type.
+            pub(crate) const RTYPE: $crate::base::iana::Rtype
+                = $crate::base::iana::Rtype::$rtype;
+        }
+
         impl<N> $target<N> {
             pub fn new($field: N) -> Self {
                 $target { $field }
@@ -1088,7 +1094,7 @@ macro_rules! dname_type_base {
 
         impl<N> $crate::base::rdata::RecordData for $target<N> {
             fn rtype(&self) -> $crate::base::iana::Rtype {
-                $crate::base::iana::Rtype::$rtype
+                $target::RTYPE
             }
         }
 
@@ -1099,7 +1105,7 @@ macro_rules! dname_type_base {
                 rtype: $crate::base::iana::Rtype,
                 parser: &mut octseq::parse::Parser<'a, Octs>,
             ) -> Result<Option<Self>, $crate::base::wire::ParseError> {
-                if rtype == $crate::base::iana::Rtype::$rtype {
+                if rtype == $target::RTYPE {
                     Self::parse(parser).map(Some)
                 }
                 else {

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -52,6 +52,11 @@ pub struct Nsec3<Octs> {
     types: RtypeBitmap<Octs>,
 }
 
+impl Nsec3<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::NSEC3;
+}
+
 impl<Octs> Nsec3<Octs> {
     pub fn new(
         hash_algorithm: Nsec3HashAlg,
@@ -280,7 +285,7 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Nsec3<Octs> {
 
 impl<Octs> RecordData for Nsec3<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Nsec3
+        Nsec3::RTYPE
     }
 }
 
@@ -292,7 +297,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Nsec3 {
+        if rtype == Nsec3::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -385,6 +390,11 @@ pub struct Nsec3param<Octs> {
     flags: u8,
     iterations: u16,
     salt: Nsec3Salt<Octs>,
+}
+
+impl Nsec3param<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::NSEC3PARAM;
 }
 
 impl<Octs> Nsec3param<Octs> {
@@ -577,7 +587,7 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Nsec3param<Octs> {
 
 impl<Octs> RecordData for Nsec3param<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Nsec3param
+        Nsec3param::RTYPE
     }
 }
 
@@ -589,7 +599,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Nsec3param {
+        if rtype == Nsec3param::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -1456,9 +1466,9 @@ mod test {
     fn nsec3_compose_parse_scan() {
         let mut rtype = RtypeBitmapBuilder::new_vec();
         rtype.add(Rtype::A).unwrap();
-        rtype.add(Rtype::Srv).unwrap();
+        rtype.add(Rtype::SRV).unwrap();
         let rdata = Nsec3::new(
-            Nsec3HashAlg::Sha1,
+            Nsec3HashAlg::SHA1,
             10,
             11,
             Nsec3Salt::from_octets(Vec::from("bar")).unwrap(),
@@ -1478,7 +1488,7 @@ mod test {
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn nsec3param_compose_parse_scan() {
         let rdata = Nsec3param::new(
-            Nsec3HashAlg::Sha1,
+            Nsec3HashAlg::SHA1,
             10,
             11,
             Nsec3Salt::from_octets(Vec::from("bar")).unwrap(),

--- a/src/rdata/rfc1035/a.rs
+++ b/src/rdata/rfc1035/a.rs
@@ -33,6 +33,11 @@ pub struct A {
 }
 
 impl A {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::A;
+}
+
+impl A {
     /// Creates a new A record data from an IPv4 address.
     #[must_use]
     pub fn new(addr: Ipv4Addr) -> A {
@@ -120,7 +125,7 @@ impl CanonicalOrd for A {
 
 impl RecordData for A {
     fn rtype(&self) -> Rtype {
-        Rtype::A
+        A::RTYPE
     }
 }
 
@@ -129,7 +134,7 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> ParseRecordData<'a, Octs> for A {
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::A {
+        if rtype == A::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/rfc1035/dname.rs
+++ b/src/rdata/rfc1035/dname.rs
@@ -20,7 +20,7 @@ dname_type_well_known! {
     /// name alias.
     ///
     /// The CNAME type is defined in RFC 1035, section 3.3.1.
-    (Cname, Cname, cname, into_cname)
+    (Cname, CNAME, cname, into_cname)
 }
 
 //------------ Mb -----------------------------------------------------------
@@ -31,7 +31,7 @@ dname_type_well_known! {
     /// The experimental MB record specifies a host that serves a mailbox.
     ///
     /// The MB record type is defined in RFC 1035, section 3.3.3.
-    (Mb, Mb, madname, into_madname)
+    (Mb, MB, madname, into_madname)
 }
 
 //------------ Md -----------------------------------------------------------
@@ -46,7 +46,7 @@ dname_type_well_known! {
     /// or convert them into an Mx record at preference 0.
     ///
     /// The MD record type is defined in RFC 1035, section 3.3.4.
-    (Md, Md, madname, into_madname)
+    (Md, MD, madname, into_madname)
 }
 
 //------------ Mf -----------------------------------------------------------
@@ -61,7 +61,7 @@ dname_type_well_known! {
     /// or convert them into an Mx record at preference 10.
     ///
     /// The MF record type is defined in RFC 1035, section 3.3.5.
-    (Mf, Mf, madname, into_madname)
+    (Mf, MF, madname, into_madname)
 }
 
 //------------ Mg -----------------------------------------------------------
@@ -75,7 +75,7 @@ dname_type_well_known! {
     /// The MG record is experimental.
     ///
     /// The MG record type is defined in RFC 1035, section 3.3.6.
-    (Mg, Mg, madname, into_madname)
+    (Mg, MG, madname, into_madname)
 }
 
 //------------ Mr -----------------------------------------------------------
@@ -89,7 +89,7 @@ dname_type_well_known! {
     /// The MR record is experimental.
     ///
     /// The MR record type is defined in RFC 1035, section 3.3.8.
-    (Mr, Mr, newname, into_newname)
+    (Mr, MR, newname, into_newname)
 }
 
 //------------ Ns -----------------------------------------------------------
@@ -100,7 +100,7 @@ dname_type_well_known! {
     /// NS records specify hosts that are authoritative for a class and domain.
     ///
     /// The NS record type is defined in RFC 1035, section 3.3.11.
-    (Ns, Ns, nsdname, into_nsdname)
+    (Ns, NS, nsdname, into_nsdname)
 }
 
 //------------ Ptr ----------------------------------------------------------
@@ -112,7 +112,7 @@ dname_type_well_known! {
     /// in the domain space.
     ///
     /// The PTR record type is defined in RFC 1035, section 3.3.12.
-    (Ptr, Ptr, ptrdname, into_ptrdname)
+    (Ptr, PTR, ptrdname, into_ptrdname)
 }
 
 //============ Testing =======================================================

--- a/src/rdata/rfc1035/hinfo.rs
+++ b/src/rdata/rfc1035/hinfo.rs
@@ -41,6 +41,11 @@ pub struct Hinfo<Octs> {
     os: CharStr<Octs>,
 }
 
+impl Hinfo<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::HINFO;
+}
+
 impl<Octs> Hinfo<Octs> {
     /// Creates a new Hinfo record data from the components.
     pub fn new(cpu: CharStr<Octs>, os: CharStr<Octs>) -> Self {
@@ -168,7 +173,7 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Hinfo<Octs> {
 
 impl<Octs> RecordData for Hinfo<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Hinfo
+        Hinfo::RTYPE
     }
 }
 
@@ -180,7 +185,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Hinfo {
+        if rtype == Hinfo::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/rfc1035/minfo.rs
+++ b/src/rdata/rfc1035/minfo.rs
@@ -33,6 +33,11 @@ pub struct Minfo<N> {
     emailbx: N,
 }
 
+impl Minfo<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::MINFO;
+}
+
 impl<N> Minfo<N> {
     /// Creates a new Minfo record data from the components.
     pub fn new(rmailbx: N, emailbx: N) -> Self {
@@ -177,7 +182,7 @@ impl<N: ToDname, NN: ToDname> CanonicalOrd<Minfo<NN>> for Minfo<N> {
 
 impl<N> RecordData for Minfo<N> {
     fn rtype(&self) -> Rtype {
-        Rtype::Minfo
+        Minfo::RTYPE
     }
 }
 
@@ -188,7 +193,7 @@ impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Minfo {
+        if rtype == Minfo::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/rfc1035/mx.rs
+++ b/src/rdata/rfc1035/mx.rs
@@ -30,6 +30,11 @@ pub struct Mx<N> {
     exchange: N,
 }
 
+impl Mx<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::MX;
+}
+
 impl<N> Mx<N> {
     /// Creates a new Mx record data from the components.
     pub fn new(preference: u16, exchange: N) -> Self {
@@ -162,7 +167,7 @@ impl<N: ToDname, NN: ToDname> CanonicalOrd<Mx<NN>> for Mx<N> {
 
 impl<N> RecordData for Mx<N> {
     fn rtype(&self) -> Rtype {
-        Rtype::Mx
+        Mx::RTYPE
     }
 }
 
@@ -173,7 +178,7 @@ impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Mx {
+        if rtype == Mx::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/rfc1035/null.rs
+++ b/src/rdata/rfc1035/null.rs
@@ -38,6 +38,11 @@ pub struct Null<Octs: ?Sized> {
     data: Octs,
 }
 
+impl Null<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::NULL;
+}
+
 impl<Octs> Null<Octs> {
     /// Creates new NULL record data from the given octets.
     ///
@@ -198,7 +203,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> hash::Hash for Null<Octs> {
 
 impl<Octs: ?Sized> RecordData for Null<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Null
+        Null::RTYPE
     }
 }
 
@@ -210,7 +215,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Null {
+        if rtype == Null::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/rfc1035/soa.rs
+++ b/src/rdata/rfc1035/soa.rs
@@ -37,6 +37,11 @@ pub struct Soa<N> {
     minimum: Ttl,
 }
 
+impl Soa<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::SOA;
+}
+
 impl<N> Soa<N> {
     /// Creates new Soa record data from content.
     pub fn new(
@@ -306,7 +311,7 @@ impl<N: ToDname, NN: ToDname> CanonicalOrd<Soa<NN>> for Soa<N> {
 
 impl<N> RecordData for Soa<N> {
     fn rtype(&self) -> Rtype {
-        Rtype::Soa
+        Soa::RTYPE
     }
 }
 
@@ -317,7 +322,7 @@ impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Soa {
+        if rtype == Soa::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -48,6 +48,11 @@ use octseq::serde::{DeserializeOctets, SerializeOctets};
 #[derive(Clone)]
 pub struct Txt<Octs: ?Sized>(Octs);
 
+impl Txt<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::TXT;
+}
+
 impl<Octs: FromBuilder> Txt<Octs> {
     /// Creates a new Txt record from a single slice.
     ///
@@ -355,7 +360,7 @@ impl<Octs: AsRef<[u8]>> hash::Hash for Txt<Octs> {
 
 impl<Octs> RecordData for Txt<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Txt
+        Txt::RTYPE
     }
 }
 
@@ -367,7 +372,7 @@ where
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Txt {
+        if rtype == Txt::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/srv.rs
+++ b/src/rdata/srv.rs
@@ -26,8 +26,12 @@ pub struct Srv<N> {
     target: N,
 }
 
+impl Srv<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::SRV;
+}
+
 impl<N> Srv<N> {
-    pub const RTYPE: Rtype = Rtype::Srv;
 
     pub fn new(priority: u16, weight: u16, port: u16, target: N) -> Self {
         Srv {
@@ -213,7 +217,7 @@ impl<N: ToDname, NN: ToDname> CanonicalOrd<Srv<NN>> for Srv<N> {
 
 impl<N> RecordData for Srv<N> {
     fn rtype(&self) -> Rtype {
-        Rtype::Srv
+        Srv::RTYPE
     }
 }
 
@@ -224,7 +228,7 @@ impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Srv {
+        if rtype == Srv::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -1074,13 +1074,11 @@ mod test {
     #[cfg(feature = "std")]
     #[test]
     fn test_representation() {
-        use crate::base::iana::svcb::SVC_PARAM_KEY_PRIVATE_RANGE_BEGIN;
-
         let mandatory = value::Mandatory::<Octets512>::from_keys(
             [
-                SvcParamKey::Alpn,
-                SvcParamKey::Ipv4Hint,
-                SVC_PARAM_KEY_PRIVATE_RANGE_BEGIN.into()
+                SvcParamKey::ALPN,
+                SvcParamKey::IPV4HINT,
+                SvcParamKey::PRIVATE_RANGE_BEGIN.into()
             ].into_iter()
         ).unwrap();
         assert_eq!(

--- a/src/rdata/svcb/rdata.rs
+++ b/src/rdata/svcb/rdata.rs
@@ -115,6 +115,16 @@ pub type Svcb<Octs, Name> = SvcbRdata<SvcbVariant, Octs, Name>;
 /// See [`SvcbRdata<..>`][SvcbRdata] for details.
 pub type Https<Octs, Name> = SvcbRdata<HttpsVariant, Octs, Name>;
 
+impl SvcbRdata<SvcbVariant, (), ()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::SVCB;
+}
+
+impl SvcbRdata<HttpsVariant, (), ()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::HTTPS;
+}
+
 impl<Variant, Octs, Name> SvcbRdata<Variant, Octs, Name> {
     /// Create a new value from its components.
     ///
@@ -339,13 +349,13 @@ for SvcbRdata<Variant, Octs, Name> {
 
 impl<Octs, Name> RecordData for SvcbRdata<SvcbVariant, Octs, Name> {
     fn rtype(&self) -> Rtype {
-        Rtype::Svcb
+        Rtype::SVCB
     }
 }
 
 impl<Octs, Name> RecordData for SvcbRdata<HttpsVariant, Octs, Name> {
     fn rtype(&self) -> Rtype {
-        Rtype::Https
+        Rtype::HTTPS
     }
 }
 
@@ -354,7 +364,7 @@ for SvcbRdata<SvcbVariant, Octs::Range<'a>, ParsedDname<Octs::Range<'a>>> {
     fn parse_rdata(
         rtype: Rtype, parser: &mut Parser<'a, Octs>
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Svcb {
+        if rtype == Rtype::SVCB {
             Self::parse(parser).map(Some)
         }
         else {
@@ -368,7 +378,7 @@ for SvcbRdata<HttpsVariant, Octs::Range<'a>, ParsedDname<Octs::Range<'a>>> {
     fn parse_rdata(
         rtype: Rtype, parser: &mut Parser<'a, Octs>
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Https{
+        if rtype == Rtype::HTTPS {
             Self::parse(parser).map(Some)
         }
         else {
@@ -503,7 +513,7 @@ mod test {
         let mut param_iter = svcb.params().iter();
         match param_iter.next() {
             Some(Ok(AllValues::Unknown(param))) => {
-                assert_eq!(0x029b, param.key());
+                assert_eq!(0x029b, param.key().to_int());
                 assert_eq!(b"\x68\x65\x6c\x6c\x6f".as_ref(), *param.value(),);
             }
             r => panic!("{:?}", r),

--- a/src/rdata/tsig.rs
+++ b/src/rdata/tsig.rs
@@ -78,6 +78,11 @@ pub struct Tsig<Octs, Name> {
     other: Octs,
 }
 
+impl Tsig<(), ()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::TSIG;
+}
+
 impl<O, N> Tsig<O, N> {
     /// Creates new TSIG record data from its components.
     ///
@@ -500,7 +505,7 @@ impl<O: AsRef<[u8]>, N: hash::Hash> hash::Hash for Tsig<O, N> {
 
 impl<O, N> RecordData for Tsig<O, N> {
     fn rtype(&self) -> Rtype {
-        Rtype::Tsig
+        Tsig::RTYPE
     }
 }
 
@@ -511,7 +516,7 @@ impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        if rtype == Rtype::Tsig {
+        if rtype == Tsig::RTYPE {
             Self::parse(parser).map(Some)
         } else {
             Ok(None)
@@ -725,7 +730,7 @@ mod test {
             12,
             "foo",
             13,
-            TsigRcode::BadCookie,
+            TsigRcode::BADCOOKIE,
             "",
         ).unwrap();
         test_rdlen(&rdata);

--- a/src/rdata/zonemd.rs
+++ b/src/rdata/zonemd.rs
@@ -40,6 +40,11 @@ pub struct Zonemd<Octs: ?Sized> {
     digest: Octs,
 }
 
+impl Zonemd<()> {
+    /// The rtype of this record data type.
+    pub(crate) const RTYPE: Rtype = Rtype::ZONEMD;
+}
+
 impl<Octs> Zonemd<Octs> {
     /// Create a Zonemd record data from provided parameters.
     pub fn new(
@@ -140,7 +145,7 @@ impl<Octs> Zonemd<Octs> {
 
 impl<Octs> RecordData for Zonemd<Octs> {
     fn rtype(&self) -> Rtype {
-        Rtype::Zonemd
+        Zonemd::RTYPE
     }
 }
 
@@ -417,7 +422,7 @@ ns2           3600   IN  AAAA    2001:db8::63
         while let Some(entry) = zone.next_entry().unwrap() {
             match entry {
                 Entry::Record(record) => {
-                    if record.rtype() != Rtype::Zonemd {
+                    if record.rtype() != Rtype::ZONEMD {
                         continue;
                     }
                     match record.into_data() {

--- a/src/resolv/lookup/addr.rs
+++ b/src/resolv/lookup/addr.rs
@@ -29,7 +29,7 @@ pub async fn lookup_addr<R: Resolver>(
     addr: IpAddr,
 ) -> Result<FoundAddrs<R>, io::Error> {
     let name = dname_from_addr(addr);
-    resolv.query((name, Rtype::Ptr)).await.map(FoundAddrs)
+    resolv.query((name, Rtype::PTR)).await.map(FoundAddrs)
 }
 
 //------------ FoundAddrs ----------------------------------------------------

--- a/src/resolv/lookup/host.rs
+++ b/src/resolv/lookup/host.rs
@@ -26,7 +26,7 @@ pub async fn lookup_host<R: Resolver>(
 ) -> Result<FoundHosts<R>, io::Error> {
     let (a, aaaa) = tokio::join!(
         resolver.query((&qname, Rtype::A)),
-        resolver.query((&qname, Rtype::Aaaa)),
+        resolver.query((&qname, Rtype::AAAA)),
     );
     FoundHosts::new(aaaa, a)
 }

--- a/src/resolv/lookup/srv.rs
+++ b/src/resolv/lookup/srv.rs
@@ -71,7 +71,7 @@ pub async fn lookup_srv(
         Ok(name) => name,
         Err(_) => return Err(SrvError::LongName),
     };
-    let answer = resolver.query((full_name, Rtype::Srv)).await?;
+    let answer = resolver.query((full_name, Rtype::SRV)).await?;
     FoundSrvs::new(answer.as_ref().for_slice(), name, fallback_port)
 }
 
@@ -211,7 +211,7 @@ impl FoundSrvs {
                     Ok(record) => record,
                     Err(_) => continue,
                 };
-                if record.class() != Class::In
+                if record.class() != Class::IN
                     || record.owner() != item.target()
                 {
                     continue;

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -370,13 +370,13 @@ impl<'a> Query<'a> {
         loop {
             match self.run_query(&mut message).await {
                 Ok(answer) => {
-                    if answer.header().rcode() == Rcode::FormErr
+                    if answer.header().rcode() == Rcode::FORMERR
                         && self.does_edns()
                     {
                         // FORMERR with EDNS: turn off EDNS and try again.
                         self.disable_edns();
                         continue;
-                    } else if answer.header().rcode() == Rcode::ServFail {
+                    } else if answer.header().rcode() == Rcode::SERVFAIL {
                         // SERVFAIL: go to next server.
                         self.update_error_servfail(answer);
                     } else {
@@ -462,8 +462,8 @@ pub struct Answer {
 impl Answer {
     /// Returns whether the answer is a final answer to be returned.
     pub fn is_final(&self) -> bool {
-        (self.message.header().rcode() == Rcode::NoError
-            || self.message.header().rcode() == Rcode::NXDomain)
+        (self.message.header().rcode() == Rcode::NOERROR
+            || self.message.header().rcode() == Rcode::NXDOMAIN)
             && !self.message.header().tc()
     }
 

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -60,7 +60,7 @@ impl<N, D> SortedRecords<N, D> {
         N: ToDname,
         D: RecordData,
     {
-        self.rrsets().find(|rrset| rrset.rtype() == Rtype::Soa)
+        self.rrsets().find(|rrset| rrset.rtype() == Rtype::SOA)
     }
 
     #[allow(clippy::type_complexity)]
@@ -121,14 +121,14 @@ impl<N, D> SortedRecords<N, D> {
                     // If we are at a zone cut, we only sign DS and NSEC
                     // records. NS records we must not sign and everything
                     // else shouldn’t be here, really.
-                    if rrset.rtype() != Rtype::Ds
-                        && rrset.rtype() != Rtype::Nsec
+                    if rrset.rtype() != Rtype::DS
+                        && rrset.rtype() != Rtype::NSEC
                     {
                         continue;
                     }
                 } else {
                     // Otherwise we only ignore RRSIGs.
-                    if rrset.rtype() == Rtype::Rrsig {
+                    if rrset.rtype() == Rtype::RRSIG {
                         continue;
                     }
                 }
@@ -230,7 +230,7 @@ impl<N, D> SortedRecords<N, D> {
 
             let mut bitmap = RtypeBitmap::<Octets>::builder();
             // Assume there’s gonna be an RRSIG.
-            bitmap.add(Rtype::Rrsig).unwrap();
+            bitmap.add(Rtype::RRSIG).unwrap();
             for rrset in family.rrsets() {
                 bitmap.add(rrset.rtype()).unwrap()
             }
@@ -340,7 +340,7 @@ impl<'a, N, D> Family<'a, N, D> {
         D: RecordData,
     {
         self.family_name().ne(apex)
-            && self.records().any(|record| record.rtype() == Rtype::Ns)
+            && self.records().any(|record| record.rtype() == Rtype::NS)
     }
 
     pub fn is_in_zone<NN: ToDname>(&self, apex: &FamilyName<NN>) -> bool

--- a/src/sign/ring.rs
+++ b/src/sign/ring.rs
@@ -51,7 +51,7 @@ impl<'a> Key<'a> {
             dnskey: Dnskey::new(
                 flags,
                 3,
-                SecAlg::EcdsaP256Sha256,
+                SecAlg::ECDSAP256SHA256,
                 public_key,
             )
             .expect("long key"),
@@ -82,7 +82,7 @@ impl<'a> SigningKey for Key<'a> {
         Ok(Ds::new(
             self.key_tag()?,
             self.dnskey.algorithm(),
-            DigestAlg::Sha256,
+            DigestAlg::SHA256,
             digest,
         )
         .expect("long digest"))

--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -147,7 +147,7 @@ fn tsig_server_drill() {
             };
             let answer = TestBuilder::new_stream_vec();
             let answer =
-                answer.start_answer(&request, Rcode::NoError).unwrap();
+                answer.start_answer(&request, Rcode::NOERROR).unwrap();
             let tran = match tsig::ServerTransaction::request(
                 &&key,
                 &mut request,
@@ -255,7 +255,7 @@ fn tsig_client_sequence_nsd() {
             // Last message has SOA as last record in answer section.
             // We don’t care about details.
             if answer.answer().unwrap().last().unwrap().unwrap().rtype()
-                == Rtype::Soa
+                == Rtype::SOA
             {
                 break;
             }
@@ -348,7 +348,7 @@ fn send_tcp(sock: &mut TcpStream, msg: &[u8]) -> Result<(), io::Error> {
 
 fn make_first_axfr(request: &TestMessage) -> TestAdditional {
     let msg = TestBuilder::new_stream_vec();
-    let mut msg = msg.start_answer(request, Rcode::NoError).unwrap();
+    let mut msg = msg.start_answer(request, Rcode::NOERROR).unwrap();
     push_soa(&mut msg);
     push_a(&mut msg, 0, 0, 0);
     msg.additional()
@@ -360,14 +360,14 @@ fn make_middle_axfr(
     two: u8,
 ) -> TestAdditional {
     let msg = TestBuilder::new_stream_vec();
-    let mut msg = msg.start_answer(request, Rcode::NoError).unwrap();
+    let mut msg = msg.start_answer(request, Rcode::NOERROR).unwrap();
     push_a(&mut msg, 1, one, two);
     msg.additional()
 }
 
 fn make_last_axfr(request: &TestMessage) -> TestAdditional {
     let msg = TestBuilder::new_stream_vec();
-    let mut msg = msg.start_answer(request, Rcode::NoError).unwrap();
+    let mut msg = msg.start_answer(request, Rcode::NOERROR).unwrap();
     push_a(&mut msg, 2, 0, 0);
     push_soa(&mut msg);
     msg.additional()

--- a/tests/net/deckard/matches.rs
+++ b/tests/net/deckard/matches.rs
@@ -143,7 +143,7 @@ where
     }
     if matches.opcode {
         // Not clear what that means. JUst check if it is Query
-        if msg.header().opcode() != Opcode::Query {
+        if msg.header().opcode() != Opcode::QUERY {
             if verbose {
                 todo!();
             }
@@ -167,7 +167,7 @@ where
         let msg_rcode =
             get_opt_rcode(&Message::from_octets(msg.as_slice()).unwrap());
         if reply.noerror {
-            if let OptRcode::NoError = msg_rcode {
+            if let OptRcode::NOERROR = msg_rcode {
                 // Okay
             } else {
                 if verbose {
@@ -215,7 +215,7 @@ fn match_section<
     }
     'outer: for msg_rr in msg_section {
         let msg_rr = msg_rr.unwrap();
-        if msg_rr.rtype() == Rtype::Opt {
+        if msg_rr.rtype() == Rtype::OPT {
             continue;
         }
         for (index, mat_rr) in match_section.iter().enumerate() {
@@ -296,10 +296,6 @@ fn get_opt_rcode<Octs: Octets>(msg: &Message<Octs>) -> OptRcode {
     let opt = msg.opt();
     match opt {
         Some(opt) => opt.rcode(msg.header()),
-        None => {
-            // Convert Rcode to OptRcode, this should be part of
-            // OptRcode
-            OptRcode::from_int(msg.header().rcode().to_int() as u16)
-        }
+        None => OptRcode::from_rcode(msg.header().rcode()),
     }
 }

--- a/tests/net/deckard/server.rs
+++ b/tests/net/deckard/server.rs
@@ -98,7 +98,7 @@ fn do_adjust<Octs: Octets>(
         todo!()
     }
     if reply.noerror {
-        msg.header_mut().set_rcode(Rcode::NoError);
+        msg.header_mut().set_rcode(Rcode::NOERROR);
     }
     if reply.nxdomain {
         todo!()


### PR DESCRIPTION
This PR changes the types for the IANA registered values into structs wrapping underlying integer types and provides the values as constants. This mostly just changes the spelling of those values. However, it also required some re-wiring of the type generation macros for record data and opt data since the type names and value names differ now.

This is a breaking change.

Fixes #273.