### PR TITLE
Don't skip children of apex in RecordsIter if apex is not there

### DIFF
--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -489,7 +489,10 @@ impl<'a, N, D> RecordsIter<'a, N, D> {
         N: ToName,
     {
         while let Some(first) = self.slice.first() {
-            if apex == first {
+            if first.class() != apex.class() {
+                continue;
+            }
+            if apex == first || first.owner().ends_with(apex.owner()) {
                 break;
             }
             self.slice = &self.slice[1..]


### PR DESCRIPTION
If none of the records in the `RecordsIter` have the apex as their name, but they are in the apex's zone, don't skip those children. Otherwise rrsigs will not be created for any queries for just subdomains.