### PR TITLE
Fix EDNS middleware bugs

### DIFF
--- a/src/net/server/middleware/edns.rs
+++ b/src/net/server/middleware/edns.rs
@@ -10,9 +10,9 @@ use tracing::{debug, enabled, error, trace, warn, Level};
 use crate::base::iana::OptRcode;
 use crate::base::message_builder::AdditionalBuilder;
 use crate::base::opt::keepalive::IdleTimeout;
-use crate::base::opt::{Opt, OptRecord, TcpKeepalive};
+use crate::base::opt::{ComposeOptData, Opt, OptRecord, TcpKeepalive};
 use crate::base::wire::Composer;
-use crate::base::StreamTarget;
+use crate::base::{Name, StreamTarget};
 use crate::net::server::message::{Request, TransportSpecificContext};
 use crate::net::server::middleware::stream::MiddlewareStream;
 use crate::net::server::service::{CallResult, Service, ServiceResult};
@@ -22,6 +22,8 @@ use crate::net::server::util::{
 
 use super::mandatory::MINIMUM_RESPONSE_BYTE_LEN;
 use super::stream::PostprocessingStream;
+use crate::base::name::ToLabelIter;
+use core::time::Duration;
 
 /// EDNS version 0.
 ///
@@ -108,36 +110,124 @@ where
                     ));
                 }
 
