### PR TITLE
Client changes in preparation for XFR and TSIG support.

### DIFF
--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -440,10 +440,10 @@ impl<Octs: Octets + ?Sized> Message<Octs> {
     }
 
     /// Could this message result in a stream of responses?
-    /// 
+    ///
     /// Most DNS queries result in a single response, but some (only AXFR and
     /// IXFR at the time of writing) can result in a stream of responses.
-    /// 
+    ///
     /// Returns true if the first question is of a type that might result in a
     /// stream of responses.
     pub fn is_streaming(&self) -> bool {

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -439,6 +439,19 @@ impl<Octs: Octets + ?Sized> Message<Octs> {
         }
     }
 
+    /// Could this message result in a stream of responses?
+    /// 
+    /// Most DNS queries result in a single response, but some (only AXFR and
+    /// IXFR at the time of writing) can result in a stream of responses.
+    /// 
+    /// Returns true if the first question is of a type that might result in a
+    /// stream of responses.
+    pub fn is_streaming(&self) -> bool {
+        self.first_question()
+            .map(|q| matches!(q.qtype(), Rtype::AXFR | Rtype::IXFR))
+            .unwrap_or_default()
+    }
+
     /// Returns the first question, if there is any.
     ///
     /// The method will return `None` both if there are no questions or if

--- a/src/net/client/multi_stream.rs
+++ b/src/net/client/multi_stream.rs
@@ -356,7 +356,7 @@ impl<Req: ComposeRequest + Clone + 'static> GetResponse for Request<Req> {
         Box::pin(Self::get_response(self))
     }
 
-    // TODO: Override stream_complete() and is_stream_complete() like 
+    // TODO: Override stream_complete() and is_stream_complete() like
     // net::client::stream does?
 }
 

--- a/src/net/client/multi_stream.rs
+++ b/src/net/client/multi_stream.rs
@@ -355,6 +355,9 @@ impl<Req: ComposeRequest + Clone + 'static> GetResponse for Request<Req> {
     > {
         Box::pin(Self::get_response(self))
     }
+
+    // TODO: Override stream_complete() and is_stream_complete() like 
+    // net::client::stream does?
 }
 
 //------------ Transport ------------------------------------------------

--- a/src/net/client/request.rs
+++ b/src/net/client/request.rs
@@ -26,7 +26,7 @@ use crate::rdata::AllRecordData;
 /// A trait that allows composing a request as a series.
 pub trait ComposeRequest: Debug + Send + Sync {
     /// Writes the message to a provided composer.
-    /// 
+    ///
     /// Returns the builder used to allow the caller to make further changes
     /// if needed.
     fn to_message_builder<Target: Composer>(
@@ -93,7 +93,7 @@ pub trait GetResponse: Debug {
     /// Get the result of a DNS request.
     ///
     /// This function is intended to be cancel safe.
-    /// 
+    ///
     /// If [`is_stream_complete()`] returns false you can call this function
     /// again to receive the next response when dealing with a stream of
     /// responses.
@@ -109,7 +109,7 @@ pub trait GetResponse: Debug {
     >;
 
     /// Signal that no more responses are expected.
-    /// 
+    ///
     /// The DNS protocol does not provide a standardized way to detect the end
     /// of a stream of responses. At the time of writing the only query types
     /// that can result in a stream of responses are AXFR and IXFR. In both
@@ -124,10 +124,10 @@ pub trait GetResponse: Debug {
     }
 
     /// Has the last response been received or are more expected?
-    /// 
+    ///
     /// Call this after each call to [`get_response`] to check if more
     /// responses are expected.
-    /// 
+    ///
     /// Returns false if more responses are expected, true otherwise.
     fn is_stream_complete(&self) -> bool {
         // DNS response streams only exist at the time of writing for
@@ -137,7 +137,7 @@ pub trait GetResponse: Debug {
         // implementaiton. We return true because the caller should always
         // check for at least one response and then if they call this function
         // to find out if there will be more we say no, the stream is
-        // complete. 
+        // complete.
         true
     }
 }
@@ -237,9 +237,10 @@ impl<Octs: AsRef<[u8]> + Debug + Octets> RequestMessage<Octs> {
 
         let builder = self.append_message_impl(target)?;
 
-        let msg = Message::from_octets(builder.finish().into_target()).expect(
-            "Message should be able to parse output from MessageBuilder",
-        );
+        let msg = Message::from_octets(builder.finish().into_target())
+            .expect(
+                "Message should be able to parse output from MessageBuilder",
+            );
         Ok(msg)
     }
 }

--- a/src/net/client/stream.rs
+++ b/src/net/client/stream.rs
@@ -342,7 +342,7 @@ impl Request {
 
         // Do we have a response stream that we should consume from? If not
         // the result is already available and can be returned immediately.
-        let stream = self.stream else {
+        let Some(stream) = self.stream.as_mut() else {
             return res;
         };
 

--- a/src/net/client/stream.rs
+++ b/src/net/client/stream.rs
@@ -954,10 +954,11 @@ where
 
     /// Convert the query message to a vector.
     fn convert_query(msg: &Req) -> Result<Vec<u8>, Error> {
-        let mut target = StreamTarget::new_vec();
-        msg.append_message(&mut target)
+        let target = StreamTarget::new_vec();
+        let target = msg
+            .to_message_builder(target)
             .map_err(|_| Error::StreamLongMessage)?;
-        Ok(target.into_target())
+        Ok(target.finish().into_target())
     }
 }
 


### PR DESCRIPTION
Taken from the `xfr` branch in order to split PR https://github.com/NLnetLabs/domain/pull/335 into several smaller PRs.

This PR changes the client code to support streaming responses (for XFR) and modifiable requests prior to sending (for TSIG), pushed to this branch as two separate commits (except for an accidentally introduced compilation error which is fixed by the third commit).

I believe that @Philip-NLnetLabs has an alternate proposal coming that is likely cleaner than this PR, but at present these are the changes to the code that PR #335 depends on.

This PR adds the concept of streaming support to all clients in principle but only extends the `net::client::stream` client to actually support a response stream, which is enough for the XFR PR.