### PR TITLE
Fix a new nightly warning involving never and unit types.

### DIFF
--- a/src/rdata/svcb/value.rs
+++ b/src/rdata/svcb/value.rs
@@ -725,7 +725,7 @@ impl<Target> AlpnBuilder<Target> {
                 protocol.len() + 1
             ).expect("long Alpn value")
         ).map_err(|_| BuildAlpnError::LongSvcParam)?;
-        len.compose(&mut self.target).map(Into::into)?;
+        len.compose(&mut self.target)?;
         self.target.append_slice(
             protocol
         ).map_err(|_| BuildAlpnError::ShortBuf)


### PR DESCRIPTION
This PR fixes a new warning “this function depends on never type fallback being `()`” by removing some code without effect.
 