### PR TITLE
Make net not include tokio-rustls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,14 +54,14 @@ serde       = ["dep:serde", "octseq/serde"]
 sign        = ["std"]
 smallvec    = ["dep:smallvec", "octseq/smallvec"]
 std         = ["bytes?/std", "octseq/std", "time/std"]
-net         = ["bytes", "futures-util", "rand", "std", "tokio", "tokio-rustls"]
+net         = ["bytes", "futures-util", "rand", "std", "tokio"]
 tsig        = ["bytes", "ring", "smallvec"]
 validate    = ["std", "ring"]
 zonefile    = ["bytes", "serde", "std"]
 
 # Unstable features
-unstable-client-transport = [ "moka", "tracing" ]
-unstable-server-transport = ["arc-swap", "chrono/clock", "hex", "libc", "tracing"]
+unstable-client-transport = [ "moka", "net", "tracing" ]
+unstable-server-transport = ["arc-swap", "chrono/clock", "hex", "libc", "net", "tracing"]
 unstable-zonetree = ["futures", "parking_lot", "serde", "tokio", "tracing"]
 
 # Test features

--- a/src/net/client/protocol.rs
+++ b/src/net/client/protocol.rs
@@ -111,9 +111,8 @@ impl AsyncConnect for TlsConnect {
     >;
 
     fn connect(&self) -> Self::Fut {
-        let tls_connection = tokio_rustls::TlsConnector::from(
-            self.client_config.clone()
-        );
+        let tls_connection =
+            tokio_rustls::TlsConnector::from(self.client_config.clone());
         let server_name = self.server_name.clone();
         let addr = self.addr;
         Box::pin(async move {


### PR DESCRIPTION
This PR removes tokio-rustls as a dependency of the net feature so you only get TLS if you ask for it.