### PR TITLE
Redefine stub resolver transport types.

### DIFF
--- a/src/resolv/stub/conf.rs
+++ b/src/resolv/stub/conf.rs
@@ -202,33 +202,11 @@ impl Default for ResolvOptions {
 /// The transport protocol to be used for a server.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Transport {
-    /// Unencrypted UDP transport.
-    Udp,
+    /// Unencrypted UDP transport, switch to TCP for truncated responses.
+    UdpTcp,
 
     /// Unencrypted TCP transport.
     Tcp,
-}
-
-impl Transport {
-    /// Returns whether the transport is a preferred transport.
-    ///
-    /// Only preferred transports are considered initially. Only if a
-    /// truncated answer comes back will we consider streaming protocols
-    /// instead.
-    pub fn is_preferred(self) -> bool {
-        match self {
-            Transport::Udp => true,
-            Transport::Tcp => false,
-        }
-    }
-
-    /// Returns whether the transport is a streaming protocol.
-    pub fn is_stream(self) -> bool {
-        match self {
-            Transport::Udp => false,
-            Transport::Tcp => true,
-        }
-    }
 }
 
 //------------ ServerConf ----------------------------------------------------
@@ -344,10 +322,10 @@ impl ResolvConf {
         if self.servers.is_empty() {
             // glibc just simply uses 127.0.0.1:53. Let's do that, too,
             // and claim it is for compatibility.
-            let addr =
-                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 53);
-            self.servers.push(ServerConf::new(addr, Transport::Udp));
-            self.servers.push(ServerConf::new(addr, Transport::Tcp));
+            self.servers.push(ServerConf::new(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 53),
+                Transport::UdpTcp,
+            ));
         }
         if self.options.search.is_empty() {
             self.options.search.push(Dname::root())
@@ -409,8 +387,7 @@ impl ResolvConf {
         use std::net::ToSocketAddrs;
 
         for addr in (next_word(&mut words)?, 53).to_socket_addrs()? {
-            self.servers.push(ServerConf::new(addr, Transport::Udp));
-            self.servers.push(ServerConf::new(addr, Transport::Tcp));
+            self.servers.push(ServerConf::new(addr, Transport::UdpTcp));
         }
         no_more_words(words)
     }

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -154,10 +154,7 @@ impl StubResolver {
                 let (conn, tran) =
                     multi_stream::Connection::new(TcpConnect::new(s.addr));
                 // Start the run function on a separate task.
-                let run_fut = tran.run();
-                fut_list_tcp.push(async move {
-                    run_fut.await;
-                });
+                fut_list_tcp.push(tran.run());
                 redun.add(Box::new(conn)).await?;
             } else {
                 let udp_connect = UdpConnect::new(s.addr);
@@ -165,9 +162,7 @@ impl StubResolver {
                 let (conn, tran) =
                     dgram_stream::Connection::new(udp_connect, tcp_connect);
                 // Start the run function on a separate task.
-                fut_list_udp_tcp.push(async move {
-                    tran.run().await;
-                });
+                fut_list_udp_tcp.push(tran.run());
                 redun.add(Box::new(conn)).await?;
             }
         }


### PR DESCRIPTION
This PR redefines the stub resolver’s `Transport::Udp` type to be `Transport::UdpTcp`, i.e., use UDP but retry with TCP if the answer is truncated and slightly reworks the server selection code in the stub resolver to use all servers if `use_vc` is set.

This is a breaking change.

Fixes #91.