### PR TITLE
Remove unnecesary cookie postprocessor handling.

### DIFF
--- a/src/net/server/middleware/processors/edns.rs
+++ b/src/net/server/middleware/processors/edns.rs
@@ -411,7 +411,7 @@ mod tests {
             "127.0.0.1:12345".parse().unwrap(),
             Instant::now(),
             message,
-            TransportSpecificContext::Udp(ctx),
+            ctx.into(),
         );
 
         // And pass the query through the middleware processor


### PR DESCRIPTION
This code was causing a bug whereby duplicate COOKIE options would be added to the response, but with a change that happened to middleware recently the problematic logic became unreachable and can now be removed entirely.

Ideally the Stelline cookie test would be revived to verify this as well, but for now I've added a unit test, as reviving the Stelline test requires resolving the open issue about how to test with mock system clock time.

_(and I tested manually using dig as well)_