### PR TITLE
Proposal for adding `run()` and `query()` style helper interfaces.

### DIFF
--- a/examples/client-transports.rs
+++ b/examples/client-transports.rs
@@ -246,11 +246,23 @@ async fn main() {
     });
 
     // Send a request message.
-    let mut request = tcp.send_request(req);
+    let mut request = tcp.send_request(req.clone());
 
     // Get the reply
     let reply = request.get_response().await;
     println!("TCP reply: {:?}", reply);
 
     drop(tcp);
+
+    // Demonstrate query style transport use (inefficient for multiple queries
+    // as it will create a new connection each time it is called).
+    let tcp_conn = TcpStream::connect(server_addr).await.unwrap();
+    let reply = stream::Connection::query(tcp_conn, req.clone()).await;
+    println!("TCP reply: {:?}", reply);
+
+    // Demonstrate run style transport use (recommended for most use cases).
+    let tcp_conn = TcpStream::connect(server_addr).await.unwrap();
+    let tcp = stream::Connection::run(tcp_conn);
+    let reply = tcp.send_request(req.clone()).get_response().await;
+    println!("TCP reply: {:?}", reply);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 #![cfg_attr(feature = "net", doc = "* [net]:")]
 #![cfg_attr(not(feature = "net"), doc = "* net:")]
-//!   Sending and receiving DNS message.
+//!   Sending and receiving DNS messages.
 #![cfg_attr(feature = "resolv", doc = "* [resolv]:")]
 #![cfg_attr(not(feature = "resolv"), doc = "* resolv:")]
 //!   An asynchronous DNS resolver based on the

--- a/src/net/client/cache.rs
+++ b/src/net/client/cache.rs
@@ -279,12 +279,15 @@ pub struct Connection<Upstream, C: Clock + Send + Sync = SystemClock> {
 }
 
 impl<Upstream> Connection<Upstream> {
-    /// Create a new connection with default configuration parameters.
+    /// Create a new connection.
+    ///
+    /// This is the same as calling [`with_config()`][`Self::with_config()`]
+    /// with [`Config::default()`].
     pub fn new(upstream: Upstream) -> Self {
         Self::with_config(upstream, Default::default())
     }
 
-    /// Create a new connection with specified configuration parameters.
+    /// Create a new connection with the given configuration.
     pub fn with_config(upstream: Upstream, config: Config) -> Self {
         Self {
             upstream,


### PR DESCRIPTION
This PR explores the idea of extending the transport interfaces, where applicable, with `run()` and `query()` style interfaces.

`run` simplifies usage in the most common case by spawning `transport::run()` onto a new Tokio task, as `new()` returns both a transport and a connection and the caller is responsible for spawning `transport::run()` onto a new tokio task, or running it and awaiting it while passing the connection or a clone of it to another task/thread. When using `run()` one cannot await the join handle of the spawned task, but there isn't anything one can usefully do with the join handle anyway.

`query` simplifies usage in the one-shot case, which is unsuitable for sending many queries but maybe useful in demonstration, test or simple client scenarios.

`examples/client-transport.rs` is extended to show the new interfaces, but in particular if we like `run()` we might want to simplify the example to use it everywhere and leave `new()` for advanced scenarios.