### PR TITLE
Add an optional push limit to `MessageBuilder`.

### DIFF
--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -2432,6 +2432,7 @@ mod test {
         assert_eq!(rr.data(), &A::from_octets(192, 0, 2, 1));
     }
 
+    #[cfg(feature = "heapless")]
     #[test]
     fn exceed_limits() {
         // Create a limited message builder.


### PR DESCRIPTION
This is useful when wanting to "reserve" space such that pushes to a message at one point in the code  will leave enough room for subsequent pushes later, e.g. of OPT or TSIG RRs.

Note: I initially implemented this using `Option<u16>` but:
- `MessageBuilder` doesn't itself impose a 65k limit on messages so `u16` is not appropriate.
- Testing >= against `Option<usize>` felt clumsy and slightly less efficient than just comparing to `usize::MAX` and `usize::MAX` seems a safe enough hack, but if not we can use `Option` if that is felt to be safer/better.