-                if let Ok(opt) = opt {
-                    let opt_rec = OptRecord::from(opt);
-
-                    // https://datatracker.ietf.org/doc/html/rfc6891#section-6.1.3
-                    // 6.1.3. OPT Record TTL Field Use
-                    //   "If a responder does not implement the VERSION level
-                    //    of the request, then it MUST respond with
-                    //    RCODE=BADVERS."
-                    if opt_rec.version() > EDNS_VERSION_ZERO {
-                        debug!("RFC 6891 6.1.3 violation: request EDNS version {} > 0", opt_rec.version());
+                let opt = match opt {
+                    Ok(opt) => opt,
+                    Err(err) => {
+                        debug!("RFC 6891 violation: unable to parse OPT RR: {err}");
                         return ControlFlow::Break(mk_error_response(
                             request.message(),
-                            OptRcode::BADVERS,
+                            OptRcode::FORMERR,
                         ));
                     }
+                };
 
-                    match request.transport_ctx() {
-                        TransportSpecificContext::Udp(ctx) => {
-                            // https://datatracker.ietf.org/doc/html/rfc7828#section-3.2.1
-                            // 3.2.1. Sending Queries
-                            //   "DNS clients MUST NOT include the
-                            //    edns-tcp-keepalive option in queries sent
-                            //    using UDP transport."
-                            // TODO: We assume there is only one keep-alive
-                            // option in the request. Should we check for
-                            // multiple? Neither RFC 6891 nor RFC 7828 seem to
-                            // disallow multiple keep alive options in the OPT
-                            // RDATA but multiple at once seems strange.
-                            if opt_rec.opt().tcp_keepalive().is_some() {
-                                debug!("RFC 7828 3.2.1 violation: edns-tcp-keepalive option received via UDP");
+                let opt_rec = OptRecord::from(opt);
+
+                // https://datatracker.ietf.org/doc/html/rfc6891#section-6.1.3
+                // 6.1.3. OPT Record TTL Field Use
+                //   "If a responder does not implement the VERSION level of
+                //    the request, then it MUST respond with RCODE=BADVERS."
+                if opt_rec.version() > EDNS_VERSION_ZERO {
+                    debug!("RFC 6891 6.1.3 violation: request EDNS version {} > 0", opt_rec.version());
+                    return ControlFlow::Break(mk_error_response(
+                        request.message(),
+                        OptRcode::BADVERS,
+                    ));
+                }
+
+                match request.transport_ctx() {
+                    TransportSpecificContext::Udp(ctx) => {
+                        // https://datatracker.ietf.org/doc/html/rfc7828#section-3.3.1
+                        // 3.3.1.  Receiving Queries
+                        //   "A DNS server that receives a query using UDP
+                        //    transport that includes the edns-tcp-keepalive
+                        //    option MUST ignore the option."
+                        if enabled!(Level::DEBUG)
+                            && opt_rec.opt().tcp_keepalive().is_some()
+                        {
+                            debug!("RFC 7828 3.2.1 violation: ignoring edns-tcp-keepalive option received via UDP");
+                        }
+
+                        // https://datatracker.ietf.org/doc/html/rfc6891#section-6.2.3
+                        // 6.2.3. Requestor's Payload Size
+                        //   "The requestor's UDP payload size (encoded in the
+                        //    RR CLASS field) is the number of octets of the
+                        //    largest UDP payload that can be reassembled and
+                        //    delivered in the requestor's network stack. Note
+                        //    that path MTU, with or without fragmentation,
+                        //    could be smaller than this.
+                        //
+                        //    Values lower than 512 MUST be treated as equal
+                        //    to 512."
+                        let requestors_udp_payload_size =
+                            opt_rec.udp_payload_size();
+
+                        if enabled!(Level::DEBUG)
+                            && requestors_udp_payload_size
+                                < MINIMUM_RESPONSE_BYTE_LEN
+                        {
+                            debug!("RFC 6891 6.2.3 violation: OPT RR class (requestor's UDP payload size) < {MINIMUM_RESPONSE_BYTE_LEN}");
+                        }
+
+                        // Clamp the lower bound of the size limit requested
+                        // by the client:
+                        let clamped_requestors_udp_payload_size = u16::max(
+                            MINIMUM_RESPONSE_BYTE_LEN,
+                            requestors_udp_payload_size,
+                        );
+
+                        // Clamp the upper bound of the size limit requested
+                        // by the server:
+                        let server_max_response_size_hint =
+                            ctx.max_response_size_hint();
+                        let clamped_server_hint =
+                            server_max_response_size_hint.map(|v| {
+                                v.clamp(
+                                    MINIMUM_RESPONSE_BYTE_LEN,
+                                    clamped_requestors_udp_payload_size,
+                                )
+                            });
+
+                        // Use the clamped client size limit if no server hint
+                        // exists, otherwise use the smallest of the client
+                        // and server limits while not going lower than 512
+                        // bytes.
+                        let negotiated_hint = match clamped_server_hint {
+                            Some(clamped_server_hint) => u16::min(
+                                clamped_requestors_udp_payload_size,
+                                clamped_server_hint,
+                            ),
+
+                            None => clamped_requestors_udp_payload_size,
+                        };
+
+                        if enabled!(Level::TRACE) {
+                            trace!("EDNS(0) response size negotation concluded: client requested={}, server requested={:?}, chosen value={}",
+                                opt_rec.udp_payload_size(), server_max_response_size_hint, negotiated_hint);
+                        }
+
+                        ctx.set_max_response_size_hint(Some(negotiated_hint));
+
+                        // https://datatracker.ietf.org/doc/html/rfc6891#section-6.1.1
+                        // 6.1.1. Basic Elements
+                        //   "If an OPT record is present in a received
+                        //    request, compliant responders MUST include an
+                        //    OPT record in their respective responses."
+                        return Self::reserve_space_for_keep_alive_opt(
+                            request, None,
+                        );
+                    }
+
+                    TransportSpecificContext::NonUdp(ctx) => {
+                        // https://datatracker.ietf.org/doc/html/rfc7828#section-3.2.1
+                        // 3.2.1. Sending Queries
+                        //   "Clients MUST specify an OPTION-LENGTH of 0 and
+                        //    omit the TIMEOUT value."
+                        if let Some(keep_alive) =
+                            opt_rec.opt().tcp_keepalive()
+                        {
+                            if keep_alive.timeout().is_some() {
+                                debug!("RFC 7828 3.2.1 violation: edns-tcp-keepalive option received via TCP contains timeout");
                                 return ControlFlow::Break(
                                     mk_error_response(
                                         request.message(),
@@ -145,86 +235,17 @@ where
                                     ),
                                 );
                             }
-
-                            // https://datatracker.ietf.org/doc/html/rfc6891#section-6.2.3
-                            // 6.2.3. Requestor's Payload Size
-                            //   "The requestor's UDP payload size (encoded in
-                            //    the RR CLASS field) is the number of octets
-                            //    of the largest UDP payload that can be
-                            //    reassembled and delivered in the requestor's
-                            //    network stack. Note that path MTU, with or
-                            //    without fragmentation, could be smaller than
-                            //    this.
-                            //
-                            //    Values lower than 512 MUST be treated as
-                            //    equal to 512."
-                            let requestors_udp_payload_size =
-                                opt_rec.udp_payload_size();
-
-                            if requestors_udp_payload_size
-                                < MINIMUM_RESPONSE_BYTE_LEN
-                            {
-                                debug!("RFC 6891 6.2.3 violation: OPT RR class (requestor's UDP payload size) < {MINIMUM_RESPONSE_BYTE_LEN}");
-                            }
-
-                            // Clamp the lower bound of the size limit
-                            // requested by the client:
-                            let clamped_requestors_udp_payload_size =
-                                u16::max(512, requestors_udp_payload_size);
-
-                            // Clamp the upper bound of the size limit
-                            // requested by the server:
-                            let server_max_response_size_hint =
-                                ctx.max_response_size_hint();
-                            let clamped_server_hint =
-                                server_max_response_size_hint.map(|v| {
-                                    v.clamp(
-                                        MINIMUM_RESPONSE_BYTE_LEN,
-                                        clamped_requestors_udp_payload_size,
-                                    )
-                                });
-
-                            // Use the clamped client size limit if no server hint exists,
-                            // otherwise use the smallest of the client and server limits
-                            // while not going lower than 512 bytes.
-                            let negotiated_hint = match clamped_server_hint {
-                                Some(clamped_server_hint) => u16::min(
-                                    clamped_requestors_udp_payload_size,
-                                    clamped_server_hint,
-                                ),
-
-                                None => clamped_requestors_udp_payload_size,
-                            };
-
-                            if enabled!(Level::TRACE) {
-                                trace!("EDNS(0) response size negotation concluded: client requested={}, server requested={:?}, chosen value={}",
-                                    opt_rec.udp_payload_size(), server_max_response_size_hint, negotiated_hint);
-                            }
-
-                            ctx.set_max_response_size_hint(Some(
-                                negotiated_hint,
-                            ));
                         }
 
-                        TransportSpecificContext::NonUdp(_) => {
-                            // https://datatracker.ietf.org/doc/html/rfc7828#section-3.2.1
-                            // 3.2.1. Sending Queries
-                            //   "Clients MUST specify an OPTION-LENGTH of 0
-                            //    and omit the TIMEOUT value."
-                            if let Some(keep_alive) =
-                                opt_rec.opt().tcp_keepalive()
-                            {
-                                if keep_alive.timeout().is_some() {
-                                    debug!("RFC 7828 3.2.1 violation: edns-tcp-keepalive option received via TCP contains timeout");
-                                    return ControlFlow::Break(
-                                        mk_error_response(
-                                            request.message(),
-                                            OptRcode::FORMERR,
-                                        ),
-                                    );
-                                }
-                            }
-                        }
+                        // https://datatracker.ietf.org/doc/html/rfc6891#section-6.1.1
+                        // 6.1.1. Basic Elements
+                        //   "If an OPT record is present in a received
+                        //    request, compliant responders MUST include an
+                        //    OPT record in their respective responses."
+                        return Self::reserve_space_for_keep_alive_opt(
+                            request,
+                            ctx.idle_timeout(),
+                        );
                     }
                 }
             }
@@ -320,6 +341,52 @@ where
         // TODO: For UDP EDNS capable clients (those that included an OPT
         // record in the request) should we set the Requestor's Payload Size
         // field to some value?
+    }
+
+    fn reserve_space_for_keep_alive_opt(
+        request: &mut Request<RequestOctets, RequestMeta>,
+        timeout: Option<Duration>,
+    ) -> ControlFlow<AdditionalBuilder<StreamTarget<NextSvc::Target>>> {
+        let keep_alive_option_len = match timeout {
+            Some(timeout) => {
+                match IdleTimeout::try_from(timeout) {
+                    Ok(idle_timeout) => {
+                        let option_data =
+                            TcpKeepalive::new(Some(idle_timeout));
+                        // OPTION-CODE + OPTION-LENGTH + OPTION-DATA
+                        2 + 2 + option_data.compose_len()
+                    }
+                    Err(err) => {
+                        debug!("RFC 7828 3.1 violation: unable to parse edns-tcp-keepalive timeout value: {err}");
+                        return ControlFlow::Break(mk_error_response(
+                            request.message(),
+                            OptRcode::FORMERR,
+                        ));
+                    }
+                }
+            }
+            None => 0,
+        };
+
+        let root_name_len = Name::root_ref().compose_len();
+
+        // See:
+        //  - https://datatracker.ietf.org/doc/html/rfc1035#section-3.2.1
+        //  - https://datatracker.ietf.org/doc/html/rfc6891#autoid-12
+        //  - https://datatracker.ietf.org/doc/html/rfc7828#section-3.1
+
+        // Calculate the size of the DNS OPTION RR that will be added to the
+        // response during post-processing.
+        let wire_opt_len = root_name_len // "0" root domain name per RFC 6891
+            + 2 // TYPE
+            + 2 // CLASS
+            + 4 // TTL
+            + 2 // RDLEN
+            + keep_alive_option_len; // OPTION-DATA
+
+        request.reserve_bytes(wire_opt_len);
+
+        ControlFlow::Continue(())
     }
 
     fn map_stream_item(

--- a/src/net/server/tests/integration.rs
+++ b/src/net/server/tests/integration.rs
@@ -358,9 +358,13 @@ fn mk_client_factory(
                         simple_dgram_client::Connection::new(connect),
                     )),
 
-                    _ => Client::Single(Box::new(dgram::Connection::new(
-                        connect,
-                    ))),
+                    _ => {
+                        let mut config = dgram::Config::new();
+                        config.set_max_retries(0);
+                        Client::Single(Box::new(
+                            dgram::Connection::with_config(connect, config),
+                        ))
+                    }
                 }
             }
         },

