### PR TITLE
Refactor pointer casts to transmutes and annotate with repr(transparent)

### DIFF
--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -184,7 +184,7 @@ impl CharStr<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Charstr has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Creates a character string from a mutable slice without checking.
@@ -195,7 +195,7 @@ impl CharStr<[u8]> {
     /// long. Otherwise, the behaviour is undefined.
     unsafe fn from_slice_mut_unchecked(slice: &mut [u8]) -> &mut Self {
         // SAFETY: Charstr has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Checks whether an octets slice contains a correct character string.

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -28,7 +28,7 @@ use super::scan::{BadSymbol, Scanner, Symbol, SymbolCharsError};
 use super::wire::{Compose, ParseError};
 #[cfg(feature = "bytes")]
 use bytes::BytesMut;
-use core::{cmp, fmt, hash, str};
+use core::{cmp, fmt, hash, mem, str};
 use octseq::builder::FreezeBuilder;
 #[cfg(feature = "serde")]
 use octseq::serde::{DeserializeOctets, SerializeOctets};
@@ -184,7 +184,7 @@ impl CharStr<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Charstr has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Creates a character string from a mutable slice without checking.
@@ -195,7 +195,7 @@ impl CharStr<[u8]> {
     /// long. Otherwise, the behaviour is undefined.
     unsafe fn from_slice_mut_unchecked(slice: &mut [u8]) -> &mut Self {
         // SAFETY: Charstr has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Checks whether an octets slice contains a correct character string.

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -118,6 +118,7 @@ use std::vec::Vec;
 ///
 /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct CharStr<Octs: ?Sized>(Octs);
 
 impl CharStr<()> {
@@ -182,7 +183,8 @@ impl CharStr<[u8]> {
     /// long. Otherwise, the behaviour is undefined.
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Self)
+        // SAFETY: Charstr has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Creates a character string from a mutable slice without checking.
@@ -192,7 +194,8 @@ impl CharStr<[u8]> {
     /// The caller has to make sure that `octets` is at most 255 octets
     /// long. Otherwise, the behaviour is undefined.
     unsafe fn from_slice_mut_unchecked(slice: &mut [u8]) -> &mut Self {
-        &mut *(slice as *mut [u8] as *mut Self)
+        // SAFETY: Charstr has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Checks whether an octets slice contains a correct character string.

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -87,6 +87,10 @@ impl Header {
     #[must_use]
     pub fn for_message_slice(s: &[u8]) -> &Header {
         assert!(s.len() >= mem::size_of::<Header>());
+
+        // SAFETY: The pointer cast is sound because
+        //  - Header has repr(transparent) and
+        //  - the slice is large enough
         unsafe { &*(s.as_ptr() as *const Header) }
     }
 
@@ -97,6 +101,10 @@ impl Header {
     /// This function panics if the slice is less than four octets long.
     pub fn for_message_slice_mut(s: &mut [u8]) -> &mut Header {
         assert!(s.len() >= mem::size_of::<Header>());
+
+        // SAFETY: The pointer cast is sound because
+        //  - Header has repr(transparent) and
+        //  - the slice is large enough
         unsafe { &mut *(s.as_mut_ptr() as *mut Header) }
     }
 
@@ -506,6 +514,11 @@ impl HeaderCounts {
     #[must_use]
     pub fn for_message_slice(message: &[u8]) -> &Self {
         assert!(message.len() >= mem::size_of::<HeaderSection>());
+
+        // SAFETY: The pointer cast is sound because
+        //  - HeaderCounts has repr(transparent) and
+        //  - the slice is large enough for a HeaderSection, which contains
+        //    both a Header (which we trim) and a HeaderCounts.
         unsafe {
             &*((message[mem::size_of::<Header>()..].as_ptr())
                 as *const HeaderCounts)
@@ -522,6 +535,11 @@ impl HeaderCounts {
     /// This function panics if the octets slice is shorter than 24 octets.
     pub fn for_message_slice_mut(message: &mut [u8]) -> &mut Self {
         assert!(message.len() >= mem::size_of::<HeaderSection>());
+
+        // SAFETY: The pointer cast is sound because
+        //  - HeaderCounts has repr(transparent) and
+        //  - the slice is large enough for a HeaderSection, which contains
+        //    both a Header (which we trim) and a HeaderCounts.
         unsafe {
             &mut *((message[mem::size_of::<Header>()..].as_mut_ptr())
                 as *mut HeaderCounts)

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -58,6 +58,7 @@ use octseq::parse::Parser;
 /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
 /// [RFC 4035]: https://tools.ietf.org/html/rfc4035
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Header {
     /// The actual header in its wire format representation.
     ///
@@ -477,6 +478,7 @@ impl FromStr for Flags {
 /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
 /// [RFC 2136]: https://tools.ietf.org/html/rfc2136
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct HeaderCounts {
     /// The actual headers in their wire-format representation.
     ///
@@ -788,6 +790,7 @@ impl HeaderCounts {
 /// [`for_message_slice_mut`][Self::for_message_slice_mut]
 /// functions.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct HeaderSection {
     inner: [u8; 12],
 }

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -217,7 +217,7 @@ impl Message<[u8]> {
     /// undefined.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Message has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Checks that the slice can be used for a message.

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -217,7 +217,7 @@ impl Message<[u8]> {
     /// undefined.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Message has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Checks that the slice can be used for a message.

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -150,6 +150,7 @@ use octseq::{Octets, OctetsFrom, Parser};
 /// [opcode]: ../iana/opcode/enum.Opcode.html
 /// [RFC 1035]: https://tools.ietf.org/html/rfc1035
 #[derive(Clone, Copy)]
+#[repr(transparent)]
 pub struct Message<Octs: ?Sized> {
     octets: Octs,
 }
@@ -215,7 +216,8 @@ impl Message<[u8]> {
     /// long as a header. If the sequence is shorter, the behavior is
     /// undefined.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Self)
+        // SAFETY: Message has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Checks that the slice can be used for a message.

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -49,6 +49,7 @@ use std::vec::Vec;
 /// [`ParsedName`]: crate::base::name::ParsedName
 /// [`Display`]: std::fmt::Display
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct Name<Octs: ?Sized>(Octs);
 
 impl Name<()> {
@@ -221,7 +222,8 @@ impl<Octs> Name<Octs> {
 impl Name<[u8]> {
     /// Creates a domain name from an octet slice without checking,
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Name<[u8]>)
+        // SAFETY: Name has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Creates a domain name from an octets slice.

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -14,7 +14,7 @@ use super::traits::{FlattenInto, ToLabelIter, ToName};
 use bytes::Bytes;
 use core::ops::{Bound, RangeBounds};
 use core::str::FromStr;
-use core::{borrow, cmp, fmt, hash, str};
+use core::{borrow, cmp, fmt, hash, mem, str};
 use octseq::builder::{
     EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder, Truncate,
 };
@@ -223,7 +223,7 @@ impl Name<[u8]> {
     /// Creates a domain name from an octet slice without checking,
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Name has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Creates a domain name from an octets slice.

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -223,7 +223,7 @@ impl Name<[u8]> {
     /// Creates a domain name from an octet slice without checking,
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Name has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Creates a domain name from an octets slice.

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -37,6 +37,7 @@ use octseq::builder::OctetsBuilder;
 /// [`Label`] differs from an octets slice in how it compares: as labels are to
 /// be case-insensitive, all the comparison traits as well as `Hash` are
 /// implemented ignoring ASCII-case.
+#[repr(transparent)]
 pub struct Label([u8]);
 
 /// # Creation
@@ -51,7 +52,8 @@ impl Label {
     ///
     /// The `slice` must be at most 63 octets long.
     pub(super) unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Self)
+        // SAFETY: Label has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Creates a mutable label from the underlying slice without checking.
@@ -62,7 +64,8 @@ impl Label {
     pub(super) unsafe fn from_slice_mut_unchecked(
         slice: &mut [u8],
     ) -> &mut Self {
-        &mut *(slice as *mut [u8] as *mut Self)
+        // SAFETY: Label has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Returns a static reference to the root label.
@@ -209,12 +212,12 @@ impl Label {
     /// Returns a reference to the underlying octets slice.
     #[must_use]
     pub fn as_slice(&self) -> &[u8] {
-        unsafe { &*(self as *const Self as *const [u8]) }
+        &self.0
     }
 
     /// Returns a mutable reference to the underlying octets slice.
     pub fn as_slice_mut(&mut self) -> &mut [u8] {
-        unsafe { &mut *(self as *mut Label as *mut [u8]) }
+        &mut self.0
     }
 
     /// Converts the label into the canonical form.

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -53,7 +53,7 @@ impl Label {
     /// The `slice` must be at most 63 octets long.
     pub(super) unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Label has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Creates a mutable label from the underlying slice without checking.
@@ -65,7 +65,7 @@ impl Label {
         slice: &mut [u8],
     ) -> &mut Self {
         // SAFETY: Label has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Returns a static reference to the root label.

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -9,7 +9,7 @@ use super::builder::{
     parse_escape, LabelFromStrError, LabelFromStrErrorEnum,
 };
 use core::str::FromStr;
-use core::{borrow, cmp, fmt, hash, iter, ops, slice};
+use core::{borrow, cmp, fmt, hash, iter, mem, ops, slice};
 use octseq::builder::OctetsBuilder;
 
 //------------ Label ---------------------------------------------------------
@@ -53,7 +53,7 @@ impl Label {
     /// The `slice` must be at most 63 octets long.
     pub(super) unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Label has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Creates a mutable label from the underlying slice without checking.
@@ -65,7 +65,7 @@ impl Label {
         slice: &mut [u8],
     ) -> &mut Self {
         // SAFETY: Label has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Returns a static reference to the root label.

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -38,6 +38,7 @@ use std::vec::Vec;
 /// can always safely turn a [`RelativeName`] into a [`Name`] by adding the root
 /// label (which is exactly one byte long).
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct RelativeName<Octs: ?Sized>(Octs);
 
 /// # Creating Values
@@ -133,7 +134,8 @@ impl RelativeName<[u8]> {
     ///
     /// [`from_octets_unchecked`]: RelativeName::from_octets_unchecked
     pub(super) unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const RelativeName<[u8]>)
+        // SAFETY: RelativeName has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Creates a relative domain name from an octet slice.

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use core::cmp::Ordering;
 use core::ops::{Bound, RangeBounds};
 use core::str::FromStr;
-use core::{borrow, cmp, fmt, hash};
+use core::{borrow, cmp, fmt, hash, mem};
 use octseq::builder::{
     EmptyBuilder, FreezeBuilder, FromBuilder, IntoBuilder, Truncate,
 };
@@ -135,7 +135,7 @@ impl RelativeName<[u8]> {
     /// [`from_octets_unchecked`]: RelativeName::from_octets_unchecked
     pub(super) unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: RelativeName has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Creates a relative domain name from an octet slice.

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -135,7 +135,7 @@ impl RelativeName<[u8]> {
     /// [`from_octets_unchecked`]: RelativeName::from_octets_unchecked
     pub(super) unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: RelativeName has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Creates a relative domain name from an octet slice.

--- a/src/base/opt/algsig.rs
+++ b/src/base/opt/algsig.rs
@@ -47,6 +47,7 @@ use core::marker::PhantomData;
 /// [`iter`][Understood::iter] method or use the [`IntoIterator`] implementation
 /// for a reference.
 #[derive(Clone, Copy)]
+#[repr(transparent)]
 pub struct Understood<Variant, Octs: ?Sized> {
     /// A marker for the variant.
     marker: PhantomData<Variant>,
@@ -152,7 +153,8 @@ impl<Variant> Understood<Variant, [u8]> {
     /// 16 bit values that is no longer than 65,535 octets.
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Self)
+        // SAFETY: Understood has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Checks that a slice contains a correctly encoded value.

--- a/src/base/opt/algsig.rs
+++ b/src/base/opt/algsig.rs
@@ -154,7 +154,7 @@ impl<Variant> Understood<Variant, [u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Understood has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Checks that a slice contains a correctly encoded value.

--- a/src/base/opt/algsig.rs
+++ b/src/base/opt/algsig.rs
@@ -23,7 +23,7 @@ use super::{
 use octseq::builder::{EmptyBuilder, FromBuilder, OctetsBuilder};
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
-use core::{borrow, fmt, hash, slice};
+use core::{borrow, fmt, hash, mem, slice};
 use core::marker::PhantomData;
 
 
@@ -154,7 +154,7 @@ impl<Variant> Understood<Variant, [u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Understood has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Checks that a slice contains a correctly encoded value.

--- a/src/base/opt/chain.rs
+++ b/src/base/opt/chain.rs
@@ -11,9 +11,8 @@ use super::super::message_builder::OptBuilder;
 use super::super::name::{Name, ToName};
 use super::super::wire::{Composer, ParseError};
 use super::{ComposeOptData, Opt, OptData, ParseOptData};
+use core::{fmt, hash, mem};
 use core::cmp::Ordering;
-use core::fmt;
-use core::hash;
 use octseq::builder::OctetsBuilder;
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
@@ -52,7 +51,7 @@ impl<Name: ?Sized> Chain<Name> {
     /// Creates a reference to CHAIN option data from a reference to the start.
     pub fn new_ref(start: &Name) -> &Self {
         // SAFETY: Chain has repr(transparent)
-        unsafe { core::mem::transmute(start) }
+        unsafe { mem::transmute(start) }
     }
 
     /// Returns a reference to the start point.

--- a/src/base/opt/chain.rs
+++ b/src/base/opt/chain.rs
@@ -52,7 +52,7 @@ impl<Name: ?Sized> Chain<Name> {
     /// Creates a reference to CHAIN option data from a reference to the start.
     pub fn new_ref(start: &Name) -> &Self {
         // SAFETY: Chain has repr(transparent)
-        unsafe { std::mem::transmute(start) }
+        unsafe { core::mem::transmute(start) }
     }
 
     /// Returns a reference to the start point.

--- a/src/base/opt/keytag.rs
+++ b/src/base/opt/keytag.rs
@@ -28,6 +28,7 @@ use core::convert::TryInto;
 /// keys they are using to validate responses. The option contains a sequence
 /// of key tags.
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct KeyTag<Octs: ?Sized> {
     octets: Octs,
 }
@@ -88,7 +89,8 @@ impl KeyTag<[u8]> {
     /// 65,536 octets.
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Self)
+        // SAFETY: KeyTag has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Checkes that the length of an octets sequence is valid.

--- a/src/base/opt/keytag.rs
+++ b/src/base/opt/keytag.rs
@@ -90,7 +90,7 @@ impl KeyTag<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: KeyTag has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Checkes that the length of an octets sequence is valid.

--- a/src/base/opt/keytag.rs
+++ b/src/base/opt/keytag.rs
@@ -15,7 +15,7 @@ use super::{Opt, OptData, ComposeOptData, ParseOptData};
 use octseq::builder::OctetsBuilder;
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
-use core::{borrow, fmt, hash};
+use core::{borrow, fmt, hash, mem};
 use core::cmp::Ordering;
 use core::convert::TryInto;
 
@@ -90,7 +90,7 @@ impl KeyTag<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: KeyTag has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Checkes that the length of an octets sequence is valid.

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -392,12 +392,20 @@ impl OptHeader {
     #[must_use]
     pub fn for_record_slice(slice: &[u8]) -> &OptHeader {
         assert!(slice.len() >= mem::size_of::<Self>());
+
+        // SAFETY: the pointer cast is sound because
+        //   - OptHeader has repr(transparent) and
+        //   - the size of the slice is large enough
         unsafe { &*(slice.as_ptr() as *const OptHeader) }
     }
 
     /// Returns a mutable reference pointing into a record’s octets.
     pub fn for_record_slice_mut(slice: &mut [u8]) -> &mut OptHeader {
         assert!(slice.len() >= mem::size_of::<Self>());
+
+        // SAFETY: the pointer cast is sound because
+        //   - OptHeader has repr(transparent) and
+        //   - the size of the slice is large enough
         unsafe { &mut *(slice.as_mut_ptr() as *mut OptHeader) }
     }
 

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -137,7 +137,7 @@ impl Opt<[u8]> {
     /// be correct.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Opt has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Checks that the slice contains acceptable OPT record data.

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -381,6 +381,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Opt<Octs> {
 //    | RDATA      | octet stream | {attribute,value} pairs      |
 //    +------------+--------------+------------------------------+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct OptHeader {
     /// The bytes of the header.
     inner: [u8; 9],

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -137,7 +137,7 @@ impl Opt<[u8]> {
     /// be correct.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Opt has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Checks that the slice contains acceptable OPT record data.

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -72,6 +72,7 @@ use octseq::parse::Parser;
 /// [`iter`]: #method.iter
 /// [`OptRecord`]: struct.OptRecord.html
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct Opt<Octs: ?Sized> {
     octets: Octs,
 }
@@ -135,7 +136,8 @@ impl Opt<[u8]> {
     /// OPT record data. The data of the options themselves does not need to
     /// be correct.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Self)
+        // SAFETY: Opt has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Checks that the slice contains acceptable OPT record data.
@@ -1056,7 +1058,7 @@ pub enum BuildDataError {
 }
 
 impl BuildDataError {
-    /// Converts the error into a `LongOptData` error for ‘endless’ buffers.
+    /// Converts the error into a [`LongOptData`] error for ‘endless’ buffers.
     ///
     /// # Panics
     ///

--- a/src/base/opt/nsid.rs
+++ b/src/base/opt/nsid.rs
@@ -95,7 +95,7 @@ impl Nsid<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Nsid has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Creates an empty NSID option value.

--- a/src/base/opt/nsid.rs
+++ b/src/base/opt/nsid.rs
@@ -16,7 +16,7 @@ use super::{
 use octseq::builder::OctetsBuilder;
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
-use core::{borrow, fmt, hash, str};
+use core::{borrow, fmt, hash, mem, str};
 use core::cmp::Ordering;
 
 
@@ -95,7 +95,7 @@ impl Nsid<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Nsid has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Creates an empty NSID option value.

--- a/src/base/opt/nsid.rs
+++ b/src/base/opt/nsid.rs
@@ -32,6 +32,7 @@ use core::cmp::Ordering;
 /// The option and details about its use are defined in
 /// [RFC 5001](https://tools.ietf.org/html/rfc5001).
 #[derive(Clone, Copy)]
+#[repr(transparent)]
 pub struct Nsid<Octs: ?Sized> {
     /// The octets of the identifier.
     octets: Octs,
@@ -93,7 +94,8 @@ impl Nsid<[u8]> {
     /// octets.
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Self)
+        // SAFETY: Nsid has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Creates an empty NSID option value.

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -671,6 +671,7 @@ impl<Octs: AsRef<[u8]>> fmt::Debug for Nsec3param<Octs> {
 /// The salt uses Base 16 (i.e., hex digits) as its representation format with
 /// no whitespace allowed.
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct Nsec3Salt<Octs: ?Sized>(Octs);
 
 impl Nsec3Salt<()> {
@@ -771,7 +772,8 @@ impl Nsec3Salt<[u8]> {
         if slice.len() > Nsec3Salt::MAX_LEN {
             Err(Nsec3SaltError(()))
         } else {
-            Ok(unsafe { &*(slice as *const [u8] as *const Nsec3Salt<[u8]>) })
+            // SAFETY: Nsec3Salt has repr(transparent)
+            Ok(unsafe { std::mem::transmute(slice) })
         }
     }
 }
@@ -1081,6 +1083,7 @@ where
 /// For its presentation format, the hash uses an unpadded Base 32 encoding
 /// with no whitespace allowed.
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct OwnerHash<Octs: ?Sized>(Octs);
 
 impl OwnerHash<()> {
@@ -1179,7 +1182,8 @@ impl OwnerHash<[u8]> {
         if slice.len() > OwnerHash::MAX_LEN {
             Err(OwnerHashError(()))
         } else {
-            Ok(unsafe { &*(slice as *const [u8] as *const OwnerHash<[u8]>) })
+            // SAFETY: OwnerHash has repr(transparent)
+            Ok(unsafe { std::mem::transmute(slice) })
         }
     }
 }

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -16,7 +16,7 @@ use crate::utils::{base16, base32};
 #[cfg(feature = "bytes")]
 use bytes::Bytes;
 use core::cmp::Ordering;
-use core::{fmt, hash, str};
+use core::{fmt, hash, mem, str};
 use octseq::builder::{
     EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder,
 };
@@ -783,7 +783,7 @@ impl Nsec3Salt<[u8]> {
     /// The passed slice must be no longer than [`Nsec3Salt::MAX_LEN`].
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Nsec3Salt has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 }
 
@@ -1202,7 +1202,7 @@ impl OwnerHash<[u8]> {
     /// The passed slice must be no longer than [`OwnerHash::MAX_LEN`].
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: OwnerHash has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 }
 

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -772,9 +772,18 @@ impl Nsec3Salt<[u8]> {
         if slice.len() > Nsec3Salt::MAX_LEN {
             Err(Nsec3SaltError(()))
         } else {
-            // SAFETY: Nsec3Salt has repr(transparent)
-            Ok(unsafe { core::mem::transmute(slice) })
+            Ok(unsafe { Self::from_slice_unchecked(slice) })
         }
+    }
+
+    /// Creates a new salt value from an octets slice without checking.
+    ///
+    /// # Safety
+    ///
+    /// The passed slice must be no longer than [`Nsec3Salt::MAX_LEN`].
+    unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
+        // SAFETY: Nsec3Salt has repr(transparent)
+        core::mem::transmute(slice)
     }
 }
 
@@ -1182,9 +1191,18 @@ impl OwnerHash<[u8]> {
         if slice.len() > OwnerHash::MAX_LEN {
             Err(OwnerHashError(()))
         } else {
-            // SAFETY: OwnerHash has repr(transparent)
-            Ok(unsafe { core::mem::transmute(slice) })
+            Ok(unsafe { Self::from_slice_unchecked(slice) })
         }
+    }
+
+    /// Creates a new owner hash from an octet slice without checking.
+    ///
+    /// # Safety
+    ///
+    /// The passed slice must be no longer than [`OwnerHash::MAX_LEN`].
+    unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
+        // SAFETY: OwnerHash has repr(transparent)
+        core::mem::transmute(slice)
     }
 }
 

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -773,7 +773,7 @@ impl Nsec3Salt<[u8]> {
             Err(Nsec3SaltError(()))
         } else {
             // SAFETY: Nsec3Salt has repr(transparent)
-            Ok(unsafe { std::mem::transmute(slice) })
+            Ok(unsafe { core::mem::transmute(slice) })
         }
     }
 }
@@ -1183,7 +1183,7 @@ impl OwnerHash<[u8]> {
             Err(OwnerHashError(()))
         } else {
             // SAFETY: OwnerHash has repr(transparent)
-            Ok(unsafe { std::mem::transmute(slice) })
+            Ok(unsafe { core::mem::transmute(slice) })
         }
     }
 }

--- a/src/rdata/rfc1035/null.rs
+++ b/src/rdata/rfc1035/null.rs
@@ -8,7 +8,7 @@ use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData,
 };
 use crate::base::wire::{Composer, ParseError};
-use core::{fmt, hash};
+use core::{fmt, hash, mem};
 use core::cmp::Ordering;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;
@@ -85,7 +85,7 @@ impl Null<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(data: &[u8]) -> &Self {
         // SAFETY: Null has repr(transparent)
-        core::mem::transmute(data)
+        mem::transmute(data)
     }
 
     /// Checks that a slice can be used for NULL record data.

--- a/src/rdata/rfc1035/null.rs
+++ b/src/rdata/rfc1035/null.rs
@@ -25,6 +25,7 @@ use octseq::parse::Parser;
 /// [1]: https://tools.ietf.org/html/rfc1035#section-3.3.10
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
 pub struct Null<Octs: ?Sized> {
     #[cfg_attr(
         feature = "serde",
@@ -83,7 +84,8 @@ impl Null<[u8]> {
     /// The caller has to ensure that `data` is at most 65,535 octets long.
     #[must_use]
     pub unsafe fn from_slice_unchecked(data: &[u8]) -> &Self {
-        &*(data as *const [u8] as *const Self)
+        // SAFETY: Null has repr(transparent)
+        std::mem::transmute(data)
     }
 
     /// Checks that a slice can be used for NULL record data.

--- a/src/rdata/rfc1035/null.rs
+++ b/src/rdata/rfc1035/null.rs
@@ -85,7 +85,7 @@ impl Null<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(data: &[u8]) -> &Self {
         // SAFETY: Null has repr(transparent)
-        std::mem::transmute(data)
+        core::mem::transmute(data)
     }
 
     /// Checks that a slice can be used for NULL record data.

--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -155,7 +155,7 @@ impl Txt<[u8]> {
     /// See [`from_octets][Self::from_octets] for the required content.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Txt has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Checks that a slice contains correctly encoded TXT data.

--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -80,6 +80,7 @@ use octseq::serde::{DeserializeOctets, SerializeOctets};
 ///
 /// [RFC 1035, section 3.3.14]: https://tools.ietf.org/html/rfc1035#section-3.3.14
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct Txt<Octs: ?Sized>(Octs);
 
 impl Txt<()> {
@@ -153,7 +154,8 @@ impl Txt<[u8]> {
     /// The passed octets must contain correctly encoded TXT record data.
     /// See [`from_octets][Self::from_octets] for the required content.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        unsafe { &*(slice as *const [u8] as *const Self) }
+        // SAFETY: Txt has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Checks that a slice contains correctly encoded TXT data.

--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -18,7 +18,7 @@ use crate::base::wire::{Composer, FormError, ParseError};
 use bytes::BytesMut;
 use core::cmp::Ordering;
 use core::convert::{Infallible, TryFrom};
-use core::{fmt, hash, str};
+use core::{fmt, hash, mem, str};
 use octseq::builder::{
     infallible, EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder,
     ShortBuf,
@@ -155,7 +155,7 @@ impl Txt<[u8]> {
     /// See [`from_octets][Self::from_octets] for the required content.
     unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: Txt has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Checks that a slice contains correctly encoded TXT data.

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -10,7 +10,7 @@ use crate::base::wire::{Compose, Parse, ParseError};
 use octseq::builder::{EmptyBuilder, FromBuilder, OctetsBuilder, ShortBuf};
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::{Parser, ShortInput};
-use core::{cmp, fmt, hash};
+use core::{cmp, fmt, hash, mem};
 use core::cmp::Ordering;
 use core::marker::PhantomData;
 
@@ -128,7 +128,7 @@ impl SvcParams<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: SvcParams has repr(transparent)
-        core::mem::transmute(slice)
+        mem::transmute(slice)
     }
 
     /// Checks that a slice contains a correctly encoded parameters sequence.

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -128,7 +128,7 @@ impl SvcParams<[u8]> {
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
         // SAFETY: SvcParams has repr(transparent)
-        std::mem::transmute(slice)
+        core::mem::transmute(slice)
     }
 
     /// Checks that a slice contains a correctly encoded parameters sequence.

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -64,6 +64,7 @@ use core::marker::PhantomData;
 /// in the record data, it is limited by the length of the record data only.
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
 pub struct SvcParams<Octs: ?Sized> {
     #[cfg_attr(
         feature = "serde",
@@ -126,7 +127,8 @@ impl SvcParams<[u8]> {
     /// parameter sequence.
     #[must_use]
     pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-        &*(slice as *const [u8] as *const Self)
+        // SAFETY: SvcParams has repr(transparent)
+        std::mem::transmute(slice)
     }
 
     /// Checks that a slice contains a correctly encoded parameters sequence.

--- a/src/rdata/svcb/value.rs
+++ b/src/rdata/svcb/value.rs
@@ -226,6 +226,7 @@ macro_rules! octets_wrapper {
     ( $(#[$attr:meta])* $name:ident => $key:ident) => {
         $(#[$attr])*
         #[derive(Debug, Clone)]
+        #[repr(transparent)]
         pub struct $name<Octs: ?Sized>(Octs);
 
         impl $name<()> {
@@ -254,7 +255,8 @@ macro_rules! octets_wrapper {
             /// formated value of at most 65,535 octets.
             #[must_use]
             pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
-                &*(slice as *const [u8] as *const Self)
+                // SAFETY: Self has repr(transparent)
+                std::mem::transmute(slice)
             }
         }
 

--- a/src/rdata/svcb/value.rs
+++ b/src/rdata/svcb/value.rs
@@ -12,7 +12,7 @@ use octseq::builder::{
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 use octseq::str::Str;
-use core::{fmt, hash, str};
+use core::{fmt, hash, mem, str};
 use core::fmt::Write as _;
 use core::str::FromStr;
 
@@ -256,7 +256,7 @@ macro_rules! octets_wrapper {
             #[must_use]
             pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
                 // SAFETY: Self has repr(transparent)
-                core::mem::transmute(slice)
+                mem::transmute(slice)
             }
         }
 

--- a/src/rdata/svcb/value.rs
+++ b/src/rdata/svcb/value.rs
@@ -256,7 +256,7 @@ macro_rules! octets_wrapper {
             #[must_use]
             pub unsafe fn from_slice_unchecked(slice: &[u8]) -> &Self {
                 // SAFETY: Self has repr(transparent)
-                std::mem::transmute(slice)
+                core::mem::transmute(slice)
             }
         }
 


### PR DESCRIPTION
We're doing many pointer casts, which Rust has a more convenient function for: `std::mem::transmute`, this reduces the syntactical overhead and is easier to understand for linters (such as MIRI and clippy).

Additionally, all these pointer casts were theoretically unsound, because `#[repr(transparent)]` was missing. I added safety comments as well referencing that attribute.

We should probably be running MIRI to really ensure that everything we're doing is safe.