### PR TITLE
Fix TSIG position calculation if there are other additional records.

### DIFF
--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -7,6 +7,7 @@ use crate::base::message_builder::{
     AdditionalBuilder, AnswerBuilder, MessageBuilder, StreamTarget,
 };
 use crate::base::name::Name;
+use crate::base::opt::TcpKeepalive;
 use crate::base::record::Ttl;
 use crate::rdata::tsig::Time48;
 use crate::rdata::{Soa, A};
@@ -21,7 +22,6 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::vec::Vec;
 use std::{env, fs, io, path::PathBuf, thread};
-use crate::base::opt::TcpKeepalive;
 
 type TestMessage = Message<Vec<u8>>;
 type TestBuilder = MessageBuilder<StreamTarget<Vec<u8>>>;
@@ -88,7 +88,9 @@ fn tsig_client_nsd() {
             .request_axfr(Name::<Vec<u8>>::from_str("example.com.").unwrap())
             .unwrap()
             .additional();
-        request.opt(|builder| builder.push(&TcpKeepalive::new(None))).unwrap();
+        request
+            .opt(|builder| builder.push(&TcpKeepalive::new(None)))
+            .unwrap();
         let tran = tsig::ClientTransaction::request(
             &key,
             &mut request,

--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -112,7 +112,7 @@ fn tsig_client_nsd() {
                 break answer;
             }
         };
-        assert!(!answer.is_error());
+        assert_eq!(answer.header().rcode(), Rcode::NOTIMP);
         if let Err(err) = tran.answer(&mut answer, Time48::now()) {
             panic!("{:?}", err);
         }

--- a/src/tsig/interop.rs
+++ b/src/tsig/interop.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::vec::Vec;
 use std::{env, fs, io, path::PathBuf, thread};
+use crate::base::opt::TcpKeepalive;
 
 type TestMessage = Message<Vec<u8>>;
 type TestBuilder = MessageBuilder<StreamTarget<Vec<u8>>>;
@@ -87,6 +88,7 @@ fn tsig_client_nsd() {
             .request_axfr(Name::<Vec<u8>>::from_str("example.com.").unwrap())
             .unwrap()
             .additional();
+        request.opt(|builder| builder.push(&TcpKeepalive::new(None))).unwrap();
         let tran = tsig::ClientTransaction::request(
             &key,
             &mut request,
@@ -108,6 +110,7 @@ fn tsig_client_nsd() {
                 break answer;
             }
         };
+        assert!(!answer.is_error());
         if let Err(err) = tran.answer(&mut answer, Time48::now()) {
             panic!("{:?}", err);
         }
@@ -116,7 +119,7 @@ fn tsig_client_nsd() {
 
     // Shut down NSD just to be sure.
     let _ = nsd.kill();
-    res.unwrap(); // Panic if the thread paniced.
+    res.unwrap(); // Panic if the thread panicked.
 }
 
 /// Tests the TSIG server implementation against drill as a client.

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -1316,11 +1316,12 @@ impl<'a, Octs: Octets + ?Sized> MessageTsig<'a, Octs> {
         let mut start = section.pos();
         let mut record = section.next()?;
         loop {
+            let record_start = section.pos();
             record = match section.next() {
                 Some(record) => record,
                 None => break,
             };
-            start = section.pos();
+            start = record_start;
         }
         record
             .ok()?


### PR DESCRIPTION
This PR fixes a mistake in the `tsig` module while calculating the start of the TSIG record when there were other records in the additional section, causing the TSIG code to fail if OPT records were in use.