### PR TITLE
Remove `SerializeOctets` bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq         =  { version = "0.5.2-dev", git = "https://github.com/NLnetLabs/octseq.git", rev ="3f7797f4274af0a52e66105250ee1186ff2ab6ac", default-features = false }
+octseq         =  { version = "0.5.2-dev", git = "https://github.com/NLnetLabs/octseq.git", default-features = false }
 time           =  { version = "0.3.1", default-features = false }
 
 rand           = { version = "0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
-octseq         =  { version = "0.5.2-dev", git = "https://github.com/NLnetLabs/octseq.git", default-features = false }
+octseq         =  { version = "0.5.2-dev", git = "https://github.com/NLnetLabs/octseq.git", branch = "remove-serialize-bounds", default-features = false }
 time           =  { version = "0.3.1", default-features = false }
 
 rand           = { version = "0.8", optional = true }

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -594,7 +594,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized + 'a> IntoIterator for &'a CharStr<T> {
 #[cfg(feature = "serde")]
 impl<T> serde::Serialize for CharStr<T>
 where
-    T: AsRef<[u8]> + SerializeOctets + ?Sized,
+    T: AsRef<[u8]> + ?Sized,
 {
     fn serialize<S: serde::Serializer>(
         &self,
@@ -608,7 +608,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "CharStr",
-                &self.0.as_serialized_octets(),
+                &self.0.as_ref().as_serialized_octets(),
             )
         }
     }

--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -31,7 +31,7 @@ use bytes::BytesMut;
 use core::{cmp, fmt, hash, mem, str};
 use octseq::builder::FreezeBuilder;
 #[cfg(feature = "serde")]
-use octseq::serde::{DeserializeOctets, SerializeOctets};
+use octseq::serde::DeserializeOctets;
 use octseq::{
     EmptyBuilder, FromBuilder, IntoBuilder, Octets, OctetsBuilder,
     OctetsFrom, Parser, ShortBuf, Truncate,
@@ -608,7 +608,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "CharStr",
-                &self.0.as_ref().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(&self.0),
             )
         }
     }

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -980,7 +980,7 @@ impl<Octs: AsRef<[u8]>> borrow::Borrow<Name<[u8]>> for Name<Octs> {
 #[cfg(feature = "serde")]
 impl<Octs> serde::Serialize for Name<Octs>
 where
-    Octs: AsRef<[u8]> + SerializeOctets + ?Sized,
+    Octs: AsRef<[u8]> + ?Sized,
 {
     fn serialize<S: serde::Serializer>(
         &self,
@@ -992,7 +992,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "Name",
-                &self.0.as_serialized_octets(),
+                &self.0.as_ref().as_serialized_octets(),
             )
         }
     }

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -21,7 +21,7 @@ use octseq::builder::{
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
 #[cfg(feature = "serde")]
-use octseq::serde::{DeserializeOctets, SerializeOctets};
+use octseq::serde::DeserializeOctets;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
@@ -992,7 +992,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "Name",
-                &self.0.as_ref().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(&self.0),
             )
         }
     }

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -652,8 +652,6 @@ impl serde::Serialize for OwnedLabel {
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        use octseq::serde::SerializeOctets;
-
         if serializer.is_human_readable() {
             serializer.serialize_newtype_struct(
                 "OwnedLabel",
@@ -662,7 +660,9 @@ impl serde::Serialize for OwnedLabel {
         } else {
             serializer.serialize_newtype_struct(
                 "OwnedLabel",
-                &self.as_label().as_slice().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(
+                    self.as_label().as_slice(),
+                ),
             )
         }
     }

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -19,7 +19,7 @@ use octseq::builder::{
 };
 use octseq::octets::{Octets, OctetsFrom};
 #[cfg(feature = "serde")]
-use octseq::serde::{DeserializeOctets, SerializeOctets};
+use octseq::serde::DeserializeOctets;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
@@ -795,7 +795,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "RelativeName",
-                &self.0.as_ref().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(&self.0.as_ref()),
             )
         }
     }

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -781,7 +781,7 @@ where
 #[cfg(feature = "serde")]
 impl<Octs> serde::Serialize for RelativeName<Octs>
 where
-    Octs: AsRef<[u8]> + SerializeOctets + ?Sized,
+    Octs: AsRef<[u8]> + ?Sized,
 {
     fn serialize<S: serde::Serializer>(
         &self,
@@ -795,7 +795,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "RelativeName",
-                &self.0.as_serialized_octets(),
+                &self.0.as_ref().as_serialized_octets(),
             )
         }
     }

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -17,7 +17,7 @@ use octseq::builder::{
     EmptyBuilder, FreezeBuilder, FromBuilder, IntoBuilder,
 };
 #[cfg(feature = "serde")]
