### PR TITLE
`HeaderSection`: Change slices to fixed-length arrays

### DIFF
--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -855,7 +855,7 @@ impl HeaderSection {
         const _: () = assert!(
             mem::size_of::<Chunk>() < mem::size_of::<HeaderSection>()
         );
-        let chunk: Chunk = self.inner[0..4].try_into().unwrap();
+        let chunk: Chunk = self.inner[4..12].try_into().unwrap();
         HeaderCounts::from_array(chunk)
     }
 

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -288,41 +288,15 @@ impl<Octs: AsRef<[u8]> + ?Sized> Message<Octs> {
         self.header_section().header()
     }
 
-    /// Returns a mutable reference to the message header.
-    pub fn header_mut(&mut self) -> &mut Header
-    where
-        Octs: AsMut<[u8]>,
-    {
-        self.header_section_mut().as_header_mut()
-    }
-
     /// Returns the header counts of the message.
     pub fn header_counts(&self) -> HeaderCounts {
         self.header_section().counts()
-    }
-
-    /// Returns a mutable reference to the header counts of the message.
-    pub fn header_counts_mut(&mut self) -> &mut HeaderCounts
-    where
-        Octs: AsMut<[u8]>,
-    {
-        self.header_section_mut().as_counts_mut()
     }
 
     /// Returns the entire header section.
     pub fn header_section(&self) -> HeaderSection {
         let chunk: &[u8; 12] = self.as_slice()[0..12].try_into().unwrap();
         HeaderSection::from_array(*chunk)
-    }
-
-    /// Returns a mutable reference to the entire header section.
-    pub fn header_section_mut(&mut self) -> &mut HeaderSection
-    where
-        Octs: AsMut<[u8]>,
-    {
-        HeaderSection::for_array_mut(
-            (&mut self.as_slice_mut()[0..12]).try_into().unwrap(),
-        )
     }
 
     /// Returns whether the rcode of the header is NoError.
