### PR TITLE
Bump to rust 1.78

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.70.0, stable, beta, nightly]
+        rust: [1.78.0, stable, beta, nightly]
     env:
         RUSTFLAGS: "-D warnings"
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "domain"
 version = "0.10.1-dev"
-rust-version = "1.70.0"
+rust-version = "1.78.0"
 edition = "2021"
 authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]
 description = "A DNS library for Rust."


### PR DESCRIPTION
Because `triomphe` requires 1.76 and we might as well bump to whatever Alpine has.