--- a/test-data/server/edns_keepalive.rpl
+++ b/test-data/server/edns_keepalive.rpl
@@ -1,103 +1,194 @@
 ; Based on: https://github.com/NLnetLabs/unbound/blob/49e425810275917e7fd09a24bae3b97d83b55c13/testdata/edns_keepalive.rpl
+
+;------------ Server configuration --------------------------------------------
+
 server:
     edns-tcp-keepalive: yes
+    ; specify the timeout that the client should honour, in milliseconds
     edns-tcp-keepalive-timeout: 30000
 
     ; Define an in-memory zone to be served by the server.
     local-data: "test.  3600  IN  SOA  ns.test. hostmaster.test. 1 3600 900 86400 3600"
-    local-data: "test. TXT test"
+    local-data: "test.            TXT  test"
 CONFIG_END
 
-SCENARIO_BEGIN TCP Keepalive
+;------------ Test definition ------------------------------------------------
 
-;; ----------------------------------------
+SCENARIO_BEGIN Test RFC 7828 DNS TCP keep-alive support.
 
-STEP 1 QUERY
+;--- Mock replies
 
-     ENTRY_BEGIN
-        MATCH TCP ednsdata
-        REPLY RD
-        SECTION QUESTION
-                test. IN TXT
-        SECTION ADDITIONAL
-                HEX_EDNSDATA_BEGIN
-                        00 0b           ; Opcode 11
-                        00 02           ; Length 2
-                        00 ff           ; Timeout
-                HEX_EDNSDATA_END
-     ENTRY_END
+; None
 
