### PR TITLE
Fix TSIG server sequence signing and switch test to dig.

### DIFF
--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -897,7 +897,7 @@ impl<K: AsRef<Key>> ServerSequence<K> {
         SigningContext::server_request(store, message, now).map(|context| {
             context.map(|context| ServerSequence {
                 context,
-                first: false,
+                first: true,
             })
         })
     }
@@ -943,6 +943,7 @@ impl<K: AsRef<Key>> ServerSequence<K> {
                 &variables,
             )
         };
+        self.context.apply_signature(mac.as_ref());
         let mac = self.key().signature_slice(&mac);
         self.key().complete_message(message, &variables, mac)
     }


### PR DESCRIPTION
This PR fixes an issue with signature generation in the TSIG server sequence, i.e., when the answer to a request signed with a TSIG key has multiple messages.

This issue wasn’t caught by the interop test since drill happily consumed to wrong signatures. Consequently, this PR switches the test to use dig which won’t error out but at least complain about them in the output.