### PR TITLE
add AsRef impl for Record to allow for passing records by references when signing

### DIFF
--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -244,6 +244,14 @@ impl<N, D> From<(N, u32, D)> for Record<N, D> {
     }
 }
 
+//--- AsRef
+
+impl<N, D> AsRef<Record<N, D>> for Record<N, D> {
+    fn as_ref(&self) -> &Record<N, D> {
+        self
+    }
+}
+
 //--- OctetsFrom and FlattenInto
 //
 // XXX We don’t have blanket FromOctets for a type T into itself, so this may

--- a/src/rdata/zonemd.rs
+++ b/src/rdata/zonemd.rs
@@ -114,7 +114,7 @@ impl<Octs> Zonemd<Octs> {
     }
 
     pub(super) fn flatten<Target: OctetsFrom<Octs>>(
-        self
+        self,
     ) -> Result<Zonemd<Target>, Target::Error> {
         self.convert_octets()
     }
@@ -361,8 +361,6 @@ mod test {
     use crate::base::rdata::test::{
         test_compose_parse, test_rdlen, test_scan,
     };
-    use crate::base::Dname;
-    use crate::rdata::ZoneRecordData;
     use crate::utils::base16::decode;
     use std::string::ToString;
     use std::vec::Vec;
@@ -393,6 +391,8 @@ mod test {
     #[cfg(feature = "zonefile")]
     #[test]
     fn zonemd_parse_zonefile() {
+        use crate::base::Dname;
+        use crate::rdata::ZoneRecordData;
         use crate::zonefile::inplace::{Entry, Zonefile};
 
         // section A.1

--- a/src/utils/base64.rs
+++ b/src/utils/base64.rs
@@ -306,7 +306,6 @@ impl<Builder: OctetsBuilder> Decoder<Builder> {
 
 //--- Default
 
-#[cfg(feature = "bytes")]
 impl<Builder: EmptyBuilder> Default for Decoder<Builder> {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
One of the use case is to allow for both owned or borrowed records
in the mutable slice when composing the signed data.

Without this, in some cases, the caller would have to clone records
if they only hold a (im)mutable slice of record references or an immutable
slice of record values.