### PR TITLE
Remove (direct) dependency on `hex` and `pin-project-lite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ chrono         = { version = "0.4.35", optional = true, default-features = false
 futures        = { version = "0.3.22", optional = true } # Force futures to at least 0.3.22 for minimal-version build
 futures-util   = { version = "0.3", optional = true }
 heapless       = { version = "0.8", optional = true }
-hex            = { version = "0.4", optional = true }
 libc           = { version = "0.2.153", default-features = false, optional = true } # 0.2.79 is the first version that has IP_PMTUDISC_OMIT
 parking_lot    = { version = "0.12.2", optional = true }
 moka           = { version = "0.12.3", optional = true, features = ["future"] }
@@ -62,7 +61,7 @@ zonefile    = ["bytes", "serde", "std"]
 
 # Unstable features
 unstable-client-transport = [ "moka", "net", "tracing" ]
-unstable-server-transport = ["arc-swap", "chrono/clock", "hex", "libc", "net", "tracing"]
+unstable-server-transport = ["arc-swap", "chrono/clock", "libc", "net", "tracing"]
 unstable-stelline = ["tokio/test-util", "tracing", "tracing-subscriber", "unstable-server-transport", "zonefile"]
 unstable-zonetree = ["futures", "parking_lot", "serde", "tokio", "tracing"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,8 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq           =  { version = "0.5.1", default-features = false }
-pin-project-lite = "0.2"
-time             =  { version = "0.3.1", default-features = false }
+octseq         =  { version = "0.5.1", default-features = false }
+time           =  { version = "0.3.1", default-features = false }
 
 rand           = { version = "0.8", optional = true }
 arc-swap       = { version = "1.7.0", optional = true }

--- a/src/net/client/protocol.rs
+++ b/src/net/client/protocol.rs
@@ -2,7 +2,6 @@
 
 use core::future::Future;
 use core::pin::Pin;
-use pin_project_lite::pin_project;
 use std::boxed::Box;
 use std::io;
 use std::net::SocketAddr;
@@ -222,24 +221,22 @@ impl<R: AsyncDgramRecv> AsyncDgramRecvEx for R {}
 
 //------------ DgramRecv -----------------------------------------------------
 
-pin_project! {
-    /// Return value of recv. This captures the future for recv.
-    pub struct DgramRecv<'a, R: ?Sized> {
-        receiver: &'a R,
-        buf: &'a mut [u8],
-    }
+/// Return value of recv. This captures the future for recv.
+pub struct DgramRecv<'a, R: ?Sized> {
+    receiver: &'a R,
+    buf: &'a mut [u8],
 }
 
 impl<R: AsyncDgramRecv + Unpin> Future for DgramRecv<'_, R> {
     type Output = io::Result<usize>;
 
     fn poll(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<usize>> {
-        let me = self.project();
-        let mut buf = ReadBuf::new(me.buf);
-        match Pin::new(me.receiver).poll_recv(cx, &mut buf) {
+        let receiver = self.receiver;
+        let mut buf = ReadBuf::new(self.buf);
+        match Pin::new(receiver).poll_recv(cx, &mut buf) {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(res) => {
                 if let Err(err) = res {

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -12,6 +12,7 @@ use crate::base::wire::Composer;
 use crate::base::Message;
 use crate::base::{MessageBuilder, ParsedName, Rtype, StreamTarget};
 use crate::rdata::AllRecordData;
+use crate::utils::base16;
 
 use super::message::Request;
 use super::service::{CallResult, Service, ServiceError, Transaction};
@@ -131,7 +132,7 @@ pub(crate) fn to_pcap_text<T: AsRef<[u8]>>(
     num_bytes: usize,
 ) -> String {
     let mut formatted = "000000".to_string();
-    let hex_encoded = hex::encode(&bytes.as_ref()[..num_bytes]);
+    let hex_encoded = base16::encode_string(&bytes.as_ref()[..num_bytes]);
     let mut chars = hex_encoded.chars();
     loop {
         match (chars.next(), chars.next()) {

--- a/src/stelline/parse_stelline.rs
+++ b/src/stelline/parse_stelline.rs
@@ -5,6 +5,7 @@ use std::net::IpAddr;
 use std::string::{String, ToString};
 use std::vec::Vec;
 
+use crate::utils::base16;
 use crate::zonefile::inplace::Entry as ZonefileEntry;
 use crate::zonefile::inplace::Zonefile;
 
@@ -467,7 +468,7 @@ fn parse_section<Lines: Iterator<Item = Result<String, std::io::Error>>>(
                         }
                         let clean_line = clean_line
                             .replace(|c: char| c.is_whitespace(), "");
-                        let edns_line_bytes = hex::decode(&clean_line)
+                        let edns_line_bytes = base16::decode_vec(&clean_line)
                             .map_err(|err| format!("Hex decoding failure of HEX_EDNSDATA line '{clean_line}': {err}"))
                             .unwrap();
                         sections

--- a/tests/net-server.rs
+++ b/tests/net-server.rs
@@ -29,6 +29,7 @@ use domain::net::server::service::{
 };
 use domain::net::server::stream::StreamServer;
 use domain::net::server::util::{mk_builder_for_target, service_fn};
+use domain::utils::base16;
 use domain::zonefile::inplace::{Entry, ScannedRecord, Zonefile};
 
 use domain::stelline::channel::ClientServerChannel;
@@ -196,7 +197,7 @@ where
     if config.cookies.enabled {
         #[cfg(feature = "siphasher")]
         if let Some(secret) = config.cookies.secret {
-            let secret = hex::decode(secret).unwrap();
+            let secret = base16::decode_vec(secret).unwrap();
             let secret = <[u8; 16]>::try_from(secret).unwrap();
             let processor = CookiesMiddlewareProcessor::new(secret);
             let processor = processor


### PR DESCRIPTION
The commits can be viewed separately.

`hex` is not necessary because we have the `domain::utils::base16` module.

`pin-project-lite` was not needed where it was used. It is still in the dependency tree because `tokio` uses it, but it's not present with minimal features anymore.