### PR TITLE
Change ToDname/ToRelativeDname to have try_to_*name and to_*name pairs.

### DIFF
--- a/src/base/name/traits.rs
+++ b/src/base/name/traits.rs
@@ -115,9 +115,7 @@ pub trait ToDname: ToLabelIter {
     /// labels of the name and adds them one by one to [`Dname`]. This will
     /// work for any name but an optimized implementation can be provided for
     /// some types of names.
-    ///
-    /// [`Dname`]: struct.Dname.html
-    fn to_dname<Octets>(
+    fn try_to_dname<Octets>(
         &self,
     ) -> Result<Dname<Octets>, BuilderAppendError<Octets>>
     where
@@ -131,8 +129,22 @@ pub trait ToDname: ToLabelIter {
         Ok(unsafe { Dname::from_octets_unchecked(builder.freeze()) })
     }
 
+    /// Converts the name into a single, uncompressed name.
+    ///
+    /// This is the same as [`try_to_dname`][ToDname::try_to_dname] but for
+    /// builder types with an unrestricted buffer.
+    fn to_dname<Octets>(&self) -> Dname<Octets>
+    where
+        Octets: FromBuilder,
+        <Octets as FromBuilder>::Builder:
+            OctetsBuilder<AppendError = Infallible>,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        infallible(self.try_to_dname())
+    }
+
     /// Converts the name into a single name in canonical form.
-    fn to_canonical_dname<Octets>(
+    fn try_to_canonical_dname<Octets>(
         &self,
     ) -> Result<Dname<Octets>, BuilderAppendError<Octets>>
     where
@@ -144,6 +156,21 @@ pub trait ToDname: ToLabelIter {
         self.iter_labels()
             .try_for_each(|label| label.compose_canonical(&mut builder))?;
         Ok(unsafe { Dname::from_octets_unchecked(builder.freeze()) })
+    }
+
+    /// Converts the name into a single name in canonical form.
+    ///
+    /// This is the same as
+    /// [`try_to_canonical_dname`][ToDname::try_to_canonical_dname] but for
+    /// builder types with an unrestricted buffer.
+    fn to_canonical_dname<Octets>(&self) -> Dname<Octets>
+    where
+        Octets: FromBuilder,
+        <Octets as FromBuilder>::Builder:
+            OctetsBuilder<AppendError = Infallible>,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        infallible(self.try_to_canonical_dname())
     }
 
     /// Returns an octets slice of the content if possible.
@@ -202,13 +229,13 @@ pub trait ToDname: ToLabelIter {
     /// Returns the domain name assembled into a `Vec<u8>`.
     #[cfg(feature = "std")]
     fn to_vec(&self) -> Dname<std::vec::Vec<u8>> {
-        infallible(self.to_dname())
+        self.to_dname()
     }
 
     /// Returns the domain name assembled into a bytes value.
     #[cfg(feature = "bytes")]
     fn to_bytes(&self) -> Dname<Bytes> {
-        infallible(self.to_dname())
+        self.to_dname()
     }
 
     /// Tests whether `self` and `other` are equal.
@@ -353,7 +380,7 @@ pub trait ToRelativeDname: ToLabelIter {
     /// some types of names.
     ///
     /// [`RelativeDname`]: struct.RelativeDname.html
-    fn to_relative_dname<Octets>(
+    fn try_to_relative_dname<Octets>(
         &self,
     ) -> Result<RelativeDname<Octets>, BuilderAppendError<Octets>>
     where
@@ -367,8 +394,23 @@ pub trait ToRelativeDname: ToLabelIter {
         Ok(unsafe { RelativeDname::from_octets_unchecked(builder.freeze()) })
     }
 
+    /// Converts the name into a single, continous name.
+    ///
+    /// This is the same as
+    /// [`try_to_relative_dname`][ToRelativeDname::try_to_relative_dname]
+    /// but for builder types with an unrestricted buffer.
+    fn to_relative_dname<Octets>(&self) -> RelativeDname<Octets>
+    where
+        Octets: FromBuilder,
+        <Octets as FromBuilder>::Builder:
+            OctetsBuilder<AppendError = Infallible>,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        infallible(self.try_to_relative_dname())
+    }
+
     /// Converts the name into a single name in canonical form.
-    fn to_canonical_relative_dname<Octets>(
+    fn try_to_canonical_relative_dname<Octets>(
         &self,
     ) -> Result<RelativeDname<Octets>, BuilderAppendError<Octets>>
     where
@@ -380,6 +422,21 @@ pub trait ToRelativeDname: ToLabelIter {
         self.iter_labels()
             .try_for_each(|label| label.compose_canonical(&mut builder))?;
         Ok(unsafe { RelativeDname::from_octets_unchecked(builder.freeze()) })
+    }
+
+    /// Converts the name into a single name in canonical form.
+    ///
+    /// This is the same as
+    /// [`try_to_canonical_relative_dname`][ToRelativeDname::try_to_canonical_relative_dname]
+    /// but for builder types with an unrestricted buffer.
+    fn to_canonical_relative_dname<Octets>(&self) -> RelativeDname<Octets>
+    where
+        Octets: FromBuilder,
+        <Octets as FromBuilder>::Builder:
+            OctetsBuilder<AppendError = Infallible>,
+        <Octets as FromBuilder>::Builder: EmptyBuilder,
+    {
+        infallible(self.try_to_canonical_relative_dname())
     }
 
     /// Returns a byte slice of the content if possible.
@@ -434,13 +491,13 @@ pub trait ToRelativeDname: ToLabelIter {
     /// Returns the domain name assembled into a `Vec<u8>`.
     #[cfg(feature = "std")]
     fn to_vec(&self) -> RelativeDname<std::vec::Vec<u8>> {
-        infallible(self.to_relative_dname())
+        self.to_relative_dname()
     }
 
     /// Returns the domain name assembled into a bytes value.
     #[cfg(feature = "bytes")]
     fn to_bytes(&self) -> RelativeDname<Bytes> {
-        infallible(self.to_relative_dname())
+        self.to_relative_dname()
     }
 
     /// Returns whether the name is empty.

--- a/src/net/client/cache.rs
+++ b/src/net/client/cache.rs
@@ -35,7 +35,7 @@ use crate::base::{
     Dname, Header, Message, MessageBuilder, ParsedDname, StaticCompressor,
     Ttl,
 };
-use crate::dep::octseq::{octets::OctetsInto, Octets};
+use crate::dep::octseq::Octets;
 use crate::net::client::clock::{Clock, Elapsed, SystemClock};
 use crate::net::client::request::{
     ComposeRequest, Error, GetResponse, SendRequest,
@@ -803,15 +803,8 @@ impl Key {
     where
         TDN: ToDname,
     {
-        let mut qname: Dname<Vec<u8>> =
-            qname.to_dname().expect("to_dname should not fail");
-
-        // Make sure qname is canonical.
-        qname.make_canonical();
-        let qname: Dname<Bytes> = qname.octets_into();
-
         Self {
-            qname,
+            qname: qname.to_canonical_dname(),
             qclass,
             qtype,
             addo: AdDo::new(ad, dnssec_ok),

--- a/src/resolv/lookup/srv.rs
+++ b/src/resolv/lookup/srv.rs
@@ -297,7 +297,7 @@ impl SrvItem {
                 srv.priority(),
                 srv.weight(),
                 srv.port(),
-                srv.target().to_dname().unwrap(),
+                srv.target().try_to_dname().unwrap(),
             ),
             fallback: false,
             resolved: None,
@@ -306,7 +306,7 @@ impl SrvItem {
 
     fn fallback(name: impl ToDname, fallback_port: u16) -> Self {
         SrvItem {
-            srv: Srv::new(0, 0, fallback_port, name.to_dname().unwrap()),
+            srv: Srv::new(0, 0, fallback_port, name.try_to_dname().unwrap()),
             fallback: true,
             resolved: None,
         }

--- a/src/resolv/lookup/srv.rs
+++ b/src/resolv/lookup/srv.rs
@@ -297,7 +297,7 @@ impl SrvItem {
                 srv.priority(),
                 srv.weight(),
                 srv.port(),
-                srv.target().try_to_dname().unwrap(),
+                srv.target().to_dname(),
             ),
             fallback: false,
             resolved: None,
@@ -306,7 +306,7 @@ impl SrvItem {
 
     fn fallback(name: impl ToDname, fallback_port: u16) -> Self {
         SrvItem {
-            srv: Srv::new(0, 0, fallback_port, name.try_to_dname().unwrap()),
+            srv: Srv::new(0, 0, fallback_port, name.to_dname()),
             fallback: true,
             resolved: None,
         }

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -391,7 +391,7 @@ where
         algorithm: Algorithm,
     ) -> Option<Self::Key> {
         // XXX This seems a bit wasteful.
-        let name = name.to_dname().unwrap();
+        let name = name.try_to_dname().unwrap();
         self.get(&(name, algorithm)).cloned()
     }
 }

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -391,7 +391,7 @@ where
         algorithm: Algorithm,
     ) -> Option<Self::Key> {
         // XXX This seems a bit wasteful.
-        let name = name.try_to_dname().unwrap();
+        let name = name.try_to_dname().ok()?;
         self.get(&(name, algorithm)).cloned()
     }
 }

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -457,13 +457,13 @@ impl<'a> EntryScanner<'a> {
     fn scan_control(&mut self) -> Result<ScannedEntry, EntryError> {
         let ctrl = self.scan_string()?;
         if ctrl.eq_ignore_ascii_case("$ORIGIN") {
-            let origin = self.scan_dname()?.to_dname().unwrap();
+            let origin = self.scan_dname()?.to_dname();
             self.zonefile.buf.require_line_feed()?;
             Ok(ScannedEntry::Origin(origin))
         } else if ctrl.eq_ignore_ascii_case("$INCLUDE") {
             let path = self.scan_string()?;
             let origin = if !self.zonefile.buf.is_line_feed() {
-                Some(self.scan_dname()?.to_dname().unwrap())
+                Some(self.scan_dname()?.to_dname())
             } else {
                 None
             };

--- a/tests/net/stelline/parse_query.rs
+++ b/tests/net/stelline/parse_query.rs
@@ -371,13 +371,13 @@ impl<'a> EntryScanner<'a> {
     fn scan_control(&mut self) -> Result<ScannedEntry, EntryError> {
         let ctrl = self.scan_string()?;
         if ctrl.eq_ignore_ascii_case("$ORIGIN") {
-            let origin = self.scan_dname()?.to_dname().unwrap();
+            let origin = self.scan_dname()?.to_dname();
             self.zonefile.buf.require_line_feed()?;
             Ok(ScannedEntry::Origin(origin))
         } else if ctrl.eq_ignore_ascii_case("$INCLUDE") {
             let path = self.scan_string()?;
             let origin = if !self.zonefile.buf.is_line_feed() {
-                Some(self.scan_dname()?.to_dname().unwrap())
+                Some(self.scan_dname()?.to_dname())
             } else {
                 None
             };


### PR DESCRIPTION
This PR changes the `ToDname` and `ToRelativeDname` traits to have a pair of methods for each conversion that either return a result or just a success value depending on whether the octets builder used for the name can fail.
This should allow removing quite a few unwraps when e.g. `Vec<u8>` or `Bytes` are used.

This is a breaking change.

Fixes #281.