### PR TITLE
Proposal for a MSRV policy.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.78.0, stable, beta, nightly]
+        rust: [1.76.0, stable, beta, nightly]
     env:
         RUSTFLAGS: "-D warnings"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
     - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
+      uses: hecrj/setup-rust-action@v2
       with:
         rust-version: ${{ matrix.rust }}
     - if: matrix.rust == 'stable'
@@ -39,9 +39,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v1
     - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
+      uses: hecrj/setup-rust-action@v2
       with:
-        rust-version: "1.76.0"
+        rust-version: "1.68.2"
     - name: Install nightly Rust
       run: rustup install nightly
     - name: Check with minimal-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,22 @@ jobs:
         cargo +nightly update -Z minimal-versions
         cargo check --all-features --all-targets
       name: Check with minimal-versions
+  minimal-versions:
+    name: Check minimal versions
+    runs-on: ubuntu-latest
+    env:
+        RUSTFLAGS: "-D warnings"
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: "1.76.0"
+    - name: Install nightly Rust
+      run: rustup install nightly
+    - name: Check with minimal-versions
+      run: |
+        cargo +nightly update -Z minimal-versions
+        cargo check --all-features --all-targets --locked
+      

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "domain"
 version = "0.10.1"
-rust-version = "1.78.0"
+rust-version = "1.76.0"
 edition = "2021"
 authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]
 description = "A DNS library for Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "domain"
 version = "0.10.1"
-rust-version = "1.76.0"
+
+# This is the mimimal Rust version with minimal dependencies as specified
+# below. With latest dependency versions 1.76.0 is currently required.
+rust-version = "1.68.2"
+
 edition = "2021"
 authors = ["NLnet Labs <dns-team@nlnetlabs.nl>"]
 description = "A DNS library for Rust."

--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ If you have ideas, requests, or proposals for future features, please
 don’t hesitate to open Github issues.
 
 
+## Minimal Supported Rust Versions
+
+We are trying to maintain a decent balance between being able to use older
+compiler versions and using new features that improve safety and usability
+of the crate.
+
+### Minimum version: 1.68.2
+
+The `rust-version` given in `Cargo.toml` is the oldest version that can
+be used to compile the crate with the minimum versions of all dependencies
+selected.
+
+### Current version: 1.76.0
+
+This is the minimum Rust version required to build with latest version of
+all dependencies at time of release. `Cargo.lock` contains these versions
+for reference.
+
 ## Licensing
 
 The domain crate is distributed under the terms of the BSD-3-clause


### PR DESCRIPTION
This PR proposes a revised policy for dealing with minimum supported Rust versions.

It suggests to keep the `rust-version` field in `Cargo.toml` at the oldest Rust version that is able to builds with minimal dependency versions and all features enabled. In addition, the Rust version necessary to build with latest dependencies is provided in the README and as a comment in `Cargo.toml`. Both these versions are checked in the CI workflow.

The reasoning behind the proposal is that `rust-version` sets a hard limit on the version, so it should be chosen as low as possible. While technically it could be lower with a subset of the features selected, this feels like a slippery slope and setting the version with all features selected feels like an acceptable compromise.

Only documenting the version that is necessary to build with latest dependencies isn’t ideal but at least provides some guidance as to what to choose for people who go look for some.

This is a draft PR since it is a proposal.

