### PR TITLE
Fix TXT record equality

### DIFF
--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -331,9 +331,7 @@ where
     Other: AsRef<[u8]>,
 {
     fn eq(&self, other: &Txt<Other>) -> bool {
-        self.iter()
-            .flat_map(|s| s.iter().copied())
-            .eq(other.iter().flat_map(|s| s.iter().copied()))
+        self.0.as_ref().eq(other.0.as_ref())
     }
 }
 
@@ -347,9 +345,7 @@ where
     Other: AsRef<[u8]>,
 {
     fn partial_cmp(&self, other: &Txt<Other>) -> Option<Ordering> {
-        self.iter()
-            .flat_map(|s| s.iter().copied())
-            .partial_cmp(other.iter().flat_map(|s| s.iter().copied()))
+        self.0.as_ref().partial_cmp(other.0.as_ref())
     }
 }
 
@@ -359,26 +355,13 @@ where
     Other: AsRef<[u8]>,
 {
     fn canonical_cmp(&self, other: &Txt<Other>) -> Ordering {
-        // Canonical comparison requires TXT RDATA to be canonically
-        // sorted in the wire format.
-        // The TXT has each label prefixed by length, which must be
-        // taken into account.
-        for (a, b) in self.iter().zip(other.iter()) {
-            match (a.len(), a).cmp(&(b.len(), b)) {
-                Ordering::Equal => continue,
-                r => return r,
-            }
-        }
-
-        Ordering::Equal
+        self.0.as_ref().cmp(other.0.as_ref())
     }
 }
 
 impl<Octs: AsRef<[u8]>> Ord for Txt<Octs> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.iter()
-            .flat_map(|s| s.iter().copied())
-            .cmp(other.iter().flat_map(|s| s.iter().copied()))
+        self.0.as_ref().cmp(other.0.as_ref())
     }
 }
 
@@ -386,9 +369,7 @@ impl<Octs: AsRef<[u8]>> Ord for Txt<Octs> {
 
 impl<Octs: AsRef<[u8]>> hash::Hash for Txt<Octs> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.iter()
-            .flat_map(|s| s.iter().copied())
-            .for_each(|c| c.hash(state))
+        self.0.as_ref().hash(state)
     }
 }
 
@@ -1033,6 +1014,29 @@ mod test {
         for (a, b) in records.iter().zip(sorted.iter()) {
             assert_eq!(a, b);
         }
+    }
+
+    #[test]
+    fn txt_strings_eq() {
+        let records = [["foo", "bar"], ["foob", "ar"], ["foo", "bar"]];
+
+        let records = records
+            .iter()
+            .map(|strings| {
+                let mut builder = TxtBuilder::<Vec<u8>>::new();
+                for string in strings {
+                    builder
+                        .append_charstr(
+                            CharStr::from_slice(string.as_bytes()).unwrap(),
+                        )
+                        .unwrap();
+                }
+                builder.finish().unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert_ne!(records[0], records[1]);
+        assert_eq!(records[0], records[2]);
     }
 
     #[cfg(all(feature = "serde", feature = "std"))]


### PR DESCRIPTION
A TXT record with strings ["foo", "bar"] is not equal to a TXT record with strings ["foob", "ar"].
This is important for resolvers and DNS servers deduplicating RRs. This fixes `PartialEq` accordingly.