@@ -333,6 +307,27 @@ impl<Octs: AsRef<[u8]> + ?Sized> Message<Octs> {
     /// Returns whether the rcode of the header is one of the error values.
     pub fn is_error(&self) -> bool {
         self.header().rcode() != Rcode::NOERROR
+    }
+}
+
+/// # Mutable access to the header section
+///
+impl<Octs: AsMut<[u8]> + ?Sized> Message<Octs> {
+    /// Returns a mutable reference to the message header.
+    pub fn header_mut(&mut self) -> &mut Header {
+        self.header_section_mut().as_header_mut()
+    }
+
+    /// Returns a mutable reference to the header counts of the message.
+    pub fn header_counts_mut(&mut self) -> &mut HeaderCounts {
+        self.header_section_mut().as_counts_mut()
+    }
+
+    /// Returns a mutable reference to the entire header section.
+    pub fn header_section_mut(&mut self) -> &mut HeaderSection {
+        HeaderSection::for_array_mut(
+            (&mut self.as_slice_mut()[0..12]).try_into().unwrap(),
+        )
     }
 }
 

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -320,8 +320,8 @@ impl<Octs: AsRef<[u8]> + ?Sized> Message<Octs> {
     where
         Octs: AsMut<[u8]>,
     {
-        HeaderSection::for_message_chunk_mut(
-            self.as_slice_mut().first_chunk_mut().unwrap(),
+        HeaderSection::for_array_mut(
+            (&mut self.as_slice_mut()[0..12]).try_into().unwrap(),
         )
     }
 

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -186,7 +186,7 @@ impl<Target: OctetsBuilder + Truncate> MessageBuilder<Target> {
         mut target: Target,
     ) -> Result<Self, Target::AppendError> {
         target.truncate(0);
-        target.append_slice(HeaderSection::new().as_slice())?;
+        target.append_slice(HeaderSection::new().as_array())?;
         Ok(MessageBuilder { target })
     }
 }
@@ -275,24 +275,42 @@ impl<Target: Composer> MessageBuilder<Target> {
 impl<Target: OctetsBuilder + AsRef<[u8]>> MessageBuilder<Target> {
     /// Return the current value of the message header.
     pub fn header(&self) -> Header {
-        *Header::for_message_slice(self.target.as_ref())
+        *self.header_section().header()
     }
 
     /// Return the current value of the message header counts.
     pub fn counts(&self) -> HeaderCounts {
-        *HeaderCounts::for_message_slice(self.target.as_ref())
+        *self.header_section().counts()
+    }
+
+    fn header_section(&self) -> &HeaderSection {
+        let chunk = self
+            .target
+            .as_ref()
+            .first_chunk()
+            .expect("target is not large enough");
+        HeaderSection::for_message_chunk(chunk)
     }
 }
 
 impl<Target: OctetsBuilder + AsMut<[u8]>> MessageBuilder<Target> {
     /// Returns a mutable reference to the message header for manipulations.
     pub fn header_mut(&mut self) -> &mut Header {
-        Header::for_message_slice_mut(self.target.as_mut())
+        self.header_section_mut().header_mut()
     }
 
     /// Returns a mutable reference to the message header counts.
     fn counts_mut(&mut self) -> &mut HeaderCounts {
-        HeaderCounts::for_message_slice_mut(self.target.as_mut())
+        self.header_section_mut().counts_mut()
+    }
+
+    fn header_section_mut(&mut self) -> &mut HeaderSection {
+        let chunk = self
+            .target
+            .as_mut()
+            .first_chunk_mut()
+            .expect("target is not large enough");
+        HeaderSection::for_message_chunk_mut(chunk)
     }
 }
 
@@ -1652,16 +1670,19 @@ impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
     /// OPT header.
     #[must_use]
     pub fn rcode(&self) -> OptRcode {
-        self.opt_header()
-            .rcode(*Header::for_message_slice(self.target.as_ref()))
+        self.opt_header().rcode(*Header::for_message_chunk(
+            self.target.as_ref().first_chunk().unwrap(),
+        ))
     }
 
     /// Sets the extended rcode of the message.
     //
     /// The method will update both the message header and the OPT header.
     pub fn set_rcode(&mut self, rcode: OptRcode) {
-        Header::for_message_slice_mut(self.target.as_mut())
-            .set_rcode(rcode.rcode());
+        Header::for_message_chunk_mut(
+            self.target.as_mut().first_chunk_mut().unwrap(),
+        )
+        .set_rcode(rcode.rcode());
         self.opt_header_mut().set_rcode(rcode)
     }
 

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -287,7 +287,8 @@ impl<Target: OctetsBuilder + AsRef<[u8]>> MessageBuilder<Target> {
         let chunk = self
             .target
             .as_ref()
-            .try_into()
+            .get(0..12)
+            .and_then(|a| a.try_into().ok())
             .expect("slice is not large enough");
         HeaderSection::from_array(chunk)
     }

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -504,8 +504,8 @@ impl<K: AsRef<Key>> ClientTransaction<K> {
             None => return Err(ValidationError::ServerUnsigned),
         };
         let mut header = message.header_section();
-        header.header_mut().set_id(tsig.record.data().original_id());
-        header.counts_mut().dec_arcount();
+        header.as_header_mut().set_id(tsig.record.data().original_id());
+        header.as_counts_mut().dec_arcount();
         let signature = self.context.answer(
             header.as_array(),
             Some(
@@ -767,8 +767,8 @@ impl<K: AsRef<Key>> ClientSequence<K> {
             None => return Err(ValidationError::ServerUnsigned),
         };
         let mut header = message.header_section();
-        header.header_mut().set_id(tsig.record.data().original_id());
-        header.counts_mut().dec_arcount();
+        header.as_header_mut().set_id(tsig.record.data().original_id());
+        header.as_counts_mut().dec_arcount();
         let signature = self.context.first_answer(
             header.as_array(),
             Some(
@@ -813,8 +813,8 @@ impl<K: AsRef<Key>> ClientSequence<K> {
 
         // Check the MAC.
         let mut header = message.header_section();
-        header.header_mut().set_id(tsig.record.data().original_id());
-        header.counts_mut().dec_arcount();
+        header.as_header_mut().set_id(tsig.record.data().original_id());
+        header.as_counts_mut().dec_arcount();
         let signature = self.context.signed_subsequent(
             header.as_array(),
             Some(
@@ -1025,8 +1025,8 @@ impl<K: AsRef<Key>> SigningContext<K> {
         //
         // Contrary to RFC 2845, this must be done before the time check.
         let mut header = message.header_section();
-        header.header_mut().set_id(tsig.record.data().original_id());
-        header.counts_mut().dec_arcount();
+        header.as_header_mut().set_id(tsig.record.data().original_id());
+        header.as_counts_mut().dec_arcount();
         let (mut context, signature) = Self::request(
             key,
             header.as_array(),

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -507,7 +507,7 @@ impl<K: AsRef<Key>> ClientTransaction<K> {
         header.header_mut().set_id(tsig.record.data().original_id());
         header.counts_mut().dec_arcount();
         let signature = self.context.answer(
-            header.as_slice(),
+            header.as_array(),
             Some(
                 &message.as_slice()
                     [mem::size_of::<HeaderSection>()..tsig.start],
@@ -770,7 +770,7 @@ impl<K: AsRef<Key>> ClientSequence<K> {
         header.header_mut().set_id(tsig.record.data().original_id());
         header.counts_mut().dec_arcount();
         let signature = self.context.first_answer(
-            header.as_slice(),
+            header.as_array(),
             Some(
                 &message.as_slice()
                     [mem::size_of::<HeaderSection>()..tsig.start],
@@ -816,7 +816,7 @@ impl<K: AsRef<Key>> ClientSequence<K> {
         header.header_mut().set_id(tsig.record.data().original_id());
         header.counts_mut().dec_arcount();
         let signature = self.context.signed_subsequent(
-            header.as_slice(),
+            header.as_array(),
             Some(
                 &message.as_slice()
                     [mem::size_of::<HeaderSection>()..tsig.start],
@@ -1029,7 +1029,7 @@ impl<K: AsRef<Key>> SigningContext<K> {
         header.counts_mut().dec_arcount();
         let (mut context, signature) = Self::request(
             key,
-            header.as_slice(),
+            header.as_array(),
             Some(
                 &message.as_slice()
                     [mem::size_of::<HeaderSection>()..tsig.start],

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -504,7 +504,9 @@ impl<K: AsRef<Key>> ClientTransaction<K> {
             None => return Err(ValidationError::ServerUnsigned),
         };
         let mut header = message.header_section();
-        header.as_header_mut().set_id(tsig.record.data().original_id());
+        header
+            .as_header_mut()
+            .set_id(tsig.record.data().original_id());
         header.as_counts_mut().dec_arcount();
         let signature = self.context.answer(
             header.as_array(),
@@ -767,7 +769,9 @@ impl<K: AsRef<Key>> ClientSequence<K> {
             None => return Err(ValidationError::ServerUnsigned),
         };
         let mut header = message.header_section();
-        header.as_header_mut().set_id(tsig.record.data().original_id());
+        header
+            .as_header_mut()
+            .set_id(tsig.record.data().original_id());
         header.as_counts_mut().dec_arcount();
         let signature = self.context.first_answer(
             header.as_array(),
@@ -813,7 +817,9 @@ impl<K: AsRef<Key>> ClientSequence<K> {
 
         // Check the MAC.
         let mut header = message.header_section();
-        header.as_header_mut().set_id(tsig.record.data().original_id());
+        header
+            .as_header_mut()
+            .set_id(tsig.record.data().original_id());
         header.as_counts_mut().dec_arcount();
         let signature = self.context.signed_subsequent(
             header.as_array(),
@@ -1025,7 +1031,9 @@ impl<K: AsRef<Key>> SigningContext<K> {
         //
         // Contrary to RFC 2845, this must be done before the time check.
         let mut header = message.header_section();
-        header.as_header_mut().set_id(tsig.record.data().original_id());
+        header
+            .as_header_mut()
+            .set_id(tsig.record.data().original_id());
         header.as_counts_mut().dec_arcount();
         let (mut context, signature) = Self::request(
             key,


### PR DESCRIPTION
`HeaderSection`, `Header` and `HeaderCounts` all have `for_message_slice` which takes a slice and panics if the slice is too short. This is annoying because the compiler cannot help us enforce that constraint at compile-time and users of `domain` would need to read the docs carefully to use those functions correctly.

This PR changes those methods to instead take a `&[u8; N]` with the length of the internal representation of these types. The advantage of this can be seen by the tests this PR removes: instead of panicking they now no longer compile.

Additionally, I changed the `as_slice` methods for these types to `as_array`. Since a reference to an array derefs to a slice, these are mostly compatible.

There's another notable change: `HeaderCounts` does not take a slice of the entire message anymore, but only of the counts part (so just 8 bytes). This makes that function simpler, which I think is better because that makes it easier to guarantee its correctness. The burden of finding the right offset to get it from is now on the caller. This means that users probably do not want to use `HeaderCounts::for_message_chunk` but instead `HeaderSection::for_message_chunk` followed by `.counts()`. This makes it clearer what information should be passed in. There's even a case to be made that `{Header, HeaderCounts}::for_message_chunk` should not be public.

We can now do the conversions with `mem::transmute`, but there's a pattern that makes the transmutes even safer. `mem::transmute` statically guarantees that the types it converts have the same size. That's nice, but not enough in our case since we want to guarantee that the size of the _referenced_ types are the same. Therefore, I add a second unused `mem::transmute` call like this:
```rust
let _ = || {
    unsafe { mem::transmute::<[u8; N], Self>(*s) };
};
``` 
This does not compile if `[u8; N]` and `Self` have different sizes, therefore guaranteeing safety. It's a bit strange, but I think it works.

This is a draft PR because:
1. It's a breaking change and we might not want this or deprecate some of the functions I changed or removed first.
2. We might want to remove the non-`mut` conversions and returned owned (copied) values instead.
3. ~This currently requires Rust 1.77, so if we downgrade to 1.76, I'd have to change some things before we can merge this.~

This is a breaking change.