-STEP 10 CHECK_ANSWER
+;--- Test steps
 
-     ENTRY_BEGIN
-        MATCH TCP
-        REPLY RD FORMERR
-        SECTION QUESTION
-                test. IN TXT
-     ENTRY_END
+; https://datatracker.ietf.org/doc/html/rfc7828#section-3.2.1
+;   "Clients MUST specify an OPTION-LENGTH of 0 and omit the TIMEOUT
+;    value."
+STEP 10 QUERY
+ENTRY_BEGIN
+MATCH TCP ednsdata
+REPLY RD
+SECTION QUESTION
+    test. IN TXT
+SECTION ADDITIONAL
+HEX_EDNSDATA_BEGIN
+    00 0b  ; Opcode 11
+    00 02  ; Length 2 - this should be zero
+    00 ff  ; Timeout - these bytes should not be present
+HEX_EDNSDATA_END
+ENTRY_END
+; ... get a FORMERR answer.
+STEP 11 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH TCP
+REPLY RD FORMERR
+SECTION QUESTION
+    test. IN TXT
+ENTRY_END
 
+; https://datatracker.ietf.org/doc/html/rfc7828#section-3.3.1
+;   "A DNS server that receives a query using UDP transport that includes the
+;    edns-tcp-keepalive option MUST ignore the option."
 STEP 20 QUERY
