### PR TITLE
Update dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.67.0, stable, beta, nightly]
+        rust: [1.70.0, stable, beta, nightly]
     env:
         RUSTFLAGS: "-D warnings"
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ serde_json         = "1.0.113"
 serde_yaml         = "0.9"
 socket2            = { version = "0.5.5" }
 tokio              = { version = "1.37", features = ["rt-multi-thread", "io-util", "net", "test-util"] }
-tokio-rustls       = { version = "0.26", features = [ "ring", "logging", "tls12" ] }
+tokio-rustls       = { version = "0.26", default-features = false, features = [ "ring", "logging", "tls12" ] }
 tokio-test         = "0.4"
 tokio-tfo          = { version = "0.2.0" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde          = { version = "1.0.130", optional = true, features = ["derive"] }
 siphasher      = { version = "1", optional = true }
 smallvec       = { version = "1.3", optional = true }
 tokio          = { version = "1.33", optional = true, features = ["io-util", "macros", "net", "time", "sync", "rt-multi-thread" ] }
-tokio-rustls   = { version = "0.26", optional = true, features = [] }
+tokio-rustls   = { version = "0.26", optional = true, default-features = false }
 tracing        = { version = "0.1.40", optional = true }
 
 # For testing in integration tests:
@@ -81,6 +81,7 @@ serde_json         = "1.0.113"
 serde_yaml         = "0.9"
 socket2            = { version = "0.5.5" }
 tokio              = { version = "1.37", features = ["rt-multi-thread", "io-util", "net", "test-util"] }
+tokio-rustls       = { version = "0.26", features = [ "ring", "logging", "tls12" ] }
 tokio-test         = "0.4"
 tokio-tfo          = { version = "0.2.0" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures-util   = { version = "0.3", optional = true }
 heapless       = { version = "0.8", optional = true }
 hex            = { version = "0.4", optional = true }
 libc           = { version = "0.2.153", default-features = false, optional = true } # 0.2.79 is the first version that has IP_PMTUDISC_OMIT
-parking_lot    = { version = "0.11.2", optional = true }
+parking_lot    = { version = "0.12.2", optional = true }
 moka           = { version = "0.12.3", optional = true, features = ["future"] }
 proc-macro2    = { version = "1.0.69", optional = true } # Force proc-macro2 to at least 1.0.69 for minimal-version build
 ring           = { version = "0.17", optional = true }
@@ -38,15 +38,11 @@ serde          = { version = "1.0.130", optional = true, features = ["derive"] }
 siphasher      = { version = "1", optional = true }
 smallvec       = { version = "1.3", optional = true }
 tokio          = { version = "1.33", optional = true, features = ["io-util", "macros", "net", "time", "sync", "rt-multi-thread" ] }
-tokio-rustls   = { version = "0.24", optional = true, features = [] }
+tokio-rustls   = { version = "0.26", optional = true, features = [] }
 tracing        = { version = "0.1.40", optional = true }
 
 # For testing in integration tests:
-mock_instant = { version = "0.3.2", optional = true, features = ["sync"] }
-
-[target.'cfg(macos)'.dependencies]
-# specifying this overrides minimum-version mio's 0.2.69 libc dependency, which allows the build to work
-libc = { version = "0.2.153", default-features = false, optional = true }
+#mock_instant = { version = "0.4.0", optional = true }
 
 [features]
 default     = ["std", "rand"]
@@ -77,22 +73,18 @@ unstable-zonetree = ["futures", "parking_lot", "serde", "tokio", "tracing"]
 #mock-time = ["mock_instant"]
 
 [dev-dependencies]
-rstest       = "0.18.2"
-rustls       = { version = "0.21.9" }
-serde_test   = "1.0.130"
-serde_json   = "1.0.113"
-serde_yaml   = "0.9"
-tokio        = { version = "1.37", features = ["rt-multi-thread", "io-util", "net", "test-util"] }
-tokio-test	 = "0.4"
-webpki-roots = { version = "0.25" }
-
-rustls-pemfile = { version = "1.0" }
-socket2        = { version = "0.5.5" }
-tokio-tfo      = { version = "0.2.0" }
-
-# For tracing support in integration tests:
-lazy_static        = { version = "1.4.0" } # Force lazy_static to > 1.0.0 for https://github.com/rust-lang-nursery/lazy-static.rs/pull/107
+lazy_static        = { version = "1.4.0" }
+rstest             = "0.19.0"
+rustls-pemfile     = { version = "2.1.2" }
+serde_test         = "1.0.130"
+serde_json         = "1.0.113"
+serde_yaml         = "0.9"
+socket2            = { version = "0.5.5" }
+tokio              = { version = "1.37", features = ["rt-multi-thread", "io-util", "net", "test-util"] }
+tokio-test         = "0.4"
+tokio-tfo          = { version = "0.2.0" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+webpki-roots       = { version = "0.26" }
 
 # For the "mysql-zone" example
 #sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls", "mysql" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "domain"
 version = "0.10.0-dev"
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 edition = "2021"
 authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]
 description = "A DNS library for Rust."

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@ Breaking changes
   using the term “dname” to just “name.” For instance, `Dname` has become
   `Name`, `ToDname` has become `ToName`, and `ToDname::to_dname` has become
   `ToName::to_name`. ([#290])
-* The `ToDname` and `ToRelativeDname` traits have been changed to have a
+* The `ToName` and `ToRelativeName` traits have been changed to have a
   pair of methods a la `try_to_name` and `to_name` for octets builders
   with limited and unlimited buffers, reflecting the pattern used
   elsewhere. ([#285])
@@ -79,17 +79,17 @@ Bug fixes
 
 Unstable features
 
-* Add the module `net::client` with experimental support for client
+* Added the module `net::client` with experimental support for client
   message transport, i.e., sending of requests and receiving responses
   as well as caching of responses.
   This is gated by the `unstable-client-transport` feature. ([#215],[#275])
-* Add the module `net::server` with experimental support for server
+* Added the module `net::server` with experimental support for server
   transports, processing requests through a middleware chain and a service
   trait.
   This is gated by the `unstable-server-transport` feature. ([#274])
-* Add the module `zonetree` providing basic traits representing a
+* Added the module `zonetree` providing basic traits representing a
   collection of zones and their data. The `zonetree::in_memory` module 
-  provides an in-memory implementation. The `zonefile::parsed` module
+  provides an in-memory implementation. The `zonetree::parsed` module
   provides a way to classify RRsets before inserting them into a tree.
   This is gated by the `unstable-zonetree` feature. ([#286])
   

--- a/examples/client-transports.rs
+++ b/examples/client-transports.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
-use tokio_rustls::rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
+use tokio_rustls::rustls::{ClientConfig, RootCertStore};
 
 #[tokio::main]
 async fn main() {
@@ -135,20 +135,12 @@ async fn main() {
     drop(request);
 
     // Some TLS boiler plate for the root certificates.
-    let mut root_store = RootCertStore::empty();
-    root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(
-        |ta| {
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        },
-    ));
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
 
     // TLS config
     let client_config = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
 

--- a/src/net/client/protocol.rs
+++ b/src/net/client/protocol.rs
@@ -11,7 +11,8 @@ use std::task::{Context, Poll};
 use tokio::io::ReadBuf;
 use tokio::net::{TcpStream, UdpSocket};
 use tokio_rustls::client::TlsStream;
-use tokio_rustls::rustls::{ClientConfig, ServerName};
+use tokio_rustls::rustls::pki_types::ServerName;
+use tokio_rustls::rustls::ClientConfig;
 use tokio_rustls::TlsConnector;
 
 /// How many times do we try a new random port if we get ‘address in use.’
@@ -77,7 +78,7 @@ pub struct TlsConnect {
     client_config: Arc<ClientConfig>,
 
     /// Server name for certificate verification.
-    server_name: ServerName,
+    server_name: ServerName<'static>,
 
     /// Remote address to connect to.
     addr: SocketAddr,
@@ -87,7 +88,7 @@ impl TlsConnect {
     /// Function to create a new TLS connection stream
     pub fn new(
         client_config: impl Into<Arc<ClientConfig>>,
-        server_name: ServerName,
+        server_name: ServerName<'static>,
         addr: SocketAddr,
     ) -> Self {
         Self {


### PR DESCRIPTION
This PR updates all dependencies to their latest major version. This requires some changes to the examples using tokio-rustls.

This PR also updates the minimum supported Rust version to 1.70.

This is a breaking change.