-use octseq::serde::{DeserializeOctets, SerializeOctets};
+use octseq::serde::DeserializeOctets;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
@@ -452,7 +452,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "UncertainName",
-                &self.as_octets().as_ref().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(self.as_octets()),
             )
         }
     }

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -438,7 +438,7 @@ impl<Octets: AsRef<[u8]>> fmt::Debug for UncertainName<Octets> {
 #[cfg(feature = "serde")]
 impl<Octets> serde::Serialize for UncertainName<Octets>
 where
-    Octets: AsRef<[u8]> + SerializeOctets,
+    Octets: AsRef<[u8]>,
 {
     fn serialize<S: serde::Serializer>(
         &self,
@@ -452,7 +452,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "UncertainName",
-                &self.as_octets().as_serialized_octets(),
+                &self.as_octets().as_ref().as_serialized_octets(),
             )
         }
     }

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -237,7 +237,7 @@ pub struct UnknownRecordData<Octs> {
             serialize_with = "crate::utils::base16::serde::serialize",
             deserialize_with = "crate::utils::base16::serde::deserialize",
             bound(
-                serialize = "Octs: AsRef<[u8]> + octseq::serde::SerializeOctets",
+                serialize = "Octs: AsRef<[u8]>",
                 deserialize = "\
                     Octs: \
                         octseq::builder::FromBuilder + \

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -24,7 +24,7 @@ use octseq::builder::{
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;
 #[cfg(feature = "serde")]
-use octseq::serde::{DeserializeOctets, SerializeOctets};
+use octseq::serde::DeserializeOctets;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 use time::{Date, Month, PrimitiveDateTime, Time};
@@ -2220,7 +2220,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "RtypeBitmap",
-                &self.0.as_ref().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(&self.0),
             )
         }
     }

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -36,9 +36,7 @@ use time::{Date, Month, PrimitiveDateTime, Time};
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(bound(
-        serialize = "
-            Octs: octseq::serde::SerializeOctets + AsRef<[u8]>
-        ",
+        serialize = "Octs: AsRef<[u8]>",
         deserialize = "
             Octs: FromBuilder + octseq::serde::DeserializeOctets<'de>,
             <Octs as FromBuilder>::Builder:
@@ -797,7 +795,7 @@ fn u32_from_buf(buf: &[u8]) -> u32 {
     derive(serde::Serialize, serde::Deserialize),
     serde(bound(
         serialize = "
-            Octs: octseq::serde::SerializeOctets + AsRef<[u8]>,
+            Octs: AsRef<[u8]>,
             Name: serde::Serialize,
         ",
         deserialize = "
@@ -1362,7 +1360,7 @@ where
     derive(serde::Serialize, serde::Deserialize),
     serde(bound(
         serialize = "
-            Octs: octseq::serde::SerializeOctets + AsRef<[u8]>,
+            Octs: AsRef<[u8]>,
             Name: serde::Serialize,
         ",
         deserialize = "
@@ -1641,9 +1639,7 @@ where
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(bound(
-        serialize = "
-            Octs: octseq::serde::SerializeOctets + AsRef<[u8]>
-        ",
+        serialize = "Octs: AsRef<[u8]>",
         deserialize = "
             Octs: FromBuilder + octseq::serde::DeserializeOctets<'de>,
             <Octs as FromBuilder>::Builder:
@@ -2193,7 +2189,7 @@ impl<Octs: AsRef<[u8]>> fmt::Debug for RtypeBitmap<Octs> {
 #[cfg(feature = "serde")]
 impl<Octs> serde::Serialize for RtypeBitmap<Octs>
 where
-    Octs: AsRef<[u8]> + SerializeOctets,
+    Octs: AsRef<[u8]>,
 {
     fn serialize<S: serde::Serializer>(
         &self,
@@ -2224,7 +2220,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "RtypeBitmap",
-                &self.0.as_serialized_octets(),
+                &self.0.as_ref().as_serialized_octets(),
             )
         }
     }
@@ -2432,8 +2428,8 @@ where
         let buf_len = self.buf.as_ref().len();
         for src_pos in (0..buf_len).step_by(34) {
             let chunk_len = (self.buf.as_ref()[src_pos + 1] as usize) + 2;
-                let buf = self.buf.as_mut();
-            buf.copy_within(src_pos..src_pos+chunk_len, dst_pos);
+            let buf = self.buf.as_mut();
+            buf.copy_within(src_pos..src_pos + chunk_len, dst_pos);
             dst_pos += chunk_len;
         }
         self.buf.truncate(dst_pos);

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -61,7 +61,7 @@ macro_rules! rdata_types {
             feature = "serde",
             serde(bound(
                 serialize = "
-                    O: AsRef<[u8]> + octseq::serde::SerializeOctets,
+                    O: AsRef<[u8]>,
                     N: serde::Serialize,
                 ",
                 deserialize = "

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -23,7 +23,7 @@ use octseq::builder::{
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;
 #[cfg(feature = "serde")]
-use octseq::serde::{DeserializeOctets, SerializeOctets};
+use octseq::serde::DeserializeOctets;
 
 //------------ Nsec3 ---------------------------------------------------------
 
@@ -982,7 +982,7 @@ impl<T: AsRef<[u8]>> serde::Serialize for Nsec3Salt<T> {
         } else {
             serializer.serialize_newtype_struct(
                 "Nsec3Salt",
-                &self.0.as_ref().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(&self.0),
             )
         }
     }
@@ -1337,7 +1337,7 @@ impl<T: AsRef<[u8]>> serde::Serialize for OwnerHash<T> {
         } else {
             serializer.serialize_newtype_struct(
                 "OwnerHash",
-                &self.0.as_ref().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(&self.0),
             )
         }
     }

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -32,9 +32,7 @@ use octseq::serde::{DeserializeOctets, SerializeOctets};
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(bound(
-        serialize = "
-            Octs: octseq::serde::SerializeOctets + AsRef<[u8]>,
-        ",
+        serialize = "Octs: AsRef<[u8]>",
         deserialize = "
             Octs: FromBuilder + octseq::serde::DeserializeOctets<'de>,
             <Octs as FromBuilder>::Builder:
@@ -376,9 +374,7 @@ impl<Octs: AsRef<[u8]>> fmt::Debug for Nsec3<Octs> {
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(bound(
-        serialize = "
-            Octs: octseq::serde::SerializeOctets + AsRef<[u8]>,
-        ",
+        serialize = "Octs: AsRef<[u8]>",
         deserialize = "
             Octs: FromBuilder + octseq::serde::DeserializeOctets<'de>,
             <Octs as FromBuilder>::Builder: OctetsBuilder + EmptyBuilder,
@@ -973,7 +969,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Nsec3Salt<Octs> {
 //--- Serialize and Deserialize
 
 #[cfg(feature = "serde")]
-impl<T: AsRef<[u8]> + SerializeOctets> serde::Serialize for Nsec3Salt<T> {
+impl<T: AsRef<[u8]>> serde::Serialize for Nsec3Salt<T> {
     fn serialize<S: serde::Serializer>(
         &self,
         serializer: S,
@@ -986,7 +982,7 @@ impl<T: AsRef<[u8]> + SerializeOctets> serde::Serialize for Nsec3Salt<T> {
         } else {
             serializer.serialize_newtype_struct(
                 "Nsec3Salt",
-                &self.0.as_serialized_octets(),
+                &self.0.as_ref().as_serialized_octets(),
             )
         }
     }
@@ -1328,7 +1324,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for OwnerHash<Octs> {
 //--- Serialize and Deserialize
 
 #[cfg(feature = "serde")]
-impl<T: AsRef<[u8]> + SerializeOctets> serde::Serialize for OwnerHash<T> {
+impl<T: AsRef<[u8]>> serde::Serialize for OwnerHash<T> {
     fn serialize<S: serde::Serializer>(
         &self,
         serializer: S,
@@ -1341,7 +1337,7 @@ impl<T: AsRef<[u8]> + SerializeOctets> serde::Serialize for OwnerHash<T> {
         } else {
             serializer.serialize_newtype_struct(
                 "OwnerHash",
-                &self.0.as_serialized_octets(),
+                &self.0.as_ref().as_serialized_octets(),
             )
         }
     }

--- a/src/rdata/rfc1035/hinfo.rs
+++ b/src/rdata/rfc1035/hinfo.rs
@@ -5,13 +5,11 @@
 use crate::base::charstr::CharStr;
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
-use crate::base::rdata::{
-    ComposeRecordData, ParseRecordData, RecordData,
-};
+use crate::base::rdata::{ComposeRecordData, ParseRecordData, RecordData};
 use crate::base::scan::Scanner;
 use crate::base::wire::{Composer, ParseError};
-use core::{fmt, hash};
 use core::cmp::Ordering;
+use core::{fmt, hash};
 #[cfg(feature = "serde")]
 use octseq::builder::{EmptyBuilder, FromBuilder};
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
@@ -32,7 +30,7 @@ use octseq::parse::Parser;
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(bound(
-        serialize = "Octs: AsRef<[u8]> + octseq::serde::SerializeOctets",
+        serialize = "Octs: AsRef<[u8]>",
         deserialize = "Octs: \
                 FromBuilder \
                 + octseq::serde::DeserializeOctets<'de>, \
@@ -268,4 +266,3 @@ mod test {
         assert_eq!(hinfo.os(), hinfo_bytes.os());
     }
 }
-

--- a/src/rdata/rfc1035/null.rs
+++ b/src/rdata/rfc1035/null.rs
@@ -30,8 +30,7 @@ pub struct Null<Octs: ?Sized> {
     #[cfg_attr(
         feature = "serde",
         serde(
-            serialize_with = "octseq::serde::serialize",
-            deserialize_with = "octseq::serde::DeserializeOctets::deserialize_octets",
+            with = "octseq::serde",
             bound(
                 serialize = "Octs: AsRef<[u8]>",
                 deserialize = "Octs: octseq::serde::DeserializeOctets<'de>",

--- a/src/rdata/rfc1035/null.rs
+++ b/src/rdata/rfc1035/null.rs
@@ -8,8 +8,8 @@ use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData,
 };
 use crate::base::wire::{Composer, ParseError};
-use core::{fmt, hash, mem};
 use core::cmp::Ordering;
+use core::{fmt, hash, mem};
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;
 
@@ -21,7 +21,7 @@ use octseq::parse::Parser;
 /// allowed in zone files.
 ///
 /// The Null record type is defined in [RFC 1035, section 3.3.10][1].
-/// 
+///
 /// [1]: https://tools.ietf.org/html/rfc1035#section-3.3.10
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -30,10 +30,10 @@ pub struct Null<Octs: ?Sized> {
     #[cfg_attr(
         feature = "serde",
         serde(
-            serialize_with = "octseq::serde::SerializeOctets::serialize_octets",
+            serialize_with = "octseq::serde::serialize",
             deserialize_with = "octseq::serde::DeserializeOctets::deserialize_octets",
             bound(
-                serialize = "Octs: octseq::serde::SerializeOctets",
+                serialize = "Octs: AsRef<[u8]>",
                 deserialize = "Octs: octseq::serde::DeserializeOctets<'de>",
             )
         )
@@ -293,4 +293,3 @@ mod test {
         test_compose_parse(&rdata, |parser| Null::parse(parser));
     }
 }
-

--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -26,7 +26,7 @@ use octseq::builder::{
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;
 #[cfg(feature = "serde")]
-use octseq::serde::{DeserializeOctets, SerializeOctets};
+use octseq::serde::DeserializeOctets;
 
 //------------ Txt ----------------------------------------------------------
 
@@ -499,7 +499,7 @@ where
         } else {
             serializer.serialize_newtype_struct(
                 "Txt",
-                &self.0.as_ref().as_serialized_octets(),
+                &octseq::serde::AsSerializedOctets::from(&self.0),
             )
         }
     }

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -7,12 +7,12 @@ use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::SvcParamKey;
 use crate::base::scan::Symbol;
 use crate::base::wire::{Compose, Parse, ParseError};
+use core::cmp::Ordering;
+use core::marker::PhantomData;
+use core::{cmp, fmt, hash, mem};
 use octseq::builder::{EmptyBuilder, FromBuilder, OctetsBuilder, ShortBuf};
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::{Parser, ShortInput};
-use core::{cmp, fmt, hash, mem};
-use core::cmp::Ordering;
-use core::marker::PhantomData;
 
 //------------ SvcParams -----------------------------------------------------
 
@@ -69,14 +69,11 @@ pub struct SvcParams<Octs: ?Sized> {
     #[cfg_attr(
         feature = "serde",
         serde(
-            serialize_with =
-                "octseq::serde::SerializeOctets::serialize_octets",
-            deserialize_with =
-                "octseq::serde::DeserializeOctets::deserialize_octets",
+            serialize_with = "octseq::serde::serialize",
+            deserialize_with = "octseq::serde::DeserializeOctets::deserialize_octets",
             bound(
-                serialize = "Octs: octseq::serde::SerializeOctets",
-                deserialize =
-                    "Octs: octseq::serde::DeserializeOctets<'de> + Sized",
+                serialize = "Octs: AsRef<[u8]>",
+                deserialize = "Octs: octseq::serde::DeserializeOctets<'de> + Sized",
             )
         )
     )]
@@ -91,7 +88,9 @@ impl<Octs> SvcParams<Octs> {
     /// individual values are correctly encoded. It also does not check for
     /// any length limit.
     pub fn from_octets(octets: Octs) -> Result<Self, SvcParamsError>
-    where Octs: AsRef<[u8]> {
+    where
+        Octs: AsRef<[u8]>,
+    {
         SvcParams::check_slice(octets.as_ref())?;
         Ok(unsafe { Self::from_octets_unchecked(octets) })
     }
@@ -159,10 +158,10 @@ impl<Octs> SvcParams<Octs> {
     pub fn from_values<F>(op: F) -> Result<Self, PushError>
     where
         Octs: FromBuilder,
-        <Octs  as FromBuilder>::Builder:
+        <Octs as FromBuilder>::Builder:
             AsRef<[u8]> + OctetsBuilder + EmptyBuilder,
         F: FnOnce(
-            &mut SvcParamsBuilder<<Octs  as FromBuilder>::Builder>
+            &mut SvcParamsBuilder<<Octs as FromBuilder>::Builder>,
         ) -> Result<(), PushError>,
     {
         let mut res = SvcParamsBuilder::empty();
@@ -174,11 +173,10 @@ impl<Octs> SvcParams<Octs> {
 impl<Octs: AsRef<[u8]>> SvcParams<Octs> {
     /// Parses a parameter sequence from its wire format.
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized + 'a>(
-        parser: &mut Parser<'a, Src>
+        parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
-        Self::from_octets(
-            parser.parse_octets(parser.remaining())?
-        ).map_err(Into::into)
+        Self::from_octets(parser.parse_octets(parser.remaining())?)
+            .map_err(Into::into)
     }
 }
 
@@ -234,21 +232,27 @@ impl<Octs: AsRef<[u8]> + ?Sized> SvcParams<Octs> {
 
     /// Returns an iterator over all values.
     pub fn iter_all(&self) -> ValueIter<Octs, AllValues<Octs>>
-    where Octs: Sized {
+    where
+        Octs: Sized,
+    {
         self.iter()
     }
 
     /// Returns an iterator over all values in their raw form.
     pub fn iter_raw(
-        &self
+        &self,
     ) -> impl Iterator<Item = UnknownSvcParam<Octs::Range<'_>>>
-    where Octs: Octets + Sized {
-        self.iter().map(|item| item.expect("parsing cannot have failed"))
+    where
+        Octs: Octets + Sized,
+    {
+        self.iter()
+            .map(|item| item.expect("parsing cannot have failed"))
     }
 
     /// Composes the wire-format of the parameter sequence.
     pub fn compose<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         target.append_slice(self.octets.as_ref())
     }
@@ -257,12 +261,12 @@ impl<Octs: AsRef<[u8]> + ?Sized> SvcParams<Octs> {
 //--- OctetsFrom
 
 impl<SrcOcts, Octs> OctetsFrom<SvcParams<SrcOcts>> for SvcParams<Octs>
-where Octs: OctetsFrom<SrcOcts> {
+where
+    Octs: OctetsFrom<SrcOcts>,
+{
     type Error = Octs::Error;
 
-    fn try_octets_from(
-        src: SvcParams<SrcOcts>
-    ) -> Result<Self, Self::Error> {
+    fn try_octets_from(src: SvcParams<SrcOcts>) -> Result<Self, Self::Error> {
         Ok(unsafe {
             SvcParams::from_octets_unchecked(src.octets.try_octets_into()?)
         })
@@ -281,7 +285,7 @@ where
     }
 }
 
-impl<Octs: AsRef<[u8]> + ?Sized> Eq for SvcParams<Octs> { }
+impl<Octs: AsRef<[u8]> + ?Sized> Eq for SvcParams<Octs> {}
 
 //--- Hash
 
@@ -299,7 +303,8 @@ where
     OtherOcts: AsRef<[u8]> + ?Sized,
 {
     fn partial_cmp(
-        &self, other: &SvcParams<OtherOcts>
+        &self,
+        other: &SvcParams<OtherOcts>,
     ) -> Option<cmp::Ordering> {
         self.as_slice().partial_cmp(other.as_slice())
     }
@@ -316,9 +321,7 @@ where
     Octs: AsRef<[u8]> + ?Sized,
     OtherOcts: AsRef<[u8]> + ?Sized,
 {
-    fn canonical_cmp(
-        &self, other: &SvcParams<OtherOcts>
-    ) -> cmp::Ordering {
+    fn canonical_cmp(&self, other: &SvcParams<OtherOcts>) -> cmp::Ordering {
         self.as_slice().cmp(other.as_slice())
     }
 }
@@ -330,37 +333,35 @@ impl<Octs: Octets + ?Sized> fmt::Display for SvcParams<Octs> {
         let mut parser = Parser::from_ref(self.as_slice());
         let mut first = true;
         while parser.remaining() > 0 {
-            let key = SvcParamKey::parse(
-                &mut parser
-            ).expect("invalid SvcbParam");
+            let key =
+                SvcParamKey::parse(&mut parser).expect("invalid SvcbParam");
             let len = usize::from(
-                u16::parse(&mut parser).expect("invalid SvcParam")
+                u16::parse(&mut parser).expect("invalid SvcParam"),
             );
-            let mut parser = parser.parse_parser(
-                len
-            ).expect("invalid SvcParam");
+            let mut parser =
+                parser.parse_parser(len).expect("invalid SvcParam");
             if first {
                 first = false;
-            }
-            else {
+            } else {
                 f.write_str(" ")?;
             }
             write!(
-                f, "{}", super::value::AllValues::parse_any(key, &mut parser)
+                f,
+                "{}",
+                super::value::AllValues::parse_any(key, &mut parser)
             )?;
-        };
+        }
         Ok(())
     }
 }
 
 impl<Octs: Octets + ?Sized> fmt::Debug for SvcParams<Octs> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("SvcParams").field(
-            &format_args!("{}", self)
-        ).finish()
+        f.debug_tuple("SvcParams")
+            .field(&format_args!("{}", self))
+            .finish()
     }
 }
-
 
 //------------ ValueIter -----------------------------------------------------
 
@@ -411,7 +412,7 @@ where
         while self.parser.remaining() > 0 {
             match self.next_step() {
                 Ok(Some(res)) => return Some(Ok(res)),
-                Ok(None) => { }
+                Ok(None) => {}
                 Err(err) => {
                     // Advance to end so we’ll return None from now on.
                     self.parser.advance_to_end();
@@ -432,13 +433,16 @@ pub trait SvcParamValue {
 }
 
 /// A service binding parameter value that can be parse from wire format.
-pub trait ParseSvcParamValue<'a, Octs: ?Sized>: SvcParamValue + Sized {
+pub trait ParseSvcParamValue<'a, Octs: ?Sized>:
+    SvcParamValue + Sized
+{
     /// Parse a parameter value from wire format.
     ///
     /// The method should return `Ok(None)` if the type cannot parse values
     /// with `key`. It should return an error if parsing fails.
     fn parse_value(
-        key: SvcParamKey, parser: &mut Parser<'a, Octs>,
+        key: SvcParamKey,
+        parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError>;
 }
 
@@ -454,7 +458,8 @@ pub trait ComposeSvcParamValue: SvcParamValue {
 
     /// Appends the wire format of the value to the end of `target`.
     fn compose_value<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target,
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError>;
 }
 
@@ -478,7 +483,9 @@ impl<Octs> UnknownSvcParam<Octs> {
     ///
     /// The function returns an error if `value` is longer than 65,535 octets.
     pub fn new(key: SvcParamKey, value: Octs) -> Result<Self, LongSvcParam>
-    where Octs: AsRef<[u8]> {
+    where
+        Octs: AsRef<[u8]>,
+    {
         LongSvcParam::check_len(value.as_ref().len())?;
         Ok(unsafe { Self::new_unchecked(key, value) })
     }
@@ -500,9 +507,8 @@ impl<Octs: AsRef<[u8]>> UnknownSvcParam<Octs> {
         key: SvcParamKey,
         parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
-        Self::new(
-            key, parser.parse_octets(parser.remaining())?
-        ).map_err(Into::into)
+        Self::new(key, parser.parse_octets(parser.remaining())?)
+            .map_err(Into::into)
     }
 
     /// Parses a full parameter from the wire format.
@@ -521,7 +527,8 @@ impl<Octs: AsRef<[u8]>> UnknownSvcParam<Octs> {
     ///
     /// This includes the key and length of the parameter.
     pub fn compose_param<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         self.key.compose(target)?;
         self.compose_len().compose(target)?;
@@ -539,16 +546,20 @@ impl<Octs> UnknownSvcParam<Octs> {
     pub fn value(&self) -> &Octs {
         &self.value
     }
- 
+
     /// Returns a slice of the value.
     pub fn as_slice(&self) -> &[u8]
-    where Octs: AsRef<[u8]> {
+    where
+        Octs: AsRef<[u8]>,
+    {
         self.value.as_ref()
     }
- 
+
     /// Returns a mutable slice of the value.
     pub fn as_slice_mut(&mut self) -> &mut [u8]
-    where Octs: AsMut<[u8]> {
+    where
+        Octs: AsMut<[u8]>,
+    {
         self.value.as_mut()
     }
 }
@@ -576,7 +587,7 @@ impl<Octs: AsMut<[u8]>> AsMut<[u8]> for UnknownSvcParam<Octs> {
 //--- PartialEq and Eq
 
 impl<Octs, OtherOcts> PartialEq<UnknownSvcParam<OtherOcts>>
-for UnknownSvcParam<Octs>
+    for UnknownSvcParam<Octs>
 where
     Octs: AsRef<[u8]>,
     OtherOcts: AsRef<[u8]>,
@@ -586,7 +597,7 @@ where
     }
 }
 
-impl<Octs: AsRef<[u8]>> Eq for UnknownSvcParam<Octs> { }
+impl<Octs: AsRef<[u8]>> Eq for UnknownSvcParam<Octs> {}
 
 //--- Hash
 
@@ -605,14 +616,15 @@ impl<Octs> SvcParamValue for UnknownSvcParam<Octs> {
 }
 
 impl<'a, Octs: Octets + ?Sized> ParseSvcParamValue<'a, Octs>
-for UnknownSvcParam<Octs::Range<'a>> {
+    for UnknownSvcParam<Octs::Range<'a>>
+{
     fn parse_value(
         key: SvcParamKey,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
-        Self::new(
-            key, parser.parse_octets(parser.remaining())?
-        ).map(Some).map_err(Into::into)
+        Self::new(key, parser.parse_octets(parser.remaining())?)
+            .map(Some)
+            .map_err(Into::into)
     }
 }
 
@@ -622,7 +634,8 @@ impl<Octs: AsRef<[u8]>> ComposeSvcParamValue for UnknownSvcParam<Octs> {
     }
 
     fn compose_value<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target,
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         target.append_slice(self.as_slice())
     }
@@ -643,7 +656,6 @@ impl<Octs: AsRef<[u8]>> fmt::Display for UnknownSvcParam<Octs> {
         Ok(())
     }
 }
-
 
 //------------ SvcParamsBuilder ----------------------------------------------
 
@@ -674,8 +686,12 @@ impl<Octs> SvcParamsBuilder<Octs> {
     /// Creates an empty parameter builder.
     #[must_use]
     pub fn empty() -> Self
-    where Octs: EmptyBuilder {
-        Self { octets: Octs::empty() }
+    where
+        Octs: EmptyBuilder,
+    {
+        Self {
+            octets: Octs::empty(),
+        }
     }
 
     /// Creates a parameter builder from an existing parameter sequence.
@@ -684,25 +700,26 @@ impl<Octs> SvcParamsBuilder<Octs> {
     /// of `params`. It can fail if the octets builder is not capable of
     /// providing enough space to hold the content of `params`.
     pub fn from_params<Src: Octets + ?Sized>(
-        params: &SvcParams<Src>
+        params: &SvcParams<Src>,
     ) -> Result<Self, ShortBuf>
-    where Octs: AsRef<[u8]> + OctetsBuilder + EmptyBuilder {
+    where
+        Octs: AsRef<[u8]> + OctetsBuilder + EmptyBuilder,
+    {
         let mut octets = Octs::empty();
         for item in params.iter::<UnknownSvcParam<_>>() {
             let item = item.expect("invalid SvcParams");
-            let start = u32::try_from(
-                octets.as_ref().len()
-            ).map_err(|_| ShortBuf)?.checked_add(
-                u32::from(u32::COMPOSE_LEN)
-            ).ok_or(ShortBuf)?;
-            octets.append_slice(
-                start.to_ne_bytes().as_ref()
-            ).map_err(Into::into)?;
+            let start = u32::try_from(octets.as_ref().len())
+                .map_err(|_| ShortBuf)?
+                .checked_add(u32::from(u32::COMPOSE_LEN))
+                .ok_or(ShortBuf)?;
+            octets
+                .append_slice(start.to_ne_bytes().as_ref())
+                .map_err(Into::into)?;
             item.compose_param(&mut octets).map_err(Into::into)?;
         }
-        octets.append_slice(
-            u32::MAX.to_be_bytes().as_ref()
-        ).map_err(Into::into)?;
+        octets
+            .append_slice(u32::MAX.to_be_bytes().as_ref())
+            .map_err(Into::into)?;
         Ok(Self { octets })
     }
 
@@ -711,38 +728,41 @@ impl<Octs> SvcParamsBuilder<Octs> {
     /// The method will return an error if a value with this key is already
     /// present or if there isn’t enough space left in the builder’s buffer.
     pub fn push<Value: ComposeSvcParamValue + ?Sized>(
-        &mut self, value: &Value
+        &mut self,
+        value: &Value,
     ) -> Result<(), PushError>
-    where Octs: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]> {
-        self.push_raw(
-            value.key(), value.compose_len(), |octs| value.compose_value(octs)
-        )
+    where
+        Octs: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
+    {
+        self.push_raw(value.key(), value.compose_len(), |octs| {
+            value.compose_value(octs)
+        })
     }
 
     pub(super) fn push_raw(
         &mut self,
         key: SvcParamKey,
         value_len: u16,
-        value: impl FnOnce(&mut Octs) -> Result<(), Octs::AppendError>
+        value: impl FnOnce(&mut Octs) -> Result<(), Octs::AppendError>,
     ) -> Result<(), PushError>
-    where Octs: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]> {
+    where
+        Octs: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
+    {
         // If octets is emtpy, we can just append ourselves and be done.
         if self.octets.as_ref().is_empty() {
-            self.octets.append_slice(
-                &u32::from(u32::COMPOSE_LEN).to_ne_bytes()
-            )?;
+            self.octets
+                .append_slice(&u32::from(u32::COMPOSE_LEN).to_ne_bytes())?;
             key.compose(&mut self.octets)?;
             value_len.compose(&mut self.octets)?;
             (value)(&mut self.octets)?;
             u32::MAX.compose(&mut self.octets)?;
-            return Ok(())
+            return Ok(());
         }
 
         // Where will this value start? This also serves as a check whether
         // we have become too long.
-        let start = u32::try_from(self.octets.as_ref().len()).map_err(|_|
-            PushError::ShortBuf
-        )?;
+        let start = u32::try_from(self.octets.as_ref().len())
+            .map_err(|_| PushError::ShortBuf)?;
 
         // Go over the values and find the predecessor and successor.
         let mut pre = None;
@@ -759,30 +779,22 @@ impl<Octs> SvcParamsBuilder<Octs> {
             let tmp_key = tmp.key();
             match tmp_key.cmp(&key) {
                 Ordering::Equal => return Err(PushError::DuplicateKey),
-                Ordering::Less => {
-                    match pre {
-                        Some((key, _)) => {
-                            if tmp_key > key {
-                                pre = Some((tmp_key, tmp_end));
-                            }
-                        }
-                        None => {
-                            pre = Some((tmp_key, tmp_end))
+                Ordering::Less => match pre {
+                    Some((key, _)) => {
+                        if tmp_key > key {
+                            pre = Some((tmp_key, tmp_end));
                         }
                     }
-                }
-                Ordering::Greater => {
-                    match next {
-                        Some((key, _)) => {
-                            if tmp_key < key {
-                                next = Some((tmp_key, tmp_start));
-                            }
-                         }
-                        None => {
-                            next = Some((tmp_key, tmp_start))
+                    None => pre = Some((tmp_key, tmp_end)),
+                },
+                Ordering::Greater => match next {
+                    Some((key, _)) => {
+                        if tmp_key < key {
+                            next = Some((tmp_key, tmp_start));
                         }
                     }
-                }
+                    None => next = Some((tmp_key, tmp_start)),
+                },
             }
             parser.advance(u32::COMPOSE_LEN.into()).unwrap();
         }
@@ -794,21 +806,20 @@ impl<Octs> SvcParamsBuilder<Octs> {
 
         // Append the pointer to the next value. MAX means none.
         self.octets.append_slice(
-            &next.map(|(_, pos)| pos).unwrap_or(u32::MAX).to_ne_bytes()
+            &next.map(|(_, pos)| pos).unwrap_or(u32::MAX).to_ne_bytes(),
         )?;
 
         // Replace the predecessor’s point with our start. If there is no
         // predecessor, we are the first item.
-        let pos = pre.map(|(_, pos)| {
-            // The u32 here was made from a usize so converting it back has to
-            // work.
-            usize::try_from(pos).unwrap()
-        }).unwrap_or(0);
-        self.octets.as_mut()[
-            pos..pos + usize::from(u32::COMPOSE_LEN)
-        ].copy_from_slice(
-            &start.to_ne_bytes()
-        );
+        let pos = pre
+            .map(|(_, pos)| {
+                // The u32 here was made from a usize so converting it back has to
+                // work.
+                usize::try_from(pos).unwrap()
+            })
+            .unwrap_or(0);
+        self.octets.as_mut()[pos..pos + usize::from(u32::COMPOSE_LEN)]
+            .copy_from_slice(&start.to_ne_bytes());
 
         Ok(())
     }
@@ -820,36 +831,34 @@ impl<Octs> SvcParamsBuilder<Octs> {
     /// builder and may fail if the target octet’s builder can’t provide
     /// enough space.
     pub fn freeze<Target>(
-        &self
+        &self,
     ) -> Result<
         SvcParams<Target>,
-        <<Target as FromBuilder>::Builder as OctetsBuilder>::AppendError
+        <<Target as FromBuilder>::Builder as OctetsBuilder>::AppendError,
     >
     where
         Octs: AsRef<[u8]>,
         Target: FromBuilder,
-        <Target as FromBuilder>::Builder: OctetsBuilder + EmptyBuilder
+        <Target as FromBuilder>::Builder: OctetsBuilder + EmptyBuilder,
     {
         let mut target = <Target as FromBuilder>::Builder::empty();
         if !self.octets.as_ref().is_empty() {
             let mut parser = Parser::from_ref(self.octets.as_ref());
             loop {
-                let pos = u32::from_ne_bytes(
-                    Parse::parse(&mut parser).unwrap()
-                );
+                let pos =
+                    u32::from_ne_bytes(Parse::parse(&mut parser).unwrap());
                 if pos == u32::MAX {
                     break;
                 }
                 let pos = usize::try_from(pos).unwrap();
                 parser.seek(pos).unwrap();
-                let param = UnknownSvcParam::parse_param(&mut parser).unwrap();
+                let param =
+                    UnknownSvcParam::parse_param(&mut parser).unwrap();
                 param.compose_param(&mut target)?;
             }
         }
         Ok(unsafe {
-            SvcParams::from_octets_unchecked(
-                Target::from_builder(target)
-            )
+            SvcParams::from_octets_unchecked(Target::from_builder(target))
         })
     }
 }
@@ -866,7 +875,7 @@ impl From<ShortInput> for SvcParamsError {
         ParseError::from(err).into()
     }
 }
-    
+
 impl From<ParseError> for SvcParamsError {
     fn from(err: ParseError) -> Self {
         SvcParamsError(err)
@@ -915,7 +924,6 @@ impl fmt::Display for LongSvcParam {
 #[cfg(feature = "std")]
 impl std::error::Error for LongSvcParam {}
 
-
 //------------ PushError -----------------------------------------------------
 
 /// An error happened when pushing values to a parameters builder.
@@ -939,7 +947,7 @@ impl fmt::Display for PushError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             PushError::DuplicateKey => f.write_str("duplicate key"),
-            PushError::ShortBuf => ShortBuf.fmt(f)
+            PushError::ShortBuf => ShortBuf.fmt(f),
         }
     }
 }
@@ -947,13 +955,12 @@ impl fmt::Display for PushError {
 #[cfg(feature = "std")]
 impl std::error::Error for PushError {}
 
-
 //============ Tests =========================================================
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use super::super::value;
+    use super::*;
     use octseq::array::Array;
 
     type Octets512 = Array<512>;
@@ -963,7 +970,6 @@ mod test {
     fn octets512(slice: impl AsRef<[u8]>) -> Octets512 {
         Octets512::try_from(slice.as_ref()).unwrap()
     }
-
 
     //--- Test vectors from the draft.
     //
@@ -1008,7 +1014,7 @@ mod test {
             b"\x00\x03\
               \x00\x02\
               \x00\x35",
-            [ value::Port::new(53) ]
+            [value::Port::new(53)]
         );
     }
 
@@ -1018,12 +1024,8 @@ mod test {
             b"\x02\x9b\
               \x00\x05\
               \x68\x65\x6c\x6c\x6f",
-            [
-                UnknownSvcParam::new(
-                    0x029b.into(),
-                    octets512(b"hello")
-                ).unwrap()
-            ]
+            [UnknownSvcParam::new(0x029b.into(), octets512(b"hello"))
+                .unwrap()]
         );
     }
 
@@ -1033,12 +1035,11 @@ mod test {
             b"\x02\x9b\
               \x00\x09\
               \x68\x65\x6c\x6c\x6f\xd2\x71\x6f\x6f",
-            [
-                UnknownSvcParam::new(
-                    0x029b.into(),
-                    octets512(b"\x68\x65\x6c\x6c\x6f\xd2\x71\x6f\x6f"),
-                ).unwrap()
-            ]
+            [UnknownSvcParam::new(
+                0x029b.into(),
+                octets512(b"\x68\x65\x6c\x6c\x6f\xd2\x71\x6f\x6f"),
+            )
+            .unwrap()]
         );
     }
 
@@ -1054,12 +1055,11 @@ mod test {
               \x00\x00\x00\x00\x00\x00\x00\x01\
               \x20\x01\x0d\xb8\x00\x00\x00\x00\
               \x00\x00\x00\x00\x00\x53\x00\x01",
-            [
-                value::Ipv6Hint::<Octets512>::from_addrs([
-                    Ipv6Addr::from_str("2001:db8::1").unwrap(),
-                    Ipv6Addr::from_str("2001:db8::53:1").unwrap(),
-                ]).unwrap()
-            ]
+            [value::Ipv6Hint::<Octets512>::from_addrs([
+                Ipv6Addr::from_str("2001:db8::1").unwrap(),
+                Ipv6Addr::from_str("2001:db8::53:1").unwrap(),
+            ])
+            .unwrap()]
         );
     }
 
@@ -1076,7 +1076,8 @@ mod test {
             [
                 value::Ipv6Hint::<Octets512>::from_addrs([
                     Ipv6Addr::from_str("::ffff:198.51.100.100").unwrap(),
-                ]).unwrap()
+                ])
+                .unwrap()
             ]
         );
     }
@@ -1091,9 +1092,11 @@ mod test {
             [
                 SvcParamKey::ALPN,
                 SvcParamKey::IPV4HINT,
-                SvcParamKey::PRIVATE_RANGE_BEGIN.into()
-            ].into_iter()
-        ).unwrap();
+                SvcParamKey::PRIVATE_RANGE_BEGIN.into(),
+            ]
+            .into_iter(),
+        )
+        .unwrap();
         assert_eq!(
             "mandatory=alpn,ipv4hint,key65280",
             format!("{}", mandatory)
@@ -1102,41 +1105,37 @@ mod test {
         let mut alpn_builder = value::AlpnBuilder::<Octets512>::empty();
         alpn_builder.push("h2").unwrap();
         alpn_builder.push("h3-19").unwrap();
-        assert_eq!(
-            "alpn=h2,h3-19",
-            format!("{}", alpn_builder.freeze())
-        );
+        assert_eq!("alpn=h2,h3-19", format!("{}", alpn_builder.freeze()));
 
         assert_eq!("nodefaultalpn", format!("{}", value::NoDefaultAlpn));
 
         assert_eq!(
             "ech",
-            format!(
-                "{}",
-                value::Ech::from_octets(Octets512::new()).unwrap()
-            )
+            format!("{}", value::Ech::from_octets(Octets512::new()).unwrap())
         );
 
         assert_eq!(
             "ipv4hint=192.0.2.1,192.0.2.2",
             format!(
                 "{}",
-                value::Ipv4Hint::<Octets512>::from_addrs(
-                    [
-                        [192, 0, 2, 1].into(), [192, 0, 2, 2].into()
-                    ]
-                ).unwrap()
+                value::Ipv4Hint::<Octets512>::from_addrs([
+                    [192, 0, 2, 1].into(),
+                    [192, 0, 2, 2].into()
+                ])
+                .unwrap()
             )
         );
     }
-
 
     //--- Builder
 
     #[test]
     fn empty_builder() {
         assert_eq!(
-            Builder512::empty().freeze::<Octets512>().unwrap().as_slice(),
+            Builder512::empty()
+                .freeze::<Octets512>()
+                .unwrap()
+                .as_slice(),
             b""
         );
     }
@@ -1154,15 +1153,15 @@ mod test {
     #[test]
     fn three_values_in_order() {
         let mut builder = Builder512::empty();
-        builder.push(
-            &UnknownSvcParam::new(1.into(), b"223").unwrap()
-        ).unwrap();
-        builder.push(
-            &UnknownSvcParam::new(2.into(), b"224").unwrap()
-        ).unwrap();
-        builder.push(
-            &UnknownSvcParam::new(8.into(), b"225").unwrap()
-        ).unwrap();
+        builder
+            .push(&UnknownSvcParam::new(1.into(), b"223").unwrap())
+            .unwrap();
+        builder
+            .push(&UnknownSvcParam::new(2.into(), b"224").unwrap())
+            .unwrap();
+        builder
+            .push(&UnknownSvcParam::new(8.into(), b"225").unwrap())
+            .unwrap();
         assert_eq!(
             builder.freeze::<Octets512>().unwrap().as_slice(),
             b"\x00\x01\x00\x03223\
@@ -1174,15 +1173,15 @@ mod test {
     #[test]
     fn three_values_out_of_order() {
         let mut builder = Builder512::empty();
-        builder.push(
-            &UnknownSvcParam::new(1.into(), b"223").unwrap()
-        ).unwrap();
-        builder.push(
-            &UnknownSvcParam::new(8.into(), b"225").unwrap()
-        ).unwrap();
-        builder.push(
-            &UnknownSvcParam::new(2.into(), b"224").unwrap()
-        ).unwrap();
+        builder
+            .push(&UnknownSvcParam::new(1.into(), b"223").unwrap())
+            .unwrap();
+        builder
+            .push(&UnknownSvcParam::new(8.into(), b"225").unwrap())
+            .unwrap();
+        builder
+            .push(&UnknownSvcParam::new(2.into(), b"224").unwrap())
+            .unwrap();
         assert_eq!(
             builder.freeze::<Octets512>().unwrap().as_slice(),
             b"\x00\x01\x00\x03223\
@@ -1194,17 +1193,14 @@ mod test {
     #[test]
     fn three_values_with_collision() {
         let mut builder = Builder512::empty();
-        builder.push(
-            &UnknownSvcParam::new(1.into(), b"223").unwrap()
-        ).unwrap();
-        builder.push(
-            &UnknownSvcParam::new(8.into(), b"225").unwrap()
-        ).unwrap();
-        assert!(
-            builder.push(
-                &UnknownSvcParam::new(8.into(), b"224").unwrap()
-            ).is_err()
-        );
+        builder
+            .push(&UnknownSvcParam::new(1.into(), b"223").unwrap())
+            .unwrap();
+        builder
+            .push(&UnknownSvcParam::new(8.into(), b"225").unwrap())
+            .unwrap();
+        assert!(builder
+            .push(&UnknownSvcParam::new(8.into(), b"224").unwrap())
+            .is_err());
     }
 }
-

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -69,11 +69,10 @@ pub struct SvcParams<Octs: ?Sized> {
     #[cfg_attr(
         feature = "serde",
         serde(
-            serialize_with = "octseq::serde::serialize",
-            deserialize_with = "octseq::serde::DeserializeOctets::deserialize_octets",
+            with = "octseq::serde",
             bound(
                 serialize = "Octs: AsRef<[u8]>",
-                deserialize = "Octs: octseq::serde::DeserializeOctets<'de> + Sized",
+                deserialize = "Octs: octseq::serde::DeserializeOctets<'de>",
             )
         )
     )]

--- a/src/rdata/tsig.rs
+++ b/src/rdata/tsig.rs
@@ -43,8 +43,7 @@ pub struct Tsig<Octs, Name> {
     #[cfg_attr(
         feature = "serde",
         serde(
-            serialize_with = "octseq::serde::serialize",
-            deserialize_with = "octseq::serde::DeserializeOctets::deserialize_octets",
+            with = "octseq::serde",
             bound(
                 serialize = "Octs: AsRef<[u8]>",
                 deserialize = "Octs: octseq::serde::DeserializeOctets<'de>",
@@ -67,8 +66,7 @@ pub struct Tsig<Octs, Name> {
     #[cfg_attr(
         feature = "serde",
         serde(
-            serialize_with = "octseq::serde::serialize",
-            deserialize_with = "octseq::serde::DeserializeOctets::deserialize_octets",
+            with = "octseq::serde",
             bound(
                 serialize = "Octs: AsRef<[u8]>",
                 deserialize = "Octs: octseq::serde::DeserializeOctets<'de>",

--- a/src/rdata/zonemd.rs
+++ b/src/rdata/zonemd.rs
@@ -29,10 +29,10 @@ pub struct Zonemd<Octs: ?Sized> {
     #[cfg_attr(
         feature = "serde",
         serde(
-            serialize_with = "octseq::serde::SerializeOctets::serialize_octets",
+            serialize_with = "octseq::serde::serialize",
             deserialize_with = "octseq::serde::DeserializeOctets::deserialize_octets",
             bound(
-                serialize = "Octs: octseq::serde::SerializeOctets",
+                serialize = "Octs: AsRef<[u8]>",
                 deserialize = "Octs: octseq::serde::DeserializeOctets<'de>",
             )
         )

--- a/src/rdata/zonemd.rs
+++ b/src/rdata/zonemd.rs
@@ -29,8 +29,7 @@ pub struct Zonemd<Octs: ?Sized> {
     #[cfg_attr(
         feature = "serde",
         serde(
-            serialize_with = "octseq::serde::serialize",
-            deserialize_with = "octseq::serde::DeserializeOctets::deserialize_octets",
+            with = "octseq::serde",
             bound(
                 serialize = "Octs: AsRef<[u8]>",
                 deserialize = "Octs: octseq::serde::DeserializeOctets<'de>",

--- a/src/utils/base16.rs
+++ b/src/utils/base16.rs
@@ -106,20 +106,20 @@ pub fn encode_display<Octets: AsRef<[u8]> + ?Sized>(
 pub mod serde {
     use core::fmt;
     use octseq::builder::{EmptyBuilder, FromBuilder, OctetsBuilder};
-    use octseq::serde::{DeserializeOctets, SerializeOctets};
+    use octseq::serde::DeserializeOctets;
 
     pub fn serialize<Octets, S>(
         octets: &Octets,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
-        Octets: AsRef<[u8]> + SerializeOctets,
+        Octets: AsRef<[u8]>,
         S: serde::Serializer,
     {
         if serializer.is_human_readable() {
             serializer.collect_str(&super::encode_display(octets))
         } else {
-            octets.serialize_octets(serializer)
+            octseq::serde::serialize(octets, serializer)
         }
     }
 

--- a/src/utils/base32.rs
+++ b/src/utils/base32.rs
@@ -136,20 +136,20 @@ pub fn encode_display_hex<Octets: AsRef<[u8]>>(
 pub mod serde {
     use core::fmt;
     use octseq::builder::{EmptyBuilder, FromBuilder, OctetsBuilder};
-    use octseq::serde::{DeserializeOctets, SerializeOctets};
+    use octseq::serde::DeserializeOctets;
 
     pub fn serialize<Octets, S>(
         octets: &Octets,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
-        Octets: AsRef<[u8]> + SerializeOctets,
+        Octets: AsRef<[u8]>,
         S: serde::Serializer,
     {
         if serializer.is_human_readable() {
             serializer.collect_str(&super::encode_display_hex(octets))
         } else {
-            octets.serialize_octets(serializer)
+            octseq::serde::serialize(octets, serializer)
         }
     }
 

--- a/src/utils/base64.rs
+++ b/src/utils/base64.rs
@@ -123,20 +123,20 @@ pub mod serde {
     use super::encode_display;
     use core::fmt;
     use octseq::builder::{EmptyBuilder, FromBuilder, OctetsBuilder};
-    use octseq::serde::{DeserializeOctets, SerializeOctets};
+    use octseq::serde::DeserializeOctets;
 
     pub fn serialize<Octets, S>(
         octets: &Octets,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
-        Octets: AsRef<[u8]> + SerializeOctets,
+        Octets: AsRef<[u8]>,
         S: serde::Serializer,
     {
         if serializer.is_human_readable() {
             serializer.collect_str(&encode_display(octets))
         } else {
-            octets.serialize_octets(serializer)
+            octseq::serde::serialize(octets, serializer)
         }
     }
 


### PR DESCRIPTION
In its current version, this needs to be paired with a new function in `octseq`: https://github.com/NLnetLabs/octseq/pull/57.

This makes the bounds more clear. It's a breaking change in a few places where _only_ `SerializeOctets` was specified and not `AsRef<[u8]>`, altough everything that implements `SerializeOctets` already implements `AsRef<[u8]>`, because `AsRef<[u8]>` is a supertrait of `Octets`, so fixing the bounds is easy.

I also think that this conceptually simplifies the serialization: we only need to look at the octets to serialize them, that functionality does not need to differ between the types.

Marking as draft because we should first land the other PR in `octseq`.