### PR TITLE
Remove incorrect compose_len from ProtoRrsig

### DIFF
--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -505,22 +505,10 @@ impl<Name: ToName> ProtoRrsig<Name> {
         self.signer_name.compose_canonical(target)
     }
 
-    fn compose_len(&self) -> u16 {
-        Rtype::COMPOSE_LEN
-            + SecAlg::COMPOSE_LEN
-            + u8::COMPOSE_LEN
-            + u32::COMPOSE_LEN
-            + Timestamp::COMPOSE_LEN
-            + Timestamp::COMPOSE_LEN
-            + u16::COMPOSE_LEN
-            + self.signer_name.compose_len()
-    }
-
     fn compose_head<Target: Composer + ?Sized>(
         &self,
         target: &mut Target,
     ) -> Result<(), Target::AppendError> {
-        self.compose_len().compose(target)?;
         self.type_covered.compose(target)?;
         self.algorithm.compose(target)?;
         self.labels.compose(target)?;


### PR DESCRIPTION
`ProtoRrsig` is used to produce the data that is signed. According to https://datatracker.ietf.org/doc/html/rfc4034#autoid-23, this serialization begins with the first rdata field which is `type_covered`, however `ProtoRrsig` is inserting a length at the beginning. As such, signatures produced by `SortedRecords::sign()` are invalid. Fix this by removing that length from the serialization.