### PR TITLE
Fix adding of EDNS options.

### DIFF
--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -135,7 +135,7 @@ use super::iana::Rtype;
 use super::iana::{OptRcode, OptionCode, Rcode};
 use super::message::Message;
 use super::name::{Label, ToName};
-use super::opt::{ComposeOptData, OptHeader};
+use super::opt::{ComposeOptData, OptHeader, OptRecord};
 use super::question::ComposeQuestion;
 use super::record::ComposeRecord;
 use super::wire::{Compose, Composer};
@@ -1591,6 +1591,16 @@ impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
                 Err(ShortBuf)
             }
         }
+    }
+
+    /// Replaces the contents of this [`OptBuilder`] with the given
+    /// [`OptRecord`]`.
+    pub fn clone_from<T: AsRef<[u8]>>(
+        &mut self,
+        source: &OptRecord<T>,
+    ) -> Result<(), Target::AppendError> {
+        self.target.truncate(self.start);
+        source.as_record().compose(self.target)
     }
 
     /// Appends an option to the OPT record.

--- a/src/net/server/message.rs
+++ b/src/net/server/message.rs
@@ -22,7 +22,7 @@ use crate::base::wire::Composer;
 //------------ UdpTransportContext -------------------------------------------
 
 /// Request context for a UDP transport.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct UdpTransportContext {
     /// Optional maximum response size hint.
     max_response_size_hint: Arc<Mutex<Option<u16>>>,
@@ -136,6 +136,22 @@ impl TransportSpecificContext {
     /// Was the message received over a non-UDP transport?
     pub fn is_non_udp(&self) -> bool {
         matches!(self, Self::NonUdp(_))
+    }
+}
+
+//--- impl From<UdpTransportContext>
+
+impl From<UdpTransportContext> for TransportSpecificContext {
+    fn from(ctx: UdpTransportContext) -> Self {
+        Self::Udp(ctx)
+    }
+}
+
+//--- impl From<NonUdpTransportContext>
+
+impl From<NonUdpTransportContext> for TransportSpecificContext {
+    fn from(ctx: NonUdpTransportContext) -> Self {
+        Self::NonUdp(ctx)
     }
 }
 

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -4,6 +4,7 @@ use std::string::{String, ToString};
 use octseq::{Octets, OctetsBuilder};
 use tracing::warn;
 
+use crate::base::iana::Rcode;
 use crate::base::message_builder::{
     AdditionalBuilder, OptBuilder, PushError, QuestionBuilder,
 };
@@ -14,7 +15,6 @@ use crate::rdata::AllRecordData;
 
 use super::message::Request;
 use super::service::{CallResult, Service, ServiceError, Transaction};
-use crate::base::iana::Rcode;
 
 //----------- mk_builder_for_target() ----------------------------------------
 

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -327,6 +327,7 @@ mod tests {
     use super::start_reply;
     use crate::base::iana::{OptRcode, Rcode};
     use crate::base::message_builder::AdditionalBuilder;
+    use crate::base::opt::UnknownOptData;
     use crate::base::wire::Composer;
     use crate::net::server::util::{
         add_edns_options, remove_edns_opt_record,
@@ -402,7 +403,7 @@ mod tests {
         // And that it has a single EDNS option.
         let opt = response.opt().unwrap();
         let options = opt.opt();
-        assert_eq!(options.len(), 1);
+        assert_eq!(options.iter::<UnknownOptData<_>>().count(), 1);
 
         // Now add another EDNS option to the OPT record (duplicates are allowed
         // by RFC 6891).
@@ -418,7 +419,7 @@ mod tests {
         // And that it has a single EDNS option.
         let opt = response.opt().unwrap();
         let options = opt.opt();
-        assert_eq!(options.len(), 2);
+        assert_eq!(options.iter::<UnknownOptData<_>>().count(), 2);
     }
 
     #[test]

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -255,21 +255,7 @@ where
             // the options within the existing OPT record plus the new options
             // that we want to add.
             let res = response.opt(|builder| {
-                // Copy the header fields
-                builder.set_version(current_opt.version());
-                builder.set_dnssec_ok(current_opt.dnssec_ok());
-                builder
-                    .set_rcode(current_opt.rcode(copied_response.header()));
-                builder.set_udp_payload_size(current_opt.udp_payload_size());
-
-                // Copy the options
-                for opt in
-                    current_opt.opt().iter::<UnknownOptData<_>>().flatten()
-                {
-                    builder.push(&opt)?;
-                }
-
-                // Invoking the user supplied callback
+                builder.clone_from(&current_opt)?;
                 op(builder)
             });
 

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -7,7 +7,6 @@ use tracing::warn;
 use crate::base::message_builder::{
     AdditionalBuilder, OptBuilder, PushError, QuestionBuilder,
 };
-use crate::base::opt::UnknownOptData;
 use crate::base::wire::Composer;
 use crate::base::Message;
 use crate::base::{MessageBuilder, ParsedName, Rtype, StreamTarget};

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -255,11 +255,21 @@ where
             // the options within the existing OPT record plus the new options
             // that we want to add.
             let res = response.opt(|builder| {
+                // Copy the header fields
+                builder.set_version(current_opt.version());
+                builder.set_dnssec_ok(current_opt.dnssec_ok());
+                builder
+                    .set_rcode(current_opt.rcode(copied_response.header()));
+                builder.set_udp_payload_size(current_opt.udp_payload_size());
+
+                // Copy the options
                 for opt in
                     current_opt.opt().iter::<UnknownOptData<_>>().flatten()
                 {
                     builder.push(&opt)?;
                 }
+
+                // Invoking the user supplied callback
                 op(builder)
             });
 


### PR DESCRIPTION
When adding an EDNS option the existing EDNS OPT record header fields are not preserved.

This PR adds a test showing that and then fixes the issue.

There is also another issue relating to EDNS OPT record handling for cookies for which this branch was originally named but I decided to split that out to a separate PR, so just ignore the confusing branch name.

This PR also contains a minor improvement in ease of construction of the transport options enum as the test does this construction and I found it annoyingly verbose and unwieldy.