### PR TITLE
Fix zone walking to include non-leaf CNAMEs

### DIFF
--- a/src/zonetree/in_memory/read.rs
+++ b/src/zonetree/in_memory/read.rs
@@ -101,7 +101,22 @@ impl ReadZone {
                 answer
             }
             Some(Special::NxDomain) => NodeAnswer::nx_domain(),
-            Some(Special::Cname(_)) | None => self.query_children(
+            Some(Special::Cname(cname)) => {
+                if walk.enabled() {
+                    let mut rrset = Rrset::new(Rtype::CNAME, cname.ttl());
+                    rrset.push_data(cname.data().clone());
+                    walk.op(&SharedRrset::new(rrset));
+                }
+
+                self.query_children(
+                    node.children(),
+                    label,
+                    qname,
+                    qtype,
+                    walk,
+                )
+            }
+            None => self.query_children(
                 node.children(),
                 label,
                 qname,


### PR DESCRIPTION
Querying a zone for a CNAME works, but when walking the zone (e.g. for diagnostic dumping or to do AXFR) a CNAME that is not at a leaf node (i.e. a CNAME at a.example.com while there also exists a deeper b.a.example.com leaf node) is incorrectly skipped by the current zone walking code.

This PR adds the missing code to emit the non-leaf CNAME to the zone walker callback operation.

This PR does NOT include unit tests to cover this fix because (a) there are no existing unit tests for this code and writing an entire set would time that I don't have right now, (b) strict unit tests are not really possible because they would also have to exercise the code in `nodes.rs` to construct the tree before wakling it and so some sort of "integration" test is needed, and (c) the new XFR work being done for PR #335 will include Stelline tests that walk zones (for AXFR) and should visit all parts of the tree.

While the Stelline tests will be at the outermost testing layer, exercising domain as a black box, so one could perhaps argue that testing somewhere nearer to the tree walking code would also be good to have, they will at least address the immediate need to exercise the entire zone walking code.