### PR TITLE
allow create real resource record from unsized data

### DIFF
--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -165,7 +165,7 @@ pub trait ParseRecordData<'a, Octs: ?Sized>: RecordData + Sized {
     /// data remaining in the parser.
     ///
     /// If the function doesn’t want to process the data, it must not touch
-    /// the parser. In particual, it must not advance it.
+    /// the parser. In particular, it must not advance it.
     fn parse_rdata(
         rtype: Rtype,
         parser: &mut Parser<'a, Octs>,

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -929,7 +929,7 @@ impl<'a, Octs: Octets + ?Sized> ParsedRecord<'a, Octs> {
         &self,
     ) -> Result<Option<Record<ParsedName<Octs::Range<'_>>, Data>>, ParseError>
     where
-        Data: ParseRecordData<'a, Octs>,
+        Data: ParseRecordData<'a, Octs> + ?Sized,
     {
         self.header
             .deref_owner()


### PR DESCRIPTION
This is another fix for missing `?Sized` bound in the 0.10.