### PR TITLE
Make sure `Found{Hosts, Addrs}` have `is_empty` and `len` methods

### DIFF
--- a/src/resolv/lookup/addr.rs
+++ b/src/resolv/lookup/addr.rs
@@ -41,6 +41,14 @@ pub async fn lookup_addr<R: Resolver>(
 pub struct FoundAddrs<R: Resolver>(R::Answer);
 
 impl<R: Resolver> FoundAddrs<R> {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.as_ref().header_counts().ancount() as usize
+    }
+
     /// Returns an iterator over the host names.
     pub fn iter(&self) -> FoundAddrsIter<'_, R::Octets>
     where

--- a/src/resolv/lookup/host.rs
+++ b/src/resolv/lookup/host.rs
@@ -97,6 +97,20 @@ impl<R: Resolver> FoundHosts<R> {
         true
     }
 
+    pub fn len(&self) -> usize {
+        let aaaa = self
+            .aaaa
+            .as_ref()
+            .map_or(0, |m| m.as_ref().header_counts().ancount());
+
+        let a = self
+            .a
+            .as_ref()
+            .map_or(0, |m| m.as_ref().header_counts().ancount());
+
+        (aaaa + a) as usize
+    }
+
     /// Returns a reference to one of the answers.
     fn answer(&self) -> &R::Answer {
         match self.aaaa.as_ref() {


### PR DESCRIPTION
I noticed that `FoundAddrs` did not have an `is_empty` method while implementing the `lookup` command for `dnsi`. I also figured that `len` methods for `FoundHosts` and `FoundAddrs` would be a nice addition.

I just kind of guessed the implementation of these methods, so I don't really know whether they are correct :)