### PR TITLE
Service enhancement prerequisites for XFR support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tokio-test",
  "tokio-tfo",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ siphasher      = { version = "1", optional = true }
 smallvec       = { version = "1.3", optional = true }
 tokio          = { version = "1.33", optional = true, features = ["io-util", "macros", "net", "time", "sync", "rt-multi-thread" ] }
 tokio-rustls   = { version = "0.26", optional = true, default-features = false }
+tokio-stream   = { version = "0.1.1", optional = true }
 tracing        = { version = "0.1.40", optional = true }
 tracing-subscriber = { version = "0.3.18", optional = true, features = ["env-filter"] }
 

--- a/examples/serve-zone.rs
+++ b/examples/serve-zone.rs
@@ -80,9 +80,9 @@ async fn main() {
     let svc = service_fn(my_service, zones);
 
     #[cfg(feature = "siphasher")]
-    let svc = CookiesMiddlewareSvc::<Vec<u8>, _>::with_random_secret(svc);
-    let svc = EdnsMiddlewareSvc::<Vec<u8>, _>::new(svc);
-    let svc = MandatoryMiddlewareSvc::<Vec<u8>, _>::new(svc);
+    let svc = CookiesMiddlewareSvc::<Vec<u8>, _, _>::with_random_secret(svc);
+    let svc = EdnsMiddlewareSvc::<Vec<u8>, _, _>::new(svc);
+    let svc = MandatoryMiddlewareSvc::<Vec<u8>, _, _>::new(svc);
     let svc = Arc::new(svc);
 
     let sock = UdpSocket::bind(addr).await.unwrap();

--- a/examples/server-transports.rs
+++ b/examples/server-transports.rs
@@ -208,7 +208,7 @@ impl Service<Vec<u8>> for MyAsyncStreamingService {
 /// The function signature is slightly more complex than when using
 /// [`service_fn`] (see the [`query`] example below).
 #[allow(clippy::type_complexity)]
-fn name_to_ip(request: Request<Vec<u8>>) -> ServiceResult<Vec<u8>> {
+fn name_to_ip(request: Request<Vec<u8>>, _: ()) -> ServiceResult<Vec<u8>> {
     let mut out_answer = None;
     if let Ok(question) = request.message().sole_question() {
         let qname = question.qname();
@@ -542,6 +542,7 @@ where
             RequestOctets,
             Svc::Future,
             Svc::Stream,
+            (),
             Arc<RwLock<Stats>>,
         >,
         Empty<ServiceResult<Self::Target>>,
@@ -571,13 +572,18 @@ fn build_middleware_chain<Svc>(
 ) -> StatsMiddlewareSvc<
     MandatoryMiddlewareSvc<
         Vec<u8>,
-        EdnsMiddlewareSvc<Vec<u8>, CookiesMiddlewareSvc<Vec<u8>, Svc>>,
+        EdnsMiddlewareSvc<
+            Vec<u8>,
+            CookiesMiddlewareSvc<Vec<u8>, Svc, ()>,
+            (),
+        >,
+        (),
     >,
 > {
     #[cfg(feature = "siphasher")]
-    let svc = CookiesMiddlewareSvc::<Vec<u8>, _>::with_random_secret(svc);
-    let svc = EdnsMiddlewareSvc::<Vec<u8>, _>::new(svc);
-    let svc = MandatoryMiddlewareSvc::<Vec<u8>, _>::new(svc);
+    let svc = CookiesMiddlewareSvc::<Vec<u8>, _, _>::with_random_secret(svc);
+    let svc = EdnsMiddlewareSvc::<Vec<u8>, _, _>::new(svc);
+    let svc = MandatoryMiddlewareSvc::<Vec<u8>, _, _>::new(svc);
     StatsMiddlewareSvc::new(svc, stats.clone())
 }
 
@@ -633,8 +639,10 @@ async fn main() {
 
     // 2. name_to_ip: a service impl defined as a function compatible with the
     //               `Service` trait.
-    let name_into_ip_svc =
-        Arc::new(build_middleware_chain(name_to_ip, stats.clone()));
+    let name_into_ip_svc = Arc::new(build_middleware_chain(
+        service_fn(name_to_ip, ()),
+        stats.clone(),
+    ));
 
     // 3. query: a service impl defined as a function converted to a `Service`
     //           impl via the `service_fn()` helper function.
@@ -642,11 +650,11 @@ async fn main() {
     // creating a separate middleware chain for use just by this server.
     let count = Arc::new(AtomicU8::new(5));
     let svc = service_fn(query, count);
-    let svc = MandatoryMiddlewareSvc::<Vec<u8>, _>::new(svc);
+    let svc = MandatoryMiddlewareSvc::<Vec<u8>, _, _>::new(svc);
     #[cfg(feature = "siphasher")]
     let svc = {
         let server_secret = "server12secret34".as_bytes().try_into().unwrap();
-        CookiesMiddlewareSvc::<Vec<u8>, _>::new(svc, server_secret)
+        CookiesMiddlewareSvc::<Vec<u8>, _, _>::new(svc, server_secret)
     };
     let svc = StatsMiddlewareSvc::new(svc, stats.clone());
     let query_svc = Arc::new(svc);

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -21,9 +21,7 @@
 //! something that looks like a [`Record`]. Apart from actual values
 //! of these types, tuples of the components also work, such as a pair of a
 //! domain name and a record type for a question or a triple of the owner
-//! name, TTL, and record data for a record. If you already have a question
-//! or record, you can use the `push_ref` method to add
-//!
+//! name, TTL, and record data for a record.
 //!
 //! The `push` method of the record
 //! section builders is also available via the [`RecordSectionBuilder`]
@@ -868,16 +866,6 @@ impl<Target: Composer> AnswerBuilder<Target> {
     pub fn push(
         &mut self,
         record: impl ComposeRecord,
-    ) -> Result<(), PushError> {
-        self.builder.push(
-            |target| record.compose_record(target).map_err(Into::into),
-            |counts| counts.inc_ancount(),
-        )
-    }
-
-    pub fn push_ref(
-        &mut self,
-        record: &impl ComposeRecord,
     ) -> Result<(), PushError> {
         self.builder.push(
             |target| record.compose_record(target).map_err(Into::into),

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -1946,14 +1946,6 @@ where
     }
 }
 
-impl<Target> FreezeBuilder for StreamTarget<Target> {
-    type Octets = Target;
-
-    fn freeze(self) -> Self::Octets {
-        self.into_target()
-    }
-}
-
 //------------ StaticCompressor ----------------------------------------------
 
 /// A domain name compressor that doesn’t require an allocator.

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -274,14 +274,18 @@ impl<Target: Composer> MessageBuilder<Target> {
             header.set_qr(true);
             header.set_opcode(msg.header().opcode());
             header.set_rd(msg.header().rd());
+            header.set_rcode(rcode);
         }
+
         let mut builder = self.question();
         for item in msg.question().flatten() {
             if builder.push(item).is_err() {
+                builder.rewind();
+                builder.header_mut().set_rcode(Rcode::SERVFAIL);
                 break;
             }
         }
-        builder.header_mut().set_rcode(rcode);
+
         builder.answer()
     }
 

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -280,7 +280,6 @@ impl<Target: Composer> MessageBuilder<Target> {
         let mut builder = self.question();
         for item in msg.question().flatten() {
             if builder.push(item).is_err() {
-                builder.rewind();
                 builder.header_mut().set_rcode(Rcode::SERVFAIL);
                 break;
             }

--- a/src/net/server/connection.rs
+++ b/src/net/server/connection.rs
@@ -1,6 +1,5 @@
 //! Support for stream based connections.
 use core::ops::{ControlFlow, Deref};
-use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 
 use std::fmt::Display;
@@ -76,14 +75,6 @@ const RESPONSE_WRITE_TIMEOUT: DefMinMax<Duration> = DefMinMax::new(
     Duration::from_secs(60 * 60),
 );
 
-/// Limit on the number of attempts that will be made to overcome
-/// non-fatal write errors.
-///
-/// The value has to be between 0 and 255 with a default of 2. A value of
-/// zero means that one try will be attempted.
-const RESPONSE_WRITE_RETRIES: DefMinMax<u8> =
-    DefMinMax::new(2, u8::MIN, u8::MAX);
-
 /// Limit on the number of DNS responses queued for writing to the client.
 ///
 /// The value has to be between zero and 1,024. The default value is 10. These
@@ -115,11 +106,12 @@ pub struct Config {
 
     /// Limit on the amount of time to wait for writing a response to
     /// complete.
+    ///
+    /// The value has to be between 1 millisecond and 1 hour with a default of
+    /// 30 seconds. These values are guesses at something reasonable. The
+    /// default is based on the Unbound 1.19.2 default value for its
+    /// `tcp-idle-timeout` setting.
     response_write_timeout: Duration,
-
-    /// Limit on the number of attempts that will be made to overcome
-    /// non-fatal write errors.
-    response_write_retries: u8,
 
     /// Limit on the number of DNS responses queued for wriing to the client.
     max_queued_responses: usize,
@@ -182,16 +174,6 @@ impl Config {
         self.response_write_timeout = value;
     }
 
-    /// Limit on the number of attempts that will be made to overcome
-    /// non-fatal write errors.
-    ///
-    /// The value has to be between 0 and 255 with a default of 2. A value of
-    /// zero means that one try will be attempted.
-    #[allow(dead_code)]
-    pub fn set_response_write_retries(&mut self, value: u8) {
-        self.response_write_retries = value;
-    }
-
     /// Set the limit on the number of DNS responses queued for writing to the
     /// client.
     ///
@@ -221,7 +203,6 @@ impl Default for Config {
         Self {
             idle_timeout: IDLE_TIMEOUT.default(),
             response_write_timeout: RESPONSE_WRITE_TIMEOUT.default(),
-            response_write_retries: RESPONSE_WRITE_RETRIES.default(),
             max_queued_responses: MAX_QUEUED_RESPONSES.default(),
         }
     }
@@ -283,9 +264,6 @@ where
     /// DNS protocol idle time out tracking.
     idle_timer: IdleTimer,
 
-    /// Is a transaction in progress?
-    in_transaction: Arc<AtomicBool>,
-
     /// [`ServerMetrics`] describing the status of the server.
     metrics: Arc<ServerMetrics>,
 }
@@ -334,7 +312,6 @@ where
             mpsc::channel(config.max_queued_responses);
         let config = Arc::new(ArcSwap::from_pointee(config));
         let idle_timer = IdleTimer::new();
-        let in_transaction = Arc::new(AtomicBool::new(false));
 
         // Place the ReadHalf of the stream into an Option so that we can take
         // it out (as we can't clone it and we can't place it into an Arc
@@ -356,7 +333,6 @@ where
             result_q_tx,
             service,
             idle_timer,
-            in_transaction,
             metrics,
         }
     }
@@ -447,7 +423,7 @@ where
                     }
 
                     _ = sleep_until(self.idle_timer.idle_timeout_deadline(self.config.load().idle_timeout)) => {
-                        self.process_dns_idle_timeout(self.config.load().idle_timeout)
+                        self.process_dns_idle_timeout()
                     }
 
                     res = &mut msg_recv => {
@@ -464,11 +440,9 @@ where
                 if let Err(err) = res {
                     match err {
                         ConnectionEvent::DisconnectWithoutFlush => {
-                            trace!("Disconnect without flush");
                             break 'outer;
                         }
                         ConnectionEvent::DisconnectWithFlush => {
-                            trace!("Disconnect with flush");
                             self.flush_write_queue().await;
                             break 'outer;
                         }
@@ -562,7 +536,10 @@ where
     }
 
     /// Stop queueing new responses and process those already in the queue.
-    async fn flush_write_queue(&mut self) {
+    async fn flush_write_queue(&mut self)
+    // where
+    // Target: Composer,
+    {
         debug!("Flushing connection write queue.");
         // Stop accepting new response messages (should we check for in-flight
         // messages that haven't generated a response yet but should be
@@ -587,7 +564,10 @@ where
     async fn process_queued_result(
         &mut self,
         response: Option<AdditionalBuilder<StreamTarget<Svc::Target>>>,
-    ) -> Result<(), ConnectionEvent> {
+    ) -> Result<(), ConnectionEvent>
+// where
+    //     Target: Composer,
+    {
         // If we failed to read the results of requests processed by the
         // service because the queue holding those results is empty and can no
         // longer be read from, then there is no point continuing to read from
@@ -603,82 +583,63 @@ where
             "Writing queued response with id {} to stream",
             response.header().id()
         );
-        self.write_response_to_stream(response.finish()).await
+        self.write_response_to_stream(response.finish()).await;
+
+        Ok(())
     }
 
     /// Write a response back to the caller over the network stream.
     async fn write_response_to_stream(
         &mut self,
         msg: StreamTarget<Svc::Target>,
-    ) -> Result<(), ConnectionEvent> {
+    )
+    // where
+    //     Target: AsRef<[u8]>,
+    {
         if enabled!(Level::TRACE) {
             let bytes = msg.as_dgram_slice();
-            let pcap_text = to_pcap_text(bytes, bytes.len().min(128));
-            trace!(addr = %self.addr, pcap_text, "Sending response (dumping max 128 bytes)");
+            let pcap_text = to_pcap_text(bytes, bytes.len());
+            trace!(addr = %self.addr, pcap_text, "Sending response");
         }
 
-        let max_tries = self.config.load().response_write_retries + 1;
-        let mut tries_left = max_tries;
-        while tries_left > 0 {
-            debug!(addr = %self.addr, "Sending response: attempts left={tries_left}");
-            tries_left -= 1;
-
-            match timeout(
-                self.config.load().response_write_timeout,
-                self.stream_tx.write_all(msg.as_stream_slice()),
-            )
-            .await
-            {
-                Err(_) => {
-                    error!(addr = %self.addr,
-                        "Write timed out (>{:?})",
-                        self.config.load().response_write_timeout
-                    );
-                    // Retry
-                    continue;
-                }
-                Ok(Err(err)) => {
-                    if let ControlFlow::Break(err) = process_io_error(err) {
-                        // Fatal error, abort.
-                        return Err(err);
-                    } else {
-                        // Retry
-                        continue;
-                    }
-                }
-                Ok(Ok(_)) => {
-                    // Success.
-                    self.metrics.inc_num_sent_responses();
-                    self.metrics.dec_num_pending_writes();
-
-                    if self.result_q_tx.capacity()
-                        == self.result_q_tx.max_capacity()
-                    {
-                        self.idle_timer.response_queue_emptied();
-                    }
-
-                    return Ok(());
-                }
+        match timeout(
+            self.config.load().response_write_timeout,
+            self.stream_tx.write_all(msg.as_stream_slice()),
+        )
+        .await
+        {
+            Err(_) => {
+                error!(
+                    "Write timed out (>{:?})",
+                    self.config.load().response_write_timeout
+                );
+                // TODO: Push it to the back of the queue to retry it?
+            }
+            Ok(Err(err)) => {
+                error!("Write error: {err}");
+            }
+            Ok(Ok(_)) => {
+                self.metrics.inc_num_sent_responses();
             }
         }
 
-        error!(addr = %self.addr, "Failed to send response after {max_tries}. The connection will be closed.");
-        Err(ConnectionEvent::DisconnectWithoutFlush)
+        self.metrics.dec_num_pending_writes();
+
+        if self.result_q_tx.capacity() == self.result_q_tx.max_capacity() {
+            self.idle_timer.response_queue_emptied();
+        }
     }
 
-    /// Implement DNS rules regarding timing out of idle connections.
+    /// Implemnt DNS rules regarding timing out of idle connections.
     ///
     /// Disconnects the current connection of the timer is expired, flushing
     /// pending responses first.
-    fn process_dns_idle_timeout(
-        &self,
-        timeout: Duration,
-    ) -> Result<(), ConnectionEvent> {
+    fn process_dns_idle_timeout(&self) -> Result<(), ConnectionEvent> {
         // DNS idle timeout elapsed, or was it reset?
-        if self.idle_timer.idle_timeout_expired(timeout)
-            && !self.in_transaction.load(Ordering::SeqCst)
+        if self
+            .idle_timer
+            .idle_timeout_expired(self.config.load().idle_timeout)
         {
-            trace!("Timing out idle connection");
             Err(ConnectionEvent::DisconnectWithoutFlush)
         } else {
             Ok(())
@@ -693,16 +654,13 @@ where
     where
         Svc::Stream: Send,
     {
-        let in_transaction = self.in_transaction.clone();
-
         match res {
             Ok(buf) => {
                 let received_at = Instant::now();
 
                 if enabled!(Level::TRACE) {
-                    let pcap_text =
-                        to_pcap_text(&buf, buf.as_ref().len().min(128));
-                    trace!(addr = %self.addr, pcap_text, "Received message (dumping max 128 bytes)");
+                    let pcap_text = to_pcap_text(&buf, buf.as_ref().len());
+                    trace!(addr = %self.addr, pcap_text, "Received message");
                 }
 
                 self.metrics.inc_num_received_requests();
@@ -721,7 +679,6 @@ where
                     }
 
                     Ok(msg) => {
-                        trace!(addr = %self.addr, ?msg, "Parsed first question: {:?}", msg.first_question());
                         let ctx = NonUdpTransportContext::new(Some(
                             self.config.load().idle_timeout,
                         ));
@@ -749,6 +706,7 @@ where
                                 "Calling service for request id {request_id}"
                             );
                             let mut stream = svc.call(request).await;
+                            let mut in_transaction = false;
 
                             trace!("Awaiting service call results for request id {request_id}");
                             while let Some(Ok(call_result)) =
@@ -780,17 +738,11 @@ where
                                         }
 
                                         ServiceFeedback::BeginTransaction => {
-                                            in_transaction.store(
-                                                true,
-                                                Ordering::SeqCst,
-                                            );
+                                            in_transaction = true;
                                         }
 
                                         ServiceFeedback::EndTransaction => {
-                                            in_transaction.store(
-                                                false,
-                                                Ordering::SeqCst,
-                                            );
+                                            in_transaction = false;
                                         }
                                     }
                                 }
@@ -813,16 +765,14 @@ where
                                             }
 
                                             Err(TrySendError::Closed(_)) => {
-                                                error!("Unable to queue message for sending: connection is shutting down.");
-                                                return;
+                                                error!("Unable to queue message for sending: server is shutting down.");
+                                                break;
                                             }
 
                                             Err(TrySendError::Full(
                                                 unused_response,
                                             )) => {
-                                                if in_transaction
-                                                    .load(Ordering::SeqCst)
-                                                {
+                                                if in_transaction {
                                                     // Wait until there is space in the message queue.
                                                     tokio::task::yield_now()
                                                         .await;
@@ -978,35 +928,35 @@ where
                 // buffer.
                 Ok(_size) => return Ok(()),
 
-                Err(err) => match process_io_error(err) {
+                Err(err) => match Self::process_io_error(err) {
                     ControlFlow::Continue(_) => continue,
                     ControlFlow::Break(err) => return Err(err),
                 },
             }
         }
     }
-}
 
-/// Handle I/O errors by deciding whether to log them, and whether to continue
-/// or abort.
-#[must_use]
-fn process_io_error(err: io::Error) -> ControlFlow<ConnectionEvent> {
-    match err.kind() {
-        io::ErrorKind::UnexpectedEof => {
-            // The client disconnected. Per RFC 7766 6.2.4 pending responses
-            // MUST NOT be sent to the client.
-            ControlFlow::Break(ConnectionEvent::DisconnectWithoutFlush)
-        }
-        io::ErrorKind::TimedOut | io::ErrorKind::Interrupted => {
-            // These errors might be recoverable, try again.
-            ControlFlow::Continue(())
-        }
-        _ => {
-            // Everything else is either unrecoverable or unknown to us at the
-            // time of writing and so we can't guess how to handle it, so
-            // abort.
-            error!("I/O error: {}", err);
-            ControlFlow::Break(ConnectionEvent::DisconnectWithoutFlush)
+    /// Handle I/O errors by deciding whether to log them, and whethr to
+    /// continue or abort.
+    #[must_use]
+    fn process_io_error(err: io::Error) -> ControlFlow<ConnectionEvent> {
+        match err.kind() {
+            io::ErrorKind::UnexpectedEof => {
+                // The client disconnected. Per RFC 7766 6.2.4 pending
+                // responses MUST NOT be sent to the client.
+                ControlFlow::Break(ConnectionEvent::DisconnectWithoutFlush)
+            }
+            io::ErrorKind::TimedOut | io::ErrorKind::Interrupted => {
+                // These errors might be recoverable, try again.
+                ControlFlow::Continue(())
+            }
+            _ => {
+                // Everything else is either unrecoverable or unknown to us at
+                // the time of writing and so we can't guess how to handle it,
+                // so abort.
+                error!("I/O error: {}", err);
+                ControlFlow::Break(ConnectionEvent::DisconnectWithoutFlush)
+            }
         }
     }
 }

--- a/src/net/server/message.rs
+++ b/src/net/server/message.rs
@@ -157,7 +157,7 @@ impl From<NonUdpTransportContext> for TransportSpecificContext {
 #[derive(Debug)]
 pub struct Request<Octs, Metadata = ()>
 where
-    Octs: AsRef<[u8]> + Send + Sync + Unpin,
+    Octs: AsRef<[u8]> + Send + Sync,
 {
     /// The network address of the connected client.
     client_addr: std::net::SocketAddr,

--- a/src/net/server/message.rs
+++ b/src/net/server/message.rs
@@ -172,12 +172,22 @@ where
     /// protocol via which it was received.
     transport_specific: TransportSpecificContext,
 
-    /// The number of bytes to be reserved when generating a response
-    /// to this request so that needed additional data can be added to
-    /// to the generated response.
+    /// The number of bytes to be reserved when generating a response to this
+    /// request so that needed additional data can be added to to the
+    /// generated response.
+    ///
+    /// Note: This is only a hint to code that considers this value, it is
+    /// still possible to generate responses that ignore this value.
     num_reserved_bytes: u16,
 
-    metadata: Metadata, // TODO: Make middleware take an impl SomeInterface?
+    /// user defined metadata to associate with the request.
+    ///
+    /// For example this could be used to pass data from one [middleware]
+    /// [`Service`] impl to another.
+    ///
+    /// [middleware]: crate::net::server::middleware
+    /// [`Service`]: crate::net::server::service::Service
+    metadata: Metadata,
 }
 
 impl<Octs, Metadata> Request<Octs, Metadata>
@@ -238,6 +248,7 @@ where
         self.num_reserved_bytes
     }
 
+    /// Set user defined metadata to associate with this request.
     pub fn with_new_metadata<T>(self, new_metadata: T) -> Request<Octs, T> {
         Request::<Octs, T> {
             client_addr: self.client_addr,
@@ -249,6 +260,7 @@ where
         }
     }
 
+    /// Get the user defined metadata associated with this request.
     pub fn metadata(&self) -> &Metadata {
         &self.metadata
     }

--- a/src/net/server/middleware/cookies.rs
+++ b/src/net/server/middleware/cookies.rs
@@ -5,10 +5,10 @@ use core::ops::ControlFlow;
 
 use std::vec::Vec;
 
-use futures::stream::{once, Once};
+use futures::stream::{once, Once, Stream};
 use octseq::Octets;
 use rand::RngCore;
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::base::iana::{OptRcode, Rcode};
 use crate::base::message_builder::AdditionalBuilder;
@@ -19,8 +19,8 @@ use crate::base::{Serial, StreamTarget};
 use crate::net::server::message::Request;
 use crate::net::server::middleware::stream::MiddlewareStream;
 use crate::net::server::service::{CallResult, Service};
-use crate::net::server::util::add_edns_options;
-use crate::net::server::util::{mk_builder_for_target, start_reply};
+use crate::net::server::util::mk_builder_for_target;
+use crate::net::server::util::{add_edns_options, mk_error_response};
 
 //----------- Constants -------------------------------------------------------
 
@@ -34,7 +34,7 @@ const ONE_HOUR_AS_SECS: u32 = 60 * 60;
 
 //----------- CookiesMiddlewareProcessor --------------------------------------
 
-/// A DNS Cookies middleware service.
+/// A middleware service for enforcing the use of DNS Cookies.
 ///
 /// Standards covered by ths implementation:
 ///
@@ -46,8 +46,8 @@ const ONE_HOUR_AS_SECS: u32 = 60 * 60;
 /// [7873]: https://datatracker.ietf.org/doc/html/rfc7873
 /// [9018]: https://datatracker.ietf.org/doc/html/rfc7873
 #[derive(Clone, Debug)]
-pub struct CookiesMiddlewareSvc<RequestOctets, Svc> {
-    svc: Svc,
+pub struct CookiesMiddlewareSvc<RequestOctets, NextSvc, RequestMeta> {
+    next_svc: NextSvc,
 
     /// A user supplied secret used in making the cookie value.
     server_secret: [u8; 16],
@@ -57,25 +57,30 @@ pub struct CookiesMiddlewareSvc<RequestOctets, Svc> {
     /// to reconnect with TCP in order to "authenticate" themselves.
     ip_deny_list: Vec<IpAddr>,
 
-    _phantom: PhantomData<RequestOctets>,
+    _phantom: PhantomData<(RequestOctets, RequestMeta)>,
+
+    enabled: bool,
 }
 
-impl<RequestOctets, Svc> CookiesMiddlewareSvc<RequestOctets, Svc> {
+impl<RequestOctets, NextSvc, RequestMeta>
+    CookiesMiddlewareSvc<RequestOctets, NextSvc, RequestMeta>
+{
     /// Creates an instance of this processor.
     #[must_use]
-    pub fn new(svc: Svc, server_secret: [u8; 16]) -> Self {
+    pub fn new(next_svc: NextSvc, server_secret: [u8; 16]) -> Self {
         Self {
-            svc,
+            next_svc,
             server_secret,
             ip_deny_list: vec![],
             _phantom: PhantomData,
+            enabled: true,
         }
     }
 
-    pub fn with_random_secret(svc: Svc) -> Self {
+    pub fn with_random_secret(next_svc: NextSvc) -> Self {
         let mut server_secret = [0u8; 16];
         rand::thread_rng().fill_bytes(&mut server_secret);
-        Self::new(svc, server_secret)
+        Self::new(next_svc, server_secret)
     }
 
     /// Define IP addresses required to supply DNS cookies if using UDP.
@@ -87,13 +92,20 @@ impl<RequestOctets, Svc> CookiesMiddlewareSvc<RequestOctets, Svc> {
         self.ip_deny_list = ip_deny_list.into();
         self
     }
+
+    pub fn enable(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
 }
 
-impl<RequestOctets, Svc> CookiesMiddlewareSvc<RequestOctets, Svc>
+impl<RequestOctets, NextSvc, RequestMeta>
+    CookiesMiddlewareSvc<RequestOctets, NextSvc, RequestMeta>
 where
     RequestOctets: Octets + Send + Sync + Unpin,
-    Svc: Service<RequestOctets>,
-    Svc::Target: Composer + Default,
+    RequestMeta: Clone + Default,
+    NextSvc: Service<RequestOctets, RequestMeta>,
+    NextSvc::Target: Composer + Default,
 {
     /// Get the DNS COOKIE, if any, for the given message.
     ///
@@ -111,7 +123,7 @@ where
     ///     parsed.
     #[must_use]
     fn cookie(
-        request: &Request<RequestOctets>,
+        request: &Request<RequestOctets, RequestMeta>,
     ) -> Option<Result<opt::Cookie, ParseError>> {
         // Note: We don't use `opt::Opt::first()` because that will silently
         // ignore an unparseable COOKIE option but we need to detect and
@@ -156,10 +168,22 @@ where
     /// Create a DNS response message for the given request, including cookie.
     fn response_with_cookie(
         &self,
-        request: &Request<RequestOctets>,
+        request: &Request<RequestOctets, RequestMeta>,
         rcode: OptRcode,
-    ) -> AdditionalBuilder<StreamTarget<Svc::Target>> {
-        let mut additional = start_reply(request.message()).additional();
+    ) -> AdditionalBuilder<StreamTarget<NextSvc::Target>> {
+        let res = mk_builder_for_target()
+            .start_answer(request.message(), rcode.rcode());
+
+        let mut additional = match res {
+            Ok(answer) => answer.additional(),
+            Err(err) => {
+                error!("Failed to create response: {err}");
+                return mk_error_response(
+                    request.message(),
+                    OptRcode::SERVFAIL,
+                );
+            }
+        };
 
         if let Some(Ok(client_cookie)) = Self::cookie(request) {
             let response_cookie = client_cookie.create_response(
@@ -193,8 +217,8 @@ where
     #[must_use]
     fn bad_cookie_response(
         &self,
-        request: &Request<RequestOctets>,
-    ) -> AdditionalBuilder<StreamTarget<Svc::Target>> {
+        request: &Request<RequestOctets, RequestMeta>,
+    ) -> AdditionalBuilder<StreamTarget<NextSvc::Target>> {
         // https://datatracker.ietf.org/doc/html/rfc7873#section-5.2.3
         //   "If the server responds [ed: by sending a BADCOOKIE error
         //    response], it SHALL generate its own COOKIE option containing
@@ -209,8 +233,8 @@ where
     #[must_use]
     fn prefetch_cookie_response(
         &self,
-        request: &Request<RequestOctets>,
-    ) -> AdditionalBuilder<StreamTarget<Svc::Target>> {
+        request: &Request<RequestOctets, RequestMeta>,
+    ) -> AdditionalBuilder<StreamTarget<NextSvc::Target>> {
         // https://datatracker.ietf.org/doc/html/rfc7873#section-5.4
         // Querying for a Server Cookie:
         //   "For servers with DNS Cookies enabled, the
@@ -228,8 +252,8 @@ where
     #[tracing::instrument(skip_all, fields(request_ip = %request.client_addr().ip()))]
     fn preprocess(
         &self,
-        request: &Request<RequestOctets>,
-    ) -> ControlFlow<AdditionalBuilder<StreamTarget<Svc::Target>>> {
+        request: &Request<RequestOctets, RequestMeta>,
+    ) -> ControlFlow<AdditionalBuilder<StreamTarget<NextSvc::Target>>> {
         match Self::cookie(request) {
             None => {
                 trace!("Request does not contain a DNS cookie");
@@ -420,66 +444,41 @@ where
 
         ControlFlow::Continue(())
     }
-
-    // fn postprocess(
-    //     _request: &Request<RequestOctets>,
-    //     _response: &mut AdditionalBuilder<StreamTarget<Svc::Target>>,
-    //     _server_secret: [u8; 16],
-    // ) where
-    //     RequestOctets: Octets,
-    // {
-    //     // https://datatracker.ietf.org/doc/html/rfc7873#section-5.2.1
-    //     // No OPT RR or No COOKIE Option:
-    //     //   If the request lacked a client cookie we don't need to do
-    //     //   anything.
-    //     //
-    //     // https://datatracker.ietf.org/doc/html/rfc7873#section-5.2.2
-    //     // Malformed COOKIE Option:
-    //     //   If the request COOKIE option was malformed we would have already
-    //     //   rejected it during pre-processing so again nothing to do here.
-    //     //
-    //     // https://datatracker.ietf.org/doc/html/rfc7873#section-5.2.3
-    //     // Only a Client Cookie:
-    //     //   If the request had a client cookie but no server cookie and
-    //     //   we didn't already reject the request during pre-processing.
-    //     //
-    //     // https://datatracker.ietf.org/doc/html/rfc7873#section-5.2.4
-    //     // A Client Cookie and an Invalid Server Cookie:
-    //     //   Per RFC 7873 this is handled the same way as the "Only a Client
-    //     //   Cookie" case.
-    //     //
-    //     // https://datatracker.ietf.org/doc/html/rfc7873#section-5.2.5
-    //     // A Client Cookie and a Valid Server Cookie
-    //     //   Any server cookie will already have been validated during
-    //     //   pre-processing, we don't need to check it again here.
-    // }
 }
 
 //--- Service
 
-impl<RequestOctets, Svc> Service<RequestOctets>
-    for CookiesMiddlewareSvc<RequestOctets, Svc>
+impl<RequestOctets, NextSvc, RequestMeta> Service<RequestOctets, RequestMeta>
+    for CookiesMiddlewareSvc<RequestOctets, NextSvc, RequestMeta>
 where
     RequestOctets: Octets + Send + Sync + 'static + Unpin,
-    Svc: Service<RequestOctets>,
-    Svc::Future: core::future::Future + Unpin,
-    <Svc::Future as core::future::Future>::Output: Unpin,
-    Svc::Target: Composer + Default,
+    RequestMeta: Clone + Default,
+    NextSvc: Service<RequestOctets, RequestMeta>,
+    NextSvc::Target: Composer + Default,
+    NextSvc::Future: Unpin,
 {
-    type Target = Svc::Target;
+    type Target = NextSvc::Target;
     type Stream = MiddlewareStream<
-        Svc::Future,
-        Svc::Stream,
-        Svc::Stream,
-        Once<Ready<<Svc::Stream as futures::stream::Stream>::Item>>,
-        <Svc::Stream as futures::stream::Stream>::Item,
+        NextSvc::Future,
+        NextSvc::Stream,
+        NextSvc::Stream,
+        Once<Ready<<NextSvc::Stream as Stream>::Item>>,
+        <NextSvc::Stream as Stream>::Item,
     >;
     type Future = core::future::Ready<Self::Stream>;
 
-    fn call(&self, request: Request<RequestOctets>) -> Self::Future {
+    fn call(
+        &self,
+        request: Request<RequestOctets, RequestMeta>,
+    ) -> Self::Future {
+        if !self.enabled {
+            let svc_call_fut = self.next_svc.call(request.clone());
+            return ready(MiddlewareStream::IdentityFuture(svc_call_fut));
+        }
+
         match self.preprocess(&request) {
             ControlFlow::Continue(()) => {
-                let svc_call_fut = self.svc.call(request.clone());
+                let svc_call_fut = self.next_svc.call(request.clone());
                 ready(MiddlewareStream::IdentityFuture(svc_call_fut))
             }
             ControlFlow::Break(response) => ready(MiddlewareStream::Result(
@@ -494,6 +493,7 @@ mod tests {
     use bytes::Bytes;
     use std::vec::Vec;
     use tokio::time::Instant;
+    use tokio_stream::StreamExt;
 
     use crate::base::opt::cookie::ClientCookie;
     use crate::base::opt::Cookie;
@@ -502,7 +502,6 @@ mod tests {
     use crate::net::server::middleware::cookies::CookiesMiddlewareSvc;
     use crate::net::server::service::{CallResult, Service, ServiceResult};
     use crate::net::server::util::service_fn;
-    use futures::prelude::stream::StreamExt;
 
     #[tokio::test]
     async fn dont_add_cookie_twice() {
@@ -520,8 +519,13 @@ mod tests {
         // as if it came from a UDP server.
         let ctx = UdpTransportContext::default();
         let client_addr = "127.0.0.1:12345".parse().unwrap();
-        let request =
-            Request::new(client_addr, Instant::now(), message, ctx.into());
+        let request = Request::new(
+            client_addr,
+            Instant::now(),
+            message,
+            ctx.into(),
+            (),
+        );
 
         fn my_service(
             _req: Request<Vec<u8>>,

--- a/src/net/server/middleware/cookies.rs
+++ b/src/net/server/middleware/cookies.rs
@@ -78,8 +78,8 @@ impl<RequestOctets, NextSvc, RequestMeta>
             next_svc,
             server_secret,
             ip_deny_list: vec![],
-            _phantom: PhantomData,
             enabled: true,
+            _phantom: PhantomData,
         }
     }
 

--- a/src/net/server/middleware/cookies.rs
+++ b/src/net/server/middleware/cookies.rs
@@ -32,7 +32,7 @@ const FIVE_MINUTES_AS_SECS: u32 = 5 * 60;
 /// https://www.rfc-editor.org/rfc/rfc9018.html#section-4.3.
 const ONE_HOUR_AS_SECS: u32 = 60 * 60;
 
-//----------- CookiesMiddlewareProcessor --------------------------------------
+//----------- CookiesMiddlewareSvc --------------------------------------------
 
 /// A middleware service for enforcing the use of DNS Cookies.
 ///
@@ -47,6 +47,8 @@ const ONE_HOUR_AS_SECS: u32 = 60 * 60;
 /// [9018]: https://datatracker.ietf.org/doc/html/rfc7873
 #[derive(Clone, Debug)]
 pub struct CookiesMiddlewareSvc<RequestOctets, NextSvc, RequestMeta> {
+    /// The upstream [`Service`] to pass requests to and receive responses
+    /// from.
     next_svc: NextSvc,
 
     /// A user supplied secret used in making the cookie value.
@@ -57,15 +59,19 @@ pub struct CookiesMiddlewareSvc<RequestOctets, NextSvc, RequestMeta> {
     /// to reconnect with TCP in order to "authenticate" themselves.
     ip_deny_list: Vec<IpAddr>,
 
-    _phantom: PhantomData<(RequestOctets, RequestMeta)>,
-
+    /// Is the middleware service enabled?
+    ///
+    /// Defaults to true. If false, the service will pass requests and
+    /// responses through unmodified.
     enabled: bool,
+
+    _phantom: PhantomData<(RequestOctets, RequestMeta)>,
 }
 
 impl<RequestOctets, NextSvc, RequestMeta>
     CookiesMiddlewareSvc<RequestOctets, NextSvc, RequestMeta>
 {
-    /// Creates an instance of this processor.
+    /// Creates an instance of this middleware service.
     #[must_use]
     pub fn new(next_svc: NextSvc, server_secret: [u8; 16]) -> Self {
         Self {
@@ -274,7 +280,7 @@ where
                 //    back to using TCP is reasonable."
 
                 // While not required by RFC 7873, like Unbound the caller can
-                // configure this middleware processor to require clients
+                // configure this middleware service to require clients
                 // contacting it from certain IP addresses to authenticate
                 // themselves or be refused with TC=1 to signal that they
                 // should resubmit their request via TCP.
@@ -535,14 +541,14 @@ mod tests {
             todo!()
         }
 
-        // And pass the query through the middleware processor
+        // And pass the query through the middleware service
         let my_svc = service_fn(my_service, ());
         let server_secret: [u8; 16] =
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-        let processor_svc = CookiesMiddlewareSvc::new(my_svc, server_secret)
+        let middleware_svc = CookiesMiddlewareSvc::new(my_svc, server_secret)
             .with_denied_ips(["127.0.0.1".parse().unwrap()]);
 
-        let mut stream = processor_svc.call(request).await;
+        let mut stream = middleware_svc.call(request).await;
         let call_result: CallResult<Vec<u8>> =
             stream.next().await.unwrap().unwrap();
         let (response, _feedback) = call_result.into_inner();

--- a/src/net/server/middleware/edns.rs
+++ b/src/net/server/middleware/edns.rs
@@ -9,11 +9,10 @@ use tracing::{debug, enabled, error, trace, warn, Level};
 
 use crate::base::iana::OptRcode;
 use crate::base::message_builder::AdditionalBuilder;
-use crate::base::name::ToLabelIter;
 use crate::base::opt::keepalive::IdleTimeout;
-use crate::base::opt::{ComposeOptData, Opt, OptRecord, TcpKeepalive};
+use crate::base::opt::{Opt, OptRecord, TcpKeepalive};
 use crate::base::wire::Composer;
-use crate::base::{Name, StreamTarget};
+use crate::base::StreamTarget;
 use crate::net::server::message::{Request, TransportSpecificContext};
 use crate::net::server::middleware::stream::MiddlewareStream;
 use crate::net::server::service::{CallResult, Service, ServiceResult};

--- a/src/net/server/middleware/edns.rs
+++ b/src/net/server/middleware/edns.rs
@@ -68,8 +68,8 @@ impl<RequestOctets, NextSvc, RequestMeta>
     pub fn new(next_svc: NextSvc) -> Self {
         Self {
             next_svc,
-            _phantom: PhantomData,
             enabled: true,
+            _phantom: PhantomData,
         }
     }
 

--- a/src/net/server/middleware/mandatory.rs
+++ b/src/net/server/middleware/mandatory.rs
@@ -40,11 +40,13 @@ pub const MINIMUM_RESPONSE_BYTE_LEN: u16 = 512;
 /// [2181]: https://datatracker.ietf.org/doc/html/rfc2181
 #[derive(Clone, Debug)]
 pub struct MandatoryMiddlewareSvc<RequestOctets, NextSvc, RequestMeta> {
-    /// In strict mode the processor does more checks on requests and
+    /// The upstream [`Service`] to pass requests to and receive responses
+    /// from.
+    next_svc: NextSvc,
+
+    /// In strict mode the service does more checks on requests and
     /// responses.
     strict: bool,
-
-    next_svc: NextSvc,
 
     _phantom: PhantomData<(RequestOctets, RequestMeta)>,
 }
@@ -52,9 +54,9 @@ pub struct MandatoryMiddlewareSvc<RequestOctets, NextSvc, RequestMeta> {
 impl<RequestOctets, NextSvc, RequestMeta>
     MandatoryMiddlewareSvc<RequestOctets, NextSvc, RequestMeta>
 {
-    /// Creates a new processor instance.
+    /// Creates an instance of this middleware service.
     ///
-    /// The processor will operate in strict mode.
+    /// The service will operate in strict mode.
     #[must_use]
     pub fn new(next_svc: NextSvc) -> Self {
         Self {
@@ -64,9 +66,9 @@ impl<RequestOctets, NextSvc, RequestMeta>
         }
     }
 
-    /// Creates a new processor instance.
+    /// Creates an instance of this middleware service.
     ///
-    /// The processor will operate in relaxed mode.
+    /// The service will operate in relaxed mode.
     #[must_use]
     pub fn relaxed(next_svc: NextSvc) -> Self {
         Self {
@@ -452,9 +454,9 @@ mod tests {
         let _call_result: CallResult<Vec<u8>> =
             stream.next().await.unwrap().unwrap();
 
-        // Or pass the query through the middleware processor
-        let processor_svc = MandatoryMiddlewareSvc::new(my_svc);
-        let mut stream = processor_svc.call(request).await;
+        // Or pass the query through the middleware service
+        let middleware_svc = MandatoryMiddlewareSvc::new(my_svc);
+        let mut stream = middleware_svc.call(request).await;
         let call_result: CallResult<Vec<u8>> =
             stream.next().await.unwrap().unwrap();
         let (response, _feedback) = call_result.into_inner();

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -27,7 +27,7 @@
 //!         <-- (optional) middleware services - post-processes responses
 //!     <-- server                             - serializes responses
 //! <-- network source                         - writes bytes to the client
-//! ````
+//! ```
 //!
 //! # Getting started
 //!
@@ -38,15 +38,15 @@
 //! application [`Service`] impl at the peak.
 //!
 //! Whether using [`DgramServer`] or [`StreamServer`] the required steps are
-//! the same.
+//! the same:
 //!
-//!   - Create an appropriate network source (more on this below).
-//!   - Construct a server transport with `new()` passing in the network
+//!   1. Create an appropriate network source (more on this below).
+//!   2. Construct a server transport with `new()` passing in the network
 //!     source and service instance as arguments.
 //!     - (optional) Tune the server behaviour via builder functions such as
 //!       `with_config()`.
-//!   - `run()` the server.
-//!   - `shutdown()` the server, explicitly or on [`drop`].
+//!   3. `run()` the server.
+//!   4. `shutdown()` the server, explicitly or on [`drop`].
 //!
 //! See [`DgramServer`] and [`StreamServer`] for example code to help you get
 //! started.

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -42,9 +42,9 @@
 //!
 //!   1. Create an appropriate network source (more on this below).
 //!   2. Construct a server transport with `new()` passing in the network
-//!     source and service instance as arguments.
-//!     - (optional) Tune the server behaviour via builder functions such as
-//!       `with_config()`.
+//!      source and service instance as arguments.
+//!      - (optional) Tune the server behaviour via builder functions such as
+//!        `with_config()`.
 //!   3. `run()` the server.
 //!   4. `shutdown()` the server, explicitly or on [`drop`].
 //!

--- a/src/net/server/service.rs
+++ b/src/net/server/service.rs
@@ -33,7 +33,7 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 ///
 /// Most DNS requests result in a single response, with the exception of AXFR
 /// and IXFR requests which can result in a stream of responses.
-///
+/// 
 /// # Usage
 ///
 /// You can either implement the [`Service`] trait on a struct or use the
@@ -138,14 +138,37 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 /// ```
 ///
 /// The above are minimalist examples to illustrate what you need to do, but
-/// lacking any actual useful behaviour.
+/// lacking any actual useful behaviour. They also only demonstrate returning
+/// a response stream containing a single immediately available value via
+/// `futures::stream::Once` and `std::future::Ready`.
 ///
 /// In your own [`Service`] impl you would implement actual business logic
-/// using synchronous or asynchronous code and returning single or multiple
-/// responses as needed.
+/// returning single or multiple responses synchronously or asynchronously as
+/// needed.
+/// 
+/// # Advanced usage
+/// 
+/// The [`Service`] trait takes two generic types which in most cases you
+/// don't need to specify as the defaults will be fine.
+/// 
+/// For more advanced cases you may need to override these defaults.
+/// 
+/// - `RequestMeta`: If implementing a [middleware] `Service` you may need to
+///   supply your own `RequestMeta` type. `RequestMeta` is intended to enable
+///   middleware `Service` impls to express strongly typed support for
+///   middleware specific data that can be consumed by upstream middleware, or
+///   even by your application service. For example a middleware `Service` may
+///   detect that the request is signed using a particular key and communicate
+///   the name of the key to any upstream `Service` that needs to know the
+///   name of the key used to sign the request.
+/// 
+/// - `RequestOctets`: By specifying your own `RequestOctets` type you can use
+///   a type other than `Vec<u8>` to transport request bytes through your
+///   application.
 ///
 /// [`DgramServer`]: crate::net::server::dgram::DgramServer
 /// [`StreamServer`]: crate::net::server::stream::StreamServer
+/// [middleware]: crate::net::server::middleware
 /// [`net::server`]: crate::net::server
 /// [`call`]: Self::call()
 /// [`service_fn`]: crate::net::server::util::service_fn()

--- a/src/net/server/service.rs
+++ b/src/net/server/service.rs
@@ -173,7 +173,7 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 /// [`call`]: Self::call()
 /// [`service_fn`]: crate::net::server::util::service_fn()
 pub trait Service<
-    RequestOctets: AsRef<[u8]> + Send + Sync + Unpin = Vec<u8>,
+    RequestOctets: AsRef<[u8]> + Send + Sync = Vec<u8>,
     RequestMeta: Clone + Default = (),
 >
 {

--- a/src/net/server/service.rs
+++ b/src/net/server/service.rs
@@ -33,7 +33,7 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 ///
 /// Most DNS requests result in a single response, with the exception of AXFR
 /// and IXFR requests which can result in a stream of responses.
-/// 
+///
 /// # Usage
 ///
 /// You can either implement the [`Service`] trait on a struct or use the
@@ -145,14 +145,14 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 /// In your own [`Service`] impl you would implement actual business logic
 /// returning single or multiple responses synchronously or asynchronously as
 /// needed.
-/// 
+///
 /// # Advanced usage
-/// 
+///
 /// The [`Service`] trait takes two generic types which in most cases you
 /// don't need to specify as the defaults will be fine.
-/// 
+///
 /// For more advanced cases you may need to override these defaults.
-/// 
+///
 /// - `RequestMeta`: If implementing a [middleware] `Service` you may need to
 ///   supply your own `RequestMeta` type. `RequestMeta` is intended to enable
 ///   middleware `Service` impls to express strongly typed support for
@@ -161,7 +161,7 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 ///   detect that the request is signed using a particular key and communicate
 ///   the name of the key to any upstream `Service` that needs to know the
 ///   name of the key used to sign the request.
-/// 
+///
 /// - `RequestOctets`: By specifying your own `RequestOctets` type you can use
 ///   a type other than `Vec<u8>` to transport request bytes through your
 ///   application.

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -44,9 +44,17 @@ where
 /// those of its associated types, but this makes implementing it for simple
 /// cases quite verbose.
 ///
-/// `service_fn()` enables you to write a slightly simpler function definition
-/// that implements the [`Service`] trait than implementing [`Service`]
-/// directly.
+/// [`service_fn()`] enables you to write a slightly simpler function
+/// definition that implements the [`Service`] trait than implementing
+/// [`Service`] directly.
+/// 
+/// <div class="warning">
+/// 
+/// Note that [`service_fn`] does not support async service functions. To
+/// use async code in a service you must implement the [`Service`] trait
+/// manually on a struct.
+/// 
+/// </div>
 ///
 /// # Example
 ///
@@ -56,13 +64,9 @@ where
 ///
 /// ```
 /// // Import the types we need.
-/// use std::boxed::Box;
-/// use std::future::Future;
-/// use std::pin::Pin;
 /// use domain::base::iana::Rcode;
-/// use domain::base::Message;
 /// use domain::net::server::message::Request;
-/// use domain::net::server::service::{CallResult, ServiceError, ServiceResult};
+/// use domain::net::server::service::{CallResult, ServiceResult};
 /// use domain::net::server::util::{mk_builder_for_target, service_fn};
 ///
 /// // Define some types to make the example easier to read.
@@ -70,7 +74,9 @@ where
 ///
 /// // Implement the application logic of our service.
 /// // Takes the received DNS request and any additional meta data you wish to
-/// // provide, and returns one or more future DNS responses.
+/// // provide, and returns one or more DNS responses.
+/// //
+/// // Note that using `service_fn()` does not permit you to use async code!
 /// fn my_service(req: Request<Vec<u8>>, _meta: MyMeta)
 ///     -> ServiceResult<Vec<u8>>
 /// {

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -47,13 +47,13 @@ where
 /// [`service_fn()`] enables you to write a slightly simpler function
 /// definition that implements the [`Service`] trait than implementing
 /// [`Service`] directly.
-/// 
+///
 /// <div class="warning">
-/// 
+///
 /// Note that [`service_fn`] does not support async service functions. To
 /// use async code in a service you must implement the [`Service`] trait
 /// manually on a struct.
-/// 
+///
 /// </div>
 ///
 /// # Example

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -1,15 +1,16 @@
 //! Small utilities for building and working with servers.
-use core::future::Ready;
+use core::future::{ready, Ready};
 
+use core::marker::PhantomData;
 use std::string::{String, ToString};
 
 use futures::stream::Once;
 use octseq::{Octets, OctetsBuilder};
 use tracing::warn;
 
-use crate::base::iana::{OptRcode, Rcode};
+use crate::base::iana::OptRcode;
 use crate::base::message_builder::{
-    AdditionalBuilder, OptBuilder, PushError, QuestionBuilder,
+    AdditionalBuilder, OptBuilder, PushError,
 };
 use crate::base::wire::Composer;
 use crate::base::Message;
@@ -90,21 +91,63 @@ where
 /// [`Vec<u8>`]: std::vec::Vec<u8>
 /// [`CallResult`]: crate::net::server::service::CallResult
 /// [`Result::Ok`]: std::result::Result::Ok
-pub fn service_fn<RequestOctets, Target, T, Metadata>(
+pub fn service_fn<RequestOctets, Target, T, RequestMeta, Metadata>(
     request_handler: T,
     metadata: Metadata,
-) -> impl Service<
-    RequestOctets,
-    Target = Target,
-    Stream = Once<Ready<ServiceResult<Target>>>,
-    Future = Ready<Once<Ready<ServiceResult<Target>>>>,
-> + Clone
+) -> ServiceFn<Target, T, Metadata>
 where
     RequestOctets: AsRef<[u8]> + Send + Sync + Unpin,
+    RequestMeta: Clone + Default,
     Metadata: Clone,
-    T: Fn(Request<RequestOctets>, Metadata) -> ServiceResult<Target> + Clone,
+    Target: Composer + Default,
+    T: Fn(
+            Request<RequestOctets, RequestMeta>,
+            Metadata,
+        ) -> ServiceResult<Target>
+        + Clone,
 {
-    move |request| request_handler(request, metadata.clone())
+    ServiceFn {
+        request_handler,
+        metadata,
+        _phantom: PhantomData,
+    }
+}
+
+//--- ServiceFn
+
+#[derive(Clone, Debug)]
+pub struct ServiceFn<Target, T, Metadata> {
+    request_handler: T,
+    metadata: Metadata,
+    _phantom: PhantomData<Target>,
+}
+
+impl<RequestOctets, Target, RequestMeta, T, Metadata>
+    Service<RequestOctets, RequestMeta> for ServiceFn<Target, T, Metadata>
+where
+    RequestOctets: AsRef<[u8]> + Send + Sync + Unpin,
+    RequestMeta: Default + Clone,
+    Metadata: Clone,
+    Target: Composer + Default,
+    T: Fn(
+            Request<RequestOctets, RequestMeta>,
+            Metadata,
+        ) -> ServiceResult<Target>
+        + Clone,
+{
+    type Target = Target;
+    type Stream = Once<Ready<ServiceResult<Self::Target>>>;
+    type Future = Ready<Self::Stream>;
+
+    fn call(
+        &self,
+        request: Request<RequestOctets, RequestMeta>,
+    ) -> Self::Future {
+        ready(futures_util::stream::once(ready((self.request_handler)(
+            request,
+            self.metadata.clone(),
+        ))))
+    }
 }
 
 //----------- to_pcap_text() -------------------------------------------------
@@ -138,53 +181,6 @@ pub(crate) fn to_pcap_text<T: AsRef<[u8]>>(
     formatted
 }
 
-//----------- start_reply ----------------------------------------------------
-
-/// Create a DNS response message that is a reply to a given request message.
-///
-/// Copy the request question into a new response and return the builder for
-/// further message construction.
-///
-/// On internal error this function will attempt to set RCODE ServFail in the
-/// returned message.
-pub fn start_reply<RequestOctets, Target>(
-    msg: &Message<RequestOctets>,
-) -> QuestionBuilder<StreamTarget<Target>>
-where
-    RequestOctets: Octets,
-    Target: Composer + Default,
-{
-    let builder = mk_builder_for_target();
-
-    // RFC (1035?) compliance - copy question from request to response.
-    let mut abort = false;
-    let mut builder = builder.question();
-    for rr in msg.question() {
-        match rr {
-            Ok(rr) => {
-                if let Err(err) = builder.push(rr) {
-                    warn!("Internal error while copying question RR to the resposne: {err}");
-                    abort = true;
-                    break;
-                }
-            }
-            Err(err) => {
-                warn!(
-                    "Parse error while copying question RR to the resposne: {err} [RR: {rr:?}]"
-                );
-                abort = true;
-                break;
-            }
-        }
-    }
-
-    if abort {
-        builder.header_mut().set_rcode(Rcode::SERVFAIL);
-    }
-
-    builder
-}
-
 //------------ mk_error_response ---------------------------------------------
 
 pub fn mk_error_response<RequestOctets, Target>(
@@ -195,7 +191,9 @@ where
     RequestOctets: Octets,
     Target: Composer + Default,
 {
-    let mut additional = start_reply(msg).additional();
+    let mut additional = mk_builder_for_target()
+        .start_error(msg, rcode.rcode())
+        .additional();
 
     // Note: if rcode is non-extended this will also correctly handle
     // setting the rcode in the main message header.
@@ -343,13 +341,12 @@ mod tests {
     use crate::base::{Message, MessageBuilder, Name, Rtype, StreamTarget};
     use crate::net::server::message::{Request, UdpTransportContext};
 
-    use super::start_reply;
     use crate::base::iana::{OptRcode, Rcode};
     use crate::base::message_builder::AdditionalBuilder;
     use crate::base::opt::UnknownOptData;
     use crate::base::wire::Composer;
     use crate::net::server::util::{
-        add_edns_options, remove_edns_opt_record,
+        add_edns_options, mk_builder_for_target, remove_edns_opt_record,
     };
     use std::vec::Vec;
 
@@ -365,10 +362,12 @@ mod tests {
         let client_ip = "127.0.0.1:12345".parse().unwrap();
         let sent_at = Instant::now();
         let ctx = UdpTransportContext::default();
-        let request = Request::new(client_ip, sent_at, msg, ctx.into());
+        let request = Request::new(client_ip, sent_at, msg, ctx.into(), ());
 
         // Create a dummy DNS reply which does not yet have an OPT record.
-        let reply = start_reply::<_, Vec<u8>>(request.message());
+        let reply = mk_builder_for_target::<Vec<u8>>()
+            .start_answer(request.message(), Rcode::NOERROR)
+            .unwrap();
         assert_eq!(reply.counts().arcount(), 0);
         assert_eq!(reply.header().rcode(), Rcode::NOERROR);
 
@@ -453,10 +452,12 @@ mod tests {
         let client_ip = "127.0.0.1:12345".parse().unwrap();
         let sent_at = Instant::now();
         let ctx = UdpTransportContext::default();
-        let request = Request::new(client_ip, sent_at, msg, ctx.into());
+        let request = Request::new(client_ip, sent_at, msg, ctx.into(), ());
 
         // Create a dummy DNS reply which does not yet have an OPT record.
-        let reply = start_reply::<_, Vec<u8>>(request.message());
+        let reply = mk_builder_for_target::<Vec<u8>>()
+            .start_answer(request.message(), Rcode::NOERROR)
+            .unwrap();
         assert_eq!(reply.counts().arcount(), 0);
 
         // Add an OPT record to the reply.


### PR DESCRIPTION
Taken from the `xfr` branch in order to split PR #335 into several smaller PRs.

This PR makes changes, some of which are breaking (i.e. not backward compatible with earlier unstable server functionality without minor adjustments to existing consumer code, e.g. see the changes to `examples/serve-zone.rs`), including:

- Adds support for indicating to downstream Service impls that a certain number of bytes should be reserved (to make space for adding a TSIG RR or EDNS options during middleware post-processing).

- Adds support for strongly typed passing of arbitrary metadata between middleware that produces a type and middleware that consumes the type (e.g. passing the used TSIG key name from TSIG middleware to XFR middleware).

- Replaces the blanket `impl Service for Arc` with a more general `impl Service for Deref`.

- Removes the blanket `impl Service for fn` as I have multiple times been blocked from defining some other Service impl because the fn one matches, because its presence can cause very confusing compiler error messages if your `impl Service for T` is not quite in sync with the signature of your other `impl T` blocks, and because Hyper doesn't need it so why do we?

- Adds an "enabled" flag to the `CookiesMiddlewareSvc` (and later the `TsigMiddlewareSvc` will have it as well) making it easier to create a service stack with optionally enabled layers based on runtime configuration.

There was some internal discussion today with @Philip-NLnetLabs about passing data between middleware layers instead as a map of string key to some value pairs, or adding an enum to Request with things that a middleware might need (e.g. TSIG key name, or other arbitrary T), but that isn't reflected (yet?) in this PR.

The upside of the approach in this PR is it allows a producing middleware to express the metadata type it produces and a consuming middleware to express compatibility with a certain metadata type (e.g. via a trait impl, see https://github.com/NLnetLabs/domain/commit/88a8f021db0051b82b1692760f492fa0fb12d3e7) and to then have compile time checking that the middleware are compatible with each other, without having to express up front every possible data that might need to be passed around with a request or else as some arbitrary Other(T). But I'm undecided about the best way to do this ...

The changes in this PR currently lack RustDocs, and testing (as the consuming and testing is done at the point of use in the `xfr` branch).