### PR TITLE
Add Message::for_slice_ref.

### DIFF
--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -268,6 +268,14 @@ impl<Octs: ?Sized> Message<Octs> {
     {
         unsafe { Message::from_slice_unchecked(self.octets.as_ref()) }
     }
+
+    /// Returns a message for a slice reference.
+    pub fn for_slice_ref(&self) -> Message<&[u8]>
+    where
+        Octs: AsRef<[u8]>,
+    {
+        unsafe { Message::from_octets_unchecked(self.octets.as_ref()) }
+    }
 }
 
 /// # Header Section


### PR DESCRIPTION
This PR adds a new method `Message<_>::for_slice_ref` which converts the message to a `Message<&[u8]>`. This comes in handy when parsing the message content into type that don’t allow unsized octets sequences like `AllRecordData<_, _>`.