### PR TITLE
Net client more docs

### DIFF
--- a/src/net/client/cache.rs
+++ b/src/net/client/cache.rs
@@ -26,9 +26,6 @@
 //! responses should be cached and whether truncated responses should be cached
 //! or not.
 
-#![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
-
 use crate::base::iana::{Class, Opcode, OptRcode, Rtype};
 use crate::base::name::ToName;
 use crate::base::{

--- a/src/net/client/dgram.rs
+++ b/src/net/client/dgram.rs
@@ -175,14 +175,14 @@ impl Default for Config {
 //------------ Connection -----------------------------------------------------
 
 /// A datagram protocol connection.
-///
-/// Because it owns the connection’s resources, this type is not [`Clone`].
-/// However, it is entirely safe to share it by sticking it into e.g. an arc.
 #[derive(Clone, Debug)]
 pub struct Connection<S> {
+    /// Actual state of the connection.
     state: Arc<ConnectionState<S>>,
 }
 
+/// Because it owns the connection’s resources, this type is not [`Clone`].
+/// However, it is entirely safe to share it by sticking it into e.g. an arc.
 #[derive(Debug)]
 struct ConnectionState<S> {
     /// User configuration variables.
@@ -386,18 +386,22 @@ pub struct QueryError {
 }
 
 impl QueryError {
+    /// Create a new `QueryError`.
     fn new(kind: QueryErrorKind, io: io::Error) -> Self {
         Self { kind, io }
     }
 
+    /// Create a new connect error.
     fn connect(io: io::Error) -> Self {
         Self::new(QueryErrorKind::Connect, io)
     }
 
+    /// Create a new send error.
     fn send(io: io::Error) -> Self {
         Self::new(QueryErrorKind::Send, io)
     }
 
+    /// Create a new short send error.
     fn short_send() -> Self {
         Self::new(
             QueryErrorKind::Send,
@@ -405,6 +409,7 @@ impl QueryError {
         )
     }
 
+    /// Create a new timeout error.
     fn timeout() -> Self {
         Self::new(
             QueryErrorKind::Timeout,
@@ -412,6 +417,7 @@ impl QueryError {
         )
     }
 
+    /// Create a new receive error.
     fn receive(io: io::Error) -> Self {
         Self::new(QueryErrorKind::Receive, io)
     }

--- a/src/net/client/dgram_stream.rs
+++ b/src/net/client/dgram_stream.rs
@@ -1,8 +1,5 @@
 //! A UDP transport that falls back to TCP if the reply is truncated
 
-#![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
-
 // To do:
 // - handle shutdown
 

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -172,6 +172,7 @@
 #![cfg(feature = "unstable-client-transport")]
 #![cfg_attr(docsrs, doc(cfg(feature = "unstable-client-transport")))]
 #![warn(missing_docs)]
+#![warn(clippy::missing_docs_in_private_items)]
 
 pub mod cache;
 pub mod dgram;

--- a/src/net/client/multi_stream.rs
+++ b/src/net/client/multi_stream.rs
@@ -1,8 +1,5 @@
 //! A DNS over multiple octet streams transport
 
-#![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
-
 // To do:
 // - too many connection errors
 

--- a/src/net/client/protocol.rs
+++ b/src/net/client/protocol.rs
@@ -223,7 +223,10 @@ impl<R: AsyncDgramRecv> AsyncDgramRecvEx for R {}
 
 /// Return value of recv. This captures the future for recv.
 pub struct DgramRecv<'a, R: ?Sized> {
+    /// The receiver of the datagram.
     receiver: &'a R,
+
+    /// Buffer to store the datagram.
     buf: &'a mut [u8],
 }
 

--- a/src/net/client/redundant.rs
+++ b/src/net/client/redundant.rs
@@ -1,8 +1,5 @@
 //! A transport that multiplexes requests over multiple redundant transports.
 
-#![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
-
 use bytes::Bytes;
 
 use futures_util::stream::FuturesUnordered;

--- a/src/net/client/request.rs
+++ b/src/net/client/request.rs
@@ -1,8 +1,5 @@
 //! Constructing and sending requests.
 
-#![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
-
 use crate::base::iana::Rcode;
 use crate::base::message::{CopyRecordsError, ShortMessage};
 use crate::base::message_builder::{

--- a/src/net/client/stream.rs
+++ b/src/net/client/stream.rs
@@ -1,8 +1,5 @@
 //! A client transport using a stream socket.
 
-#![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
-
 // RFC 7766 describes DNS over TCP
 // RFC 7828 describes the edns-tcp-keepalive option
 


### PR DESCRIPTION
Add #![warn(clippy::missing_docs_in_private_items)] to src/net/client/mod.rs and add missing internal documentation.