+ENTRY_BEGIN
+MATCH UDP ednsdata
+REPLY RD
+SECTION QUESTION
+    test. IN TXT
+SECTION ADDITIONAL
+HEX_EDNSDATA_BEGIN
+    00 0b  ; Opcode 11
+    00 00  ; Length 0
+HEX_EDNSDATA_END
+ENTRY_END
+; ... get a FORMERR answer.
+STEP 21 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH UDP
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+    test. IN TXT
+SECTION ANSWER
+    test. IN TXT "test"
+ENTRY_END
 
-     ENTRY_BEGIN
-        MATCH TCP ednsdata
-        REPLY RD
-        SECTION QUESTION
-                test. IN TXT
-        SECTION ADDITIONAL
-                HEX_EDNSDATA_BEGIN
-                        00 0b           ; Opcode 11
-                        00 00           ; Length 0
-                HEX_EDNSDATA_END
-     ENTRY_END
+; https://datatracker.ietf.org/doc/html/rfc7828#section-3.2.1
+;   "DNS clients MAY include the edns-tcp-keepalive option in the first query
+;    sent to a server using TCP transport to signal their desire to keep the
+;    connection open when idle.
+;    ...
+;    Clients MUST specify an OPTION-LENGTH of 0 and omit the TIMEOUT value."
+STEP 30 QUERY
+ENTRY_BEGIN
+MATCH TCP ednsdata
+REPLY RD
+SECTION QUESTION
+    test. IN TXT
+SECTION ADDITIONAL
+HEX_EDNSDATA_BEGIN
+    00 0b  ; Opcode 11
+    00 00  ; Length 0
+HEX_EDNSDATA_END
+ENTRY_END
+; ... get a NOERROR answer with the servers timeout for this TCP session.
+STEP 31 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH TCP ednsdata
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+    test. IN TXT
+SECTION ANSWER
+    test. IN TXT "test"
+SECTION ADDITIONAL
+HEX_EDNSDATA_BEGIN
+    00 0b  ; Opcode 11
+    00 02  ; Length 2
+    01 2c  ; 300, to be interpreted as 300 * 100ms = 30000ms as configured.
+HEX_EDNSDATA_END
+ENTRY_END
 
-STEP 30 CHECK_ANSWER
+; https://datatracker.ietf.org/doc/html/rfc7828#section-1
+; 1. Introduction
+;   ...
+;   "If a server is to perform adequately with a significant query load received
+;    over TCP, it must manage its available resources to ensure that all
+;    established TCP sessions are well-used, and idle connections are closed
+;    after an appropriate amount of time."
+; And:
+; https://datatracker.ietf.org/doc/html/rfc7828#section-3.2.2
+;   "A DNS client that receives a response using TCP transport that includes the
+;    edns-tcp-keepalive option MAY keep the existing TCP session open when it is
+;    idle.  It SHOULD honour the timeout received in that response (overriding
+;    any previous timeout) and initiate close of the connection before the
+;    timeout expires."
+; And:
+; https://datatracker.ietf.org/doc/html/rfc7828#section-3.4
+;   "DNS clients and servers MAY close a TCP session at any time in order to
+;    manage local resource constraints."
+; And:
+; https://datatracker.ietf.org/doc/html/rfc7828#section-5
+;   "When a DNS server detects abusive behaviour, it SHOULD immediately close
+;    the TCP connection and free the resources used."
+;
+; In our case the edns-tcp-keepalive-timeout value is passed to
+; net::server::stream via the connection::Config::idle_timeout setting, and
+; the server will close the connection after that much idle time has elapsed.
+; So just before the timeout the connection should still be open, and just
+; after it the connection should have been closed.
+ 
+STEP 40 TIME_PASSES ELAPSE 29 ; (25 seconds < 30000 milliseconds)
 
