### PR TITLE
Make FamilyName::new() public

### DIFF
--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -359,7 +359,7 @@ pub struct FamilyName<N> {
 }
 
 impl<N> FamilyName<N> {
-    fn new(owner: N, class: Class) -> Self {
+    pub fn new(owner: N, class: Class) -> Self {
         FamilyName { owner, class }
     }
 


### PR DESCRIPTION
A `FamilyName` is needed in order to use `SortedRecords::sign()`, however there does not appears to be a way for one to be created. Make `FamilyName::new()` public to facilitate that.