-     ENTRY_BEGIN
-        MATCH TCP ednsdata
-        REPLY QR RD RA NOERROR
-        SECTION QUESTION
-                test. IN TXT
-        SECTION ANSWER
-                test. IN TXT "test"
-        SECTION ADDITIONAL
-                HEX_EDNSDATA_BEGIN
-                        00 0b           ; Opcode 11
-                        00 02           ; Length 2
-                        01 2c           ; 30s = 300 10th secs
-                HEX_EDNSDATA_END
-     ENTRY_END
+STEP 50 QUERY
+ENTRY_BEGIN
+MATCH TCP ednsdata
+REPLY RD
+SECTION QUESTION
+    test. IN TXT
+SECTION ADDITIONAL
+HEX_EDNSDATA_BEGIN
+    00 0b  ; Opcode 11
+    00 00  ; Length 0
+HEX_EDNSDATA_END
+ENTRY_END
+; ... get a NOERROR answer with the servers timeout for this TCP session.
+STEP 51 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH TCP ednsdata
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+    test. IN TXT
+SECTION ANSWER
+    test. IN TXT "test"
+SECTION ADDITIONAL
+HEX_EDNSDATA_BEGIN
+    00 0b  ; Opcode 11
+    00 02  ; Length 2
+    01 2c  ; 300, to be interpreted as 300 * 100ms = 30000ms as configured.
+HEX_EDNSDATA_END
+ENTRY_END
 
-; Check that a subsequent query on the connection without keepalive will
-; generate a keepalive reply because we've already seen one.
+STEP 60 TIME_PASSES ELAPSE 31 ; (31 seconds > 30000 milliseconds)
 
-STEP 40 QUERY
-
-     ENTRY_BEGIN
-        MATCH TCP ednsdata
-        REPLY RD
-        SECTION QUESTION
-                test. IN TXT
-        SECTION ADDITIONAL
-                HEX_EDNSDATA_BEGIN
-                        ; Empty
-                HEX_EDNSDATA_END
-     ENTRY_END
-
-STEP 50 CHECK_ANSWER
-
-     ENTRY_BEGIN
-        MATCH TCP ednsdata
-        REPLY QR RD RA NOERROR
-        SECTION QUESTION
-                test. IN TXT
-        SECTION ANSWER
-                test. IN TXT "test"
-        SECTION ADDITIONAL
-                HEX_EDNSDATA_BEGIN
-                        00 0b           ; Opcode 11
-                        00 02           ; Length 2
-                        01 2c           ; 30s = 300 10th secs
-                HEX_EDNSDATA_END
-     ENTRY_END
+STEP 70 QUERY
+ENTRY_BEGIN
+MATCH TCP ednsdata
+REPLY RD
+SECTION QUESTION
+    test. IN TXT
+SECTION ADDITIONAL
+HEX_EDNSDATA_BEGIN
+    00 0b  ; Opcode 11
+    00 00  ; Length 0
+HEX_EDNSDATA_END
+ENTRY_END
+; ... get a connection closed error.
+STEP 71 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH TCP CONNECTION_CLOSED
+REPLY RD FORMERR
+SECTION QUESTION
+    test. IN TXT
+ENTRY_END
 
 SCENARIO_END


### PR DESCRIPTION
Various EDNS middleware fixes and improved Stelline test:

- Reply with FORMERR if an OPT RR cannot be parsed.
- Don't reply with FORMERR if an edns-tcp-keepalive option is received via UDP, instead ignore it per RFC 7828 3.2.1.
- Only reserve space for an edns-tcp-keepalive option for TCP requests, not UDP requests.
- Always reserve space for an OPT RR in the response for any request that has an OPT RR, not just TCP requests.
- Disable TCP client retries in Stelline server tests otherwise a connection abort causes a retry which violates the test expectation.
- Fixes a bug in Stelline where it fails to catch that an expected connection termination actually didn't happen.
