### PR TITLE
XFR zone updating.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,11 @@ zonefile    = ["bytes", "serde", "std"]
 
 # Unstable features
 unstable-client-transport = ["moka", "net", "tracing"]
-unstable-server-transport = ["arc-swap", "chrono/clock", "libc", "net", "rustversion", "siphasher", "tracing"]
+unstable-server-transport = ["arc-swap", "chrono/clock", "libc", "net", "siphasher", "tracing"]
 unstable-stelline = ["tokio/test-util", "tracing", "tracing-subscriber", "unstable-server-transport", "zonefile"]
 unstable-validator = ["validate", "zonefile", "unstable-client-transport"]
 unstable-xfr = []
-unstable-zonetree = ["futures-util", "parking_lot", "serde", "tokio", "tracing"]
+unstable-zonetree = ["futures-util", "parking_lot", "rustversion", "serde", "tokio", "tracing"]
 
 [dev-dependencies]
 lazy_static        = { version = "1.4.0" }

--- a/src/base/serial.rs
+++ b/src/base/serial.rs
@@ -4,21 +4,19 @@
 //! viewed as the 32 bit modulus of a larger number space. Because of that,
 //! special rules apply when processing these values. This module provides
 //! the type [`Serial`] that implements these rules.
-use core::cmp::Ordering;
-use core::{cmp, fmt, str};
-
-#[cfg(all(feature = "std", not(test)))]
-use std::time::{SystemTime, UNIX_EPOCH};
-
-#[cfg(feature = "chrono")]
-use chrono::{DateTime, TimeZone};
-#[cfg(all(feature = "std", test))]
-use mock_instant::thread_local::{SystemTime, UNIX_EPOCH};
-use octseq::parse::Parser;
 
 use super::cmp::CanonicalOrd;
 use super::scan::{Scan, Scanner};
 use super::wire::{Compose, Composer, Parse, ParseError};
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, TimeZone};
+use core::cmp::Ordering;
+use core::{cmp, fmt, str};
+#[cfg(all(feature = "std", test))]
+use mock_instant::thread_local::{SystemTime, UNIX_EPOCH};
+use octseq::parse::Parser;
+#[cfg(all(feature = "std", not(test)))]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 //------------ Serial --------------------------------------------------------
 
@@ -90,13 +88,6 @@ impl Serial {
     pub fn add(self, other: u32) -> Self {
         assert!(other <= 0x7FFF_FFFF);
         Serial(self.0.wrapping_add(other))
-    }
-
-    #[allow(clippy::should_implement_trait)]
-    #[must_use]
-    pub fn sub(self, other: u32) -> Self {
-        assert!(other <= 0x7FFF_FFFF);
-        Serial(self.0.wrapping_sub(other))
     }
 
     pub fn scan<S: Scanner>(scanner: &mut S) -> Result<Self, S::Error> {

--- a/src/net/xfr/protocol/interpreter.rs
+++ b/src/net/xfr/protocol/interpreter.rs
@@ -297,9 +297,7 @@ impl RecordProcessor {
                 ZoneUpdate::Finished(rec)
             }
 
-            XfrType::Axfr => {
-                ZoneUpdate::AddRecord(self.current_soa.serial(), rec)
-            }
+            XfrType::Axfr => ZoneUpdate::AddRecord(rec),
 
             XfrType::Ixfr if self.rr_count < 2 => unreachable!(),
 
@@ -348,7 +346,7 @@ impl RecordProcessor {
                     // assume that "incremental zone transfer is not available"
                     // and so "the behaviour is the same as an AXFR response",
                     self.actual_xfr_type = XfrType::Axfr;
-                    ZoneUpdate::AddRecord(self.current_soa.serial(), rec)
+                    ZoneUpdate::AddRecord(rec)
                 }
             }
 
@@ -377,14 +375,10 @@ impl RecordProcessor {
                     }
                 } else {
                     match self.ixfr_update_mode {
-                        IxfrUpdateMode::Deleting => ZoneUpdate::DeleteRecord(
-                            self.current_soa.serial(),
-                            rec,
-                        ),
-                        IxfrUpdateMode::Adding => ZoneUpdate::AddRecord(
-                            self.current_soa.serial(),
-                            rec,
-                        ),
+                        IxfrUpdateMode::Deleting => {
+                            ZoneUpdate::DeleteRecord(rec)
+                        }
+                        IxfrUpdateMode::Adding => ZoneUpdate::AddRecord(rec),
                     }
                 }
             }

--- a/src/net/xfr/protocol/interpreter.rs
+++ b/src/net/xfr/protocol/interpreter.rs
@@ -40,6 +40,8 @@ pub struct XfrResponseInterpreter {
     /// Internal state.
     ///
     /// None until the first call to [`interpret_response()`].
+    ///
+    /// [`interpret_response()`]: XfrResponseInterpreter::interpret_response()
     inner: Option<Inner>,
 }
 
@@ -148,6 +150,8 @@ impl XfrResponseInterpreter {
 ///
 /// Separated out from [`XfrResponseInterpreter`] to avoid needing multiple
 /// mutable self references in [`interpret_response()`].
+///
+/// [`interpret_response()`]: XfrResponseInterpreter::interpret_response()
 struct Inner {
     /// The response message currently being processed.
     resp: Message<Bytes>,

--- a/src/net/xfr/protocol/interpreter.rs
+++ b/src/net/xfr/protocol/interpreter.rs
@@ -8,7 +8,7 @@ use crate::rdata::{Soa, ZoneRecordData};
 use crate::zonetree::types::ZoneUpdate;
 
 use super::iterator::XfrZoneUpdateIterator;
-use super::types::{Error, IxfrUpdateMode, XfrRecord, XfrType};
+use super::types::{Error, IxfrUpdateMode, ParsedRecord, XfrType};
 
 //------------ XfrResponseInterpreter -----------------------------------------
 
@@ -259,8 +259,8 @@ impl RecordProcessor {
     /// record, if any.
     pub(super) fn process_record(
         &mut self,
-        rec: XfrRecord,
-    ) -> ZoneUpdate<XfrRecord> {
+        rec: ParsedRecord,
+    ) -> ZoneUpdate<ParsedRecord> {
         self.rr_count += 1;
 
         // https://datatracker.ietf.org/doc/html/rfc5936#section-2.2

--- a/src/net/xfr/protocol/iterator.rs
+++ b/src/net/xfr/protocol/iterator.rs
@@ -9,7 +9,7 @@ use crate::rdata::ZoneRecordData;
 use crate::zonetree::types::ZoneUpdate;
 
 use super::interpreter::RecordProcessor;
-use super::types::{Error, IterationError, XfrRecord};
+use super::types::{Error, IterationError, ParsedRecord};
 
 //------------ XfrZoneUpdateIterator ------------------------------------------
 
@@ -62,7 +62,7 @@ impl<'a, 'b> XfrZoneUpdateIterator<'a, 'b> {
 }
 
 impl<'a, 'b> Iterator for XfrZoneUpdateIterator<'a, 'b> {
-    type Item = Result<ZoneUpdate<XfrRecord>, IterationError>;
+    type Item = Result<ZoneUpdate<ParsedRecord>, IterationError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.iter.next()? {

--- a/src/net/xfr/protocol/iterator.rs
+++ b/src/net/xfr/protocol/iterator.rs
@@ -72,9 +72,9 @@ impl<'a, 'b> Iterator for XfrZoneUpdateIterator<'a, 'b> {
             self.state.rr_count += 1;
 
             if self.state.actual_xfr_type == XfrType::Axfr {
-                // For AXFR we're not making changes to a zone, we're
-                // replacing its entire contents, so before returning any
-                // actual updates to apply, first instruct the consumer to
+                // For AXFR we're not making incremental changes to a zone,
+                // we're replacing its entire contents, so before returning
+                // any actual updates to apply first instruct the consumer to
                 // "discard" everything it has.
                 return Some(Ok(ZoneUpdate::DeleteAllRecords));
             }

--- a/src/net/xfr/protocol/mod.rs
+++ b/src/net/xfr/protocol/mod.rs
@@ -15,4 +15,4 @@ mod tests;
 
 pub use interpreter::XfrResponseInterpreter;
 pub use iterator::XfrZoneUpdateIterator;
-pub use types::{Error, IterationError, XfrRecord};
+pub use types::{Error, IterationError, ParsedRecord};

--- a/src/net/xfr/protocol/tests.rs
+++ b/src/net/xfr/protocol/tests.rs
@@ -9,7 +9,7 @@ use crate::base::iana::Rcode;
 use crate::base::message_builder::{
     AnswerBuilder, AuthorityBuilder, QuestionBuilder,
 };
-use crate::base::net::Ipv4Addr;
+use crate::base::net::{Ipv4Addr, Ipv6Addr};
 use crate::base::rdata::ComposeRecordData;
 use crate::base::{
     Message, MessageBuilder, ParsedName, Record, Rtype, Serial, Ttl,
@@ -20,7 +20,6 @@ use crate::zonetree::types::{ZoneUpdate, ZoneUpdate as ZU};
 
 use super::interpreter::XfrResponseInterpreter;
 use super::types::{Error, IterationError, ParsedRecord};
-use core::net::Ipv6Addr;
 
 #[test]
 fn non_xfr_response_is_rejected() {

--- a/src/net/xfr/protocol/tests.rs
+++ b/src/net/xfr/protocol/tests.rs
@@ -19,7 +19,7 @@ use crate::rdata::{Soa, ZoneRecordData, A};
 use crate::zonetree::types::{ZoneUpdate, ZoneUpdate as ZU};
 
 use super::interpreter::XfrResponseInterpreter;
-use super::types::{Error, IterationError, XfrRecord};
+use super::types::{Error, IterationError, ParsedRecord};
 
 #[test]
 fn non_xfr_response_is_rejected() {
@@ -276,7 +276,7 @@ fn ixfr_response_generates_expected_updates() {
     // Verify the updates emitted by the XFR interpreter.
     let owner =
         ParsedName::<Bytes>::from(Name::from_str("example.com").unwrap());
-    let expected_updates: [Result<ZoneUpdate<XfrRecord>, IterationError>; 7] = [
+    let expected_updates: [Result<ZoneUpdate<ParsedRecord>, IterationError>; 7] = [
         Ok(ZoneUpdate::BeginBatchDelete(Record::from((
             owner.clone(),
             0,

--- a/src/net/xfr/protocol/tests.rs
+++ b/src/net/xfr/protocol/tests.rs
@@ -15,11 +15,12 @@ use crate::base::{
     Message, MessageBuilder, ParsedName, Record, Rtype, Serial, Ttl,
 };
 use crate::base::{Name, ToName};
-use crate::rdata::{Soa, ZoneRecordData, A};
+use crate::rdata::{Aaaa, Soa, ZoneRecordData, A};
 use crate::zonetree::types::{ZoneUpdate, ZoneUpdate as ZU};
 
 use super::interpreter::XfrResponseInterpreter;
 use super::types::{Error, IterationError, ParsedRecord};
+use core::net::Ipv6Addr;
 
 #[test]
 fn non_xfr_response_is_rejected() {
@@ -112,7 +113,8 @@ fn incomplete_axfr_response_is_accepted() {
     // Process the response.
     let mut it = interpreter.interpret_response(resp).unwrap();
 
-    // Verify that no updates are by the XFR interpreter.
+    // Verify that no updates are output by the XFR interpreter.
+    assert_eq!(it.next(), Some(Ok(ZoneUpdate::DeleteAllRecords)));
     assert!(it.next().is_none());
 }
 
@@ -141,6 +143,7 @@ fn axfr_response_with_only_soas_is_accepted() {
     let mut it = interpreter.interpret_response(resp).unwrap();
 
     // Verify the updates emitted by the XFR interpreter.
+    assert_eq!(it.next(), Some(Ok(ZoneUpdate::DeleteAllRecords)));
     assert!(matches!(it.next(), Some(Ok(ZU::Finished(_)))));
     assert!(it.next().is_none());
 }
@@ -169,6 +172,7 @@ fn axfr_multi_response_with_only_soas_is_accepted() {
     let mut it = interpreter.interpret_response(resp).unwrap();
 
     // Verify the updates emitted by the XFR interpreter.
+    assert_eq!(it.next(), Some(Ok(ZoneUpdate::DeleteAllRecords)));
     assert!(it.next().is_none());
 
     // Create another AXFR response to complete the transfer.
@@ -200,7 +204,7 @@ fn axfr_response_generates_expected_updates() {
     let soa = mk_soa(serial);
     add_answer_record(&req, &mut answer, soa.clone());
     add_answer_record(&req, &mut answer, A::new(Ipv4Addr::LOCALHOST));
-    add_answer_record(&req, &mut answer, A::new(Ipv4Addr::BROADCAST));
+    add_answer_record(&req, &mut answer, Aaaa::new(Ipv6Addr::LOCALHOST));
     add_answer_record(&req, &mut answer, soa);
     let resp = answer.into_message();
 
@@ -208,10 +212,14 @@ fn axfr_response_generates_expected_updates() {
     let mut it = interpreter.interpret_response(resp).unwrap();
 
     // Verify the updates emitted by the XFR interpreter.
-    let s = serial;
-    assert!(matches!(it.next(), Some(Ok(ZU::AddRecord(n, _))) if n == s));
-    assert!(matches!(it.next(), Some(Ok(ZU::AddRecord(n, _))) if n == s));
-    assert!(matches!(it.next(), Some(Ok(ZU::Finished(_)))));
+    assert_eq!(it.next(), Some(Ok(ZoneUpdate::DeleteAllRecords)));
+    assert!(
+        matches!(it.next(), Some(Ok(ZoneUpdate::AddRecord(r))) if r.rtype() == Rtype::A)
+    );
+    assert!(
+        matches!(it.next(), Some(Ok(ZoneUpdate::AddRecord(r))) if r.rtype() == Rtype::AAAA)
+    );
+    assert!(matches!(it.next(), Some(Ok(ZoneUpdate::Finished(_)))));
     assert!(it.next().is_none());
 }
 
@@ -283,43 +291,31 @@ fn ixfr_response_generates_expected_updates() {
             0,
             ZoneRecordData::Soa(expected_old_soa),
         )))),
-        Ok(ZoneUpdate::DeleteRecord(
-            old_serial,
-            Record::from((
-                owner.clone(),
-                0,
-                ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
-            )),
-        )),
-        Ok(ZoneUpdate::DeleteRecord(
-            old_serial,
-            Record::from((
-                owner.clone(),
-                0,
-                ZoneRecordData::A(A::new(Ipv4Addr::BROADCAST)),
-            )),
-        )),
+        Ok(ZoneUpdate::DeleteRecord(Record::from((
+            owner.clone(),
+            0,
+            ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
+        )))),
+        Ok(ZoneUpdate::DeleteRecord(Record::from((
+            owner.clone(),
+            0,
+            ZoneRecordData::A(A::new(Ipv4Addr::BROADCAST)),
+        )))),
         Ok(ZoneUpdate::BeginBatchAdd(Record::from((
             owner.clone(),
             0,
             ZoneRecordData::Soa(expected_new_soa.clone()),
         )))),
-        Ok(ZoneUpdate::AddRecord(
-            new_serial,
-            Record::from((
-                owner.clone(),
-                0,
-                ZoneRecordData::A(A::new(Ipv4Addr::BROADCAST)),
-            )),
-        )),
-        Ok(ZoneUpdate::AddRecord(
-            new_serial,
-            Record::from((
-                owner.clone(),
-                0,
-                ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
-            )),
-        )),
+        Ok(ZoneUpdate::AddRecord(Record::from((
+            owner.clone(),
+            0,
+            ZoneRecordData::A(A::new(Ipv4Addr::BROADCAST)),
+        )))),
+        Ok(ZoneUpdate::AddRecord(Record::from((
+            owner.clone(),
+            0,
+            ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
+        )))),
         Ok(ZoneUpdate::Finished(Record::from((
             owner.clone(),
             0,

--- a/src/net/xfr/protocol/tests.rs
+++ b/src/net/xfr/protocol/tests.rs
@@ -276,7 +276,8 @@ fn ixfr_response_generates_expected_updates() {
     // Verify the updates emitted by the XFR interpreter.
     let owner =
         ParsedName::<Bytes>::from(Name::from_str("example.com").unwrap());
-    let expected_updates: [Result<ZoneUpdate<ParsedRecord>, IterationError>; 7] = [
+    let expected_updates: [Result<ZoneUpdate<ParsedRecord>, IterationError>;
+        7] = [
         Ok(ZoneUpdate::BeginBatchDelete(Record::from((
             owner.clone(),
             0,

--- a/src/net/xfr/protocol/types.rs
+++ b/src/net/xfr/protocol/types.rs
@@ -12,7 +12,7 @@ use crate::{
 /// The type of record processed by [`XfrResponseInterpreter`].
 ///
 /// [`XfrResponseInterpreter`]: super::interpreter::XfrResponseInterpreter
-pub type XfrRecord =
+pub type ParsedRecord =
     Record<ParsedName<Bytes>, ZoneRecordData<Bytes, ParsedName<Bytes>>>;
 
 //------------ XfrType --------------------------------------------------------

--- a/src/zonetree/in_memory/mod.rs
+++ b/src/zonetree/in_memory/mod.rs
@@ -1,3 +1,6 @@
+//! An in-memory backing store for [`Zone`]s.
+//!
+//! [`Zone`]: super::Zone
 mod builder;
 mod nodes;
 mod read;

--- a/src/zonetree/in_memory/nodes.rs
+++ b/src/zonetree/in_memory/nodes.rs
@@ -268,7 +268,7 @@ impl NodeRrsets {
     }
 
     /// Removes the RRset for the given type.
-    pub fn remove(&self, rtype: Rtype, version: Version) {
+    pub fn remove_rtype(&self, rtype: Rtype, version: Version) {
         self.rrsets
             .write()
             .entry(rtype)

--- a/src/zonetree/in_memory/nodes.rs
+++ b/src/zonetree/in_memory/nodes.rs
@@ -254,11 +254,15 @@ impl NodeRrsets {
 
     /// Updates an RRset.
     pub fn update(&self, rrset: SharedRrset, version: Version) {
-        self.rrsets
-            .write()
-            .entry(rrset.rtype())
-            .or_default()
-            .update(rrset, version)
+        if rrset.is_empty() {
+            self.remove_rtype(rrset.rtype(), version);
+        } else {
+            self.rrsets
+                .write()
+                .entry(rrset.rtype())
+                .or_default()
+                .update(rrset, version);
+        }
     }
 
     /// Removes the RRset for the given type.
@@ -267,7 +271,7 @@ impl NodeRrsets {
             .write()
             .entry(rtype)
             .or_default()
-            .remove(version)
+            .remove(version);
     }
 
     pub fn rollback(&self, version: Version) {

--- a/src/zonetree/in_memory/nodes.rs
+++ b/src/zonetree/in_memory/nodes.rs
@@ -335,11 +335,6 @@ impl NodeRrset {
     pub fn rollback(&mut self, version: Version) {
         self.rrsets.rollback(version);
     }
-
-    #[allow(dead_code)]
-    pub fn clean(&mut self, version: Version) {
-        self.rrsets.rollback(version);
-    }
 }
 
 //------------ Special -------------------------------------------------------

--- a/src/zonetree/in_memory/nodes.rs
+++ b/src/zonetree/in_memory/nodes.rs
@@ -1,4 +1,4 @@
-//! The nodes in a zone tree.
+//! The resource record tree nodes of an in-memory zone.
 
 use std::boxed::Box;
 use std::collections::{hash_map, HashMap};

--- a/src/zonetree/in_memory/nodes.rs
+++ b/src/zonetree/in_memory/nodes.rs
@@ -15,6 +15,7 @@ use crate::base::iana::{Class, Rtype};
 use crate::base::name::{Label, OwnedLabel, ToName};
 use crate::zonetree::error::{CnameError, OutOfZone, ZoneCutError};
 use crate::zonetree::types::{StoredName, ZoneCut};
+use crate::zonetree::util::rel_name_rev_iter;
 use crate::zonetree::walk::WalkState;
 use crate::zonetree::{
     ReadableZone, SharedRr, SharedRrset, WritableZone, ZoneStore,
@@ -23,7 +24,6 @@ use crate::zonetree::{
 use super::read::ReadZone;
 use super::versioned::{Version, Versioned};
 use super::write::{WriteZone, ZoneVersions};
-use crate::zonetree::util::rel_name_rev_iter;
 
 //------------ ZoneApex ------------------------------------------------------
 

--- a/src/zonetree/in_memory/nodes.rs
+++ b/src/zonetree/in_memory/nodes.rs
@@ -1,6 +1,5 @@
 //! The nodes in a zone tree.
 
-use core::any::Any;
 use std::boxed::Box;
 use std::collections::{hash_map, HashMap};
 use std::future::Future;
@@ -151,10 +150,6 @@ impl ZoneStore for ZoneApex {
             Box::new(WriteZone::new(self, lock, version, zone_versions))
                 as Box<dyn WritableZone>
         })
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self as &dyn Any
     }
 }
 

--- a/src/zonetree/in_memory/nodes.rs
+++ b/src/zonetree/in_memory/nodes.rs
@@ -12,7 +12,7 @@ use parking_lot::{
 use tokio::sync::Mutex;
 
 use crate::base::iana::{Class, Rtype};
-use crate::base::name::{Label, OwnedLabel, ToLabelIter, ToName};
+use crate::base::name::{Label, OwnedLabel, ToName};
 use crate::zonetree::error::{CnameError, OutOfZone, ZoneCutError};
 use crate::zonetree::types::{StoredName, ZoneCut};
 use crate::zonetree::walk::WalkState;
@@ -23,6 +23,7 @@ use crate::zonetree::{
 use super::read::ReadZone;
 use super::versioned::{Version, Versioned};
 use super::write::{WriteZone, ZoneVersions};
+use crate::zonetree::util::rel_name_rev_iter;
 
 //------------ ZoneApex ------------------------------------------------------
 
@@ -71,14 +72,7 @@ impl ZoneApex {
         &self,
         qname: &'l impl ToName,
     ) -> Result<impl Iterator<Item = &'l Label> + Clone, OutOfZone> {
-        let mut qname = qname.iter_labels().rev();
-        for apex_label in self.name().iter_labels().rev() {
-            let qname_label = qname.next();
-            if Some(apex_label) != qname_label {
-                return Err(OutOfZone);
-            }
-        }
-        Ok(qname)
+        rel_name_rev_iter(&self.apex_name, qname)
     }
 
     /// Returns the RRsets of this node.

--- a/src/zonetree/in_memory/read.rs
+++ b/src/zonetree/in_memory/read.rs
@@ -1,4 +1,4 @@
-//! Quering for zone data.
+//! Read access to in-memory zones.
 use core::iter;
 
 use std::sync::Arc;

--- a/src/zonetree/in_memory/versioned.rs
+++ b/src/zonetree/in_memory/versioned.rs
@@ -69,7 +69,17 @@ impl<T> Versioned<T> {
     }
 
     pub fn remove(&mut self, version: Version) {
-        self.data.retain(|item| item.0 >= version)
+        // We can't just remove the value for the specified version because if
+        // it should be a new version of the zone and a value exists for a
+        // previous version, then we have to mask the old value so that it
+        // isn't seen by consumers of the newer version of the zone.
+        if let Some(last) = self.data.last_mut() {
+            if last.0 == version {
+                last.1 = None;
+                return;
+            }
+        }
+        self.data.push((version, None))
     }
 }
 

--- a/src/zonetree/in_memory/versioned.rs
+++ b/src/zonetree/in_memory/versioned.rs
@@ -69,24 +69,7 @@ impl<T> Versioned<T> {
     }
 
     pub fn remove(&mut self, version: Version) {
-        // WARNING: This isn't safe to do while updating a zone, e.g. via an
-        // AXFR that lacks some records that were in the previous version of
-        // the zone, as the effects are immediately visible to users of the
-        // zone!
-        //
-        //   self.data.retain(|item| item.0 >= version)
-        //
-        // When updating a Zone via ZoneStore::write(), the new version of the
-        // zone that is created will be one higher than the highest version of
-        // data currently in the zone.
-        //
-        // So adding an empty value at the new version will cause current
-        // clients to continue seeing the old version, but clients of the zone
-        // after it is committed will see the new version, i.e. the empty
-        // value which will cause get() to return None.
-        if self.data.last().map(|item| item.0).is_some() {
-            self.data.push((version, None));
-        }
+        self.data.retain(|item| item.0 >= version)
     }
 }
 

--- a/src/zonetree/in_memory/versioned.rs
+++ b/src/zonetree/in_memory/versioned.rs
@@ -21,9 +21,6 @@ impl Version {
     pub fn next(self) -> Version {
         Version(self.0.add(1))
     }
-    pub fn prev(self) -> Version {
-        Version(self.0.sub(1))
-    }
 }
 
 impl Default for Version {

--- a/src/zonetree/in_memory/versioned.rs
+++ b/src/zonetree/in_memory/versioned.rs
@@ -1,3 +1,4 @@
+//! Data types for storing in-memory zone data by zone version.
 use crate::base::serial::Serial;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
@@ -31,6 +32,9 @@ impl Default for Version {
 
 //------------ Versioned -----------------------------------------------------
 
+/// A history preserving ordered map of data keyed by zone version.
+///
+/// Updates and inserts preserve previous versions of the stored data.
 #[derive(Clone, Debug)]
 pub struct Versioned<T> {
     data: Vec<(Version, Option<T>)>,

--- a/src/zonetree/in_memory/versioned.rs
+++ b/src/zonetree/in_memory/versioned.rs
@@ -46,13 +46,17 @@ impl<T> Versioned<T> {
     }
 
     pub fn get(&self, version: Version) -> Option<&T> {
-        self.data.iter().rev().find_map(|item| {
+        let res = self.data.iter().rev().find_map(|item| {
             if item.0 <= version {
-                item.1.as_ref()
+                // Allow returning of empty values.
+                Some(item.1.as_ref())
             } else {
                 None
             }
-        })
+        });
+
+        // Flatten Some(None) to None for empty values.
+        res.flatten()
     }
 
     pub fn update(&mut self, version: Version, value: T) {

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -258,6 +258,7 @@ impl WritableZone for WriteZone {
 
         if let Ok(write_node) = &new_apex {
             *self.diff.lock().unwrap() = write_node.diff();
+            self.dirty.store(true, Ordering::SeqCst);
         }
 
         let res = new_apex
@@ -268,8 +269,6 @@ impl WritableZone for WriteZone {
                     format!("Open error: {err}"),
                 )
             });
-
-        self.dirty.store(true, Ordering::SeqCst);
 
         Box::pin(ready(res))
     }

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -402,7 +402,7 @@ impl WriteNode {
             }
         }
 
-        rrsets.remove(rtype, self.zone.new_version);
+        rrsets.remove_rtype(rtype, self.zone.new_version);
         self.check_nx_domain()?;
 
         Ok(())

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -35,19 +35,19 @@ pub struct WriteZone {
     apex: Arc<ZoneApex>,
 
     /// A write lock on the zone.
-    /// 
+    ///
     /// This lock is granted by [`ZoneApex::write()`] and held by us until we
     /// are finished. Further calls to [`ZoneApex::write()`] will block until
     /// we are dropped and release the lock.
-    /// 
+    ///
     /// [ZoneApex::write()]: ZoneApex::write()
     _lock: Option<OwnedMutexGuard<()>>,
 
     /// The version number of the new zone version to create.
-    /// 
+    ///
     /// This is set initially in [`new()`] and is incremented by [`commit()`]
     /// after the new zone version has been published.
-    /// 
+    ///
     /// Note: There is currently no mechanism for controlling the version
     /// number of the next zone version to be published. However, this version
     /// number is for internal use and is not (yet?) constrained to match the
@@ -69,7 +69,7 @@ pub struct WriteZone {
     /// needs to call [`ZoneDiffBuilder::build()`] in [`commit()`] which
     /// requires that the builder be consumed (and thus owned, ). It is stored
     /// as an Option because storing a diff is costly thus optional.
-    /// 
+    ///
     /// The innermost Arc<Mutex<..>> is needed because each time
     /// [`WriteNode::update_child()`] is called it creates a new [`WriteNode`]
     /// which also needs to be able to add and remove things from the same

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -6,7 +6,6 @@ use core::sync::atomic::Ordering;
 
 use std::boxed::Box;
 use std::future::Future;
-use std::io::ErrorKind;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -17,7 +16,7 @@ use std::{fmt, io};
 use futures_util::future::Either;
 use parking_lot::RwLock;
 use tokio::sync::OwnedMutexGuard;
-use tracing::trace;
+use tracing::{trace, warn};
 
 use crate::base::iana::Rtype;
 use crate::base::name::Label;
@@ -326,13 +325,13 @@ impl WritableZone for WriteZone {
                 self.add_soa_add_diff_entry(new_soa_rr, &mut diff);
 
             if old_serial.is_some() && new_serial.is_some() {
-                let Ok(zone_diff) = diff.build() else {
-                    return Box::pin(ready(Err(std::io::Error::new(
-                        ErrorKind::Other,
-                        "Diff lacks SOA records",
-                    ))));
+                out_diff = match diff.build() {
+                    Ok(zone_diff) => Some(zone_diff),
+                    Err(err) => {
+                        warn!("Error constructing diff: {err}");
+                        None
+                    }
                 };
-                out_diff = Some(zone_diff);
             }
         }
 

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -1,4 +1,4 @@
-//! Write access to zones.
+//! Write access to in-memory zones.
 
 use core::future::ready;
 use std::boxed::Box;
@@ -29,6 +29,7 @@ use crate::rdata::ZoneRecordData;
 
 //------------ WriteZone -----------------------------------------------------
 
+/// Serialized write operations on in-memory zones with auto-diffing support.
 pub struct WriteZone {
     apex: Arc<ZoneApex>,
     _lock: Option<OwnedMutexGuard<()>>,
@@ -231,12 +232,20 @@ impl WritableZone for WriteZone {
     }
 }
 
+/// Returns the inner value, if the Arc has exactly one strong reference.
+///
+/// Wrapper around [`Arc::into_inner()`] with an implementation back-ported
+/// for Rust <1.70.0 when [`Arc::into_inner()`] did not exist yet.
 #[rustversion::since(1.70.0)]
 fn arc_into_inner<T>(this: Arc<Mutex<T>>) -> Option<Mutex<T>> {
     #[allow(clippy::incompatible_msrv)]
     Arc::into_inner(this)
 }
 
+/// Returns the inner value, if the Arc has exactly one strong reference.
+///
+/// Wrapper around [`Arc::into_inner()`] with an implementation back-ported
+/// for Rust <1.70.0 when [`Arc::into_inner()`] did not exist yet.
 #[rustversion::before(1.70.0)]
 fn arc_into_inner<T>(this: Arc<Mutex<T>>) -> Option<Mutex<T>> {
     // From: https://doc.rust-lang.org/std/sync/struct.Arc.html#method.into_inner
@@ -258,6 +267,7 @@ fn arc_into_inner<T>(this: Arc<Mutex<T>>) -> Option<Mutex<T>> {
 
 //------------ WriteNode ------------------------------------------------------
 
+/// Write operations on in-memory zone tree nodes with auto-diffing support.
 pub struct WriteNode {
     /// The writer for the zone we are working with.
     zone: WriteZone,
@@ -634,6 +644,7 @@ impl fmt::Display for WriteApexError {
 
 //------------ ZoneVersions --------------------------------------------------
 
+/// An ordered collection of zone versions of which only one is "current".
 #[derive(Debug)]
 pub struct ZoneVersions {
     current: (Version, Arc<VersionMarker>),

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -228,7 +228,7 @@ fn arc_into_inner<T>(this: Arc<Mutex<T>>) -> Option<Mutex<T>> {
 }
 
 #[rustversion::before(1.70.0)]
-fn arc_into_inner(this: Arc<Mutex<T>>) -> Option<Mutex<T>> {
+fn arc_into_inner<T>(this: Arc<Mutex<T>>) -> Option<Mutex<T>> {
     // From: https://doc.rust-lang.org/std/sync/struct.Arc.html#method.into_inner
     //
     // "If Arc::into_inner is called on every clone of this Arc, it is

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -306,10 +306,8 @@ impl WritableZone for WriteZone {
         let old_soa_rr = self.apex.get_soa(self.last_published_version());
         let new_soa_rr = self.apex.get_soa(self.new_version);
 
-        let mut soa_serial_bumped = false;
         if bump_soa_serial && old_soa_rr.is_some() && new_soa_rr.is_none() {
             self.bump_soa_serial(&old_soa_rr);
-            soa_serial_bumped = true;
         }
 
         // Extract (and finish) the created diff, if any.
@@ -321,18 +319,16 @@ impl WritableZone for WriteZone {
             let mut diff = Mutex::into_inner(diff).unwrap();
 
             // Generate a diff entry for the update of the SOA record
-            if soa_serial_bumped {
-                let old_serial =
-                    self.add_soa_remove_diff_entry(old_soa_rr, &mut diff);
+            let old_serial =
+                self.add_soa_remove_diff_entry(old_soa_rr, &mut diff);
 
-                let new_serial =
-                    self.add_soa_add_diff_entry(new_soa_rr, &mut diff);
+            let new_serial =
+                self.add_soa_add_diff_entry(new_soa_rr, &mut diff);
 
-                if old_serial.is_some() && new_serial.is_some() {
-                    let old_serial = old_serial.unwrap();
-                    let new_serial = new_serial.unwrap();
-                    out_diff = Some(diff.build(old_serial, new_serial));
-                }
+            if old_serial.is_some() && new_serial.is_some() {
+                let old_serial = old_serial.unwrap();
+                let new_serial = new_serial.unwrap();
+                out_diff = Some(diff.build(old_serial, new_serial));
             }
         }
 

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -460,11 +460,7 @@ impl WriteNode {
             }
         }
 
-        // if rrset.is_empty() {
-        //     rrsets.remove(rrset.rtype(), self.zone.version.prev());
-        // } else {
         rrsets.update(rrset, self.zone.new_version);
-        // }
         self.check_nx_domain()?;
         Ok(())
     }

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -524,11 +524,11 @@ impl WriteNode {
                 }
                 (false, true) => {
                     trace!("Diff detected: update of existing RRSET - recording addition of new RRSET {new_rrset:#?}");
-                diff.lock().unwrap().add(
-                    owner.clone(),
+                    diff.lock().unwrap().add(
+                        owner.clone(),
                         new_rrset.rtype(),
                         new_rrset.clone(),
-                );
+                    );
                 }
                 (false, false) => {
                     // NOOP

--- a/src/zonetree/in_memory/write.rs
+++ b/src/zonetree/in_memory/write.rs
@@ -103,8 +103,6 @@ impl WritableZone for WriteZone {
         let new_apex = WriteNode::new_apex(self.clone(), create_diff);
 
         if let Ok(write_node) = &new_apex {
-            // Note: the start and end serial of the diff will be filled in
-            // when commit() is invoked.
             *self.diff.lock().unwrap() = write_node.diff();
         }
 

--- a/src/zonetree/mod.rs
+++ b/src/zonetree/mod.rs
@@ -122,7 +122,7 @@ pub use self::types::{
     Rrset, SharedRr, SharedRrset, StoredName, StoredRecord, ZoneDiff,
 };
 pub use self::walk::WalkOp;
-pub use self::zone::{Zone, ZoneKey};
+pub use self::zone::Zone;
 
 /// Zone related utilities.
 pub mod util {

--- a/src/zonetree/mod.rs
+++ b/src/zonetree/mod.rs
@@ -1,34 +1,53 @@
 #![cfg(feature = "unstable-zonetree")]
 #![cfg_attr(docsrs, doc(cfg(feature = "unstable-zonetree")))]
 #![warn(missing_docs)]
-//! Experimental storing and querying of zone trees.
+//! Experimental storing and querying of zones and zone trees.
+//!
+//! # Zone trees
 //!
 //! A [`ZoneTree`] is a multi-rooted hierarchy of [`Zone`]s, each root being
-//! the apex of a subtree for a distinct [`Class`].
+//! the apex of a subtree for a distinct [`Class`]. `Zone`s can be inserted
+//! and removed from the tree, looked up by containing or exact name, and the
+//! set of zones in the tree can be iterated over.
 //!
-//! Individual `Zone`s within the tree can be looked up by containing or exact
-//! name, and then one can [`query`] the found `Zone` by [`Class`], [`Rtype`] and
-//! [`Name`] to produce an [`Answer`], which in turn can be used to produce a
-//! response [`Message`] for serving to a DNS client.
-//!
-//! Trees can also be iterated over to inspect or export their content.
+//! # Zones
 //!
 //! The `Zone`s that a tree is comprised of can be created by feeding
 //! zonefiles or individual resource records into [`ZoneBuilder`] and then
-//! inserted into a `ZoneTree`.
+//! inserted into a `ZoneTree`. `Zone`s can also be used directly without
+//! inserting them into a `ZoneTree`.
+//!
+//! `Zone`s can be queried via their [read interface][traits::ReadableZone] by
+//! [`Class`], [`Rtype`] and [`Name`] to produce an [`Answer`], which in turn
+//! can be used to produce a response [`Message`] for serving to a DNS client.
+//! Entire `Zone`s can also be [`walk`]ed to inspect or export their content.
+//!
+//! Updating a zone can be done via the low-level [`WritableZone`] interface
+//! or using a higher-level helper like the [`ZoneUpdater`]. Updates to a
+//! `Zone` can be captured as difference sets which for example can be used to
+//! respond to IXFR queries.
+//!
+//! # Backing stores
 //!
 //! By default `Zone`s are stored in memory only. Zones with other types of
 //! backing store can be created by implementing the [`ZoneStore`] trait and
 //! passing an instance of the implementing struct to [`Zone::new`]. Zones
 //! with different backing store types can be mixed and matched within the
-//! same tree.
+//! same tree. Backing stores can be synchronous or asynchronous, the latter
+//! being useful for a remote backing store such as a distributed database.
 //!
-//! The example below shows how to populate a [`ZoneTree`] from a zonefile. For
-//! more examples of using [`Zone`]s and [`ZoneTree`]s including implementing an
-//! alternate zone backing store for your [`Zone`]s, see the
-//! [examples in the GitHub repository](https://github.com/NLnetLabs/domain/tree/main/examples).
+//! The default in-memory zone implementation uses an append only write
+//! strategy with new zone versions only becoming visible to consumers on
+//! commit and existing zone versions remaining readable during write
+//! operations.
 //!
 //! # Usage
+//!
+//! The example below shows how to populate a [`ZoneTree`] from a zonefile.
+//! For more examples of using [`Zone`]s and [`ZoneTree`]s including
+//! implementing an alternate zone backing store for your [`Zone`]s, see the
+//! [examples in the GitHub
+//! repository](https://github.com/NLnetLabs/domain/tree/main/examples).
 //!
 //! The following example builds and queries a [`ZoneTree`] containing a
 //! single in-memory [`Zone`].
@@ -71,7 +90,8 @@
 //! assert_eq!(res.rcode(), Rcode::NOERROR);
 //! ```
 //!
-//! [`query`]: crate::zonetree::ReadableZone::query
+//! [`query`]: ReadableZone::query
+//! [`walk`]: ReadableZone::walk
 //! [`Class`]: crate::base::iana::Class
 //! [`Rtype`]: crate::base::iana::Rtype
 //! [`Name`]: crate::base::name::Name
@@ -79,6 +99,7 @@
 //! [`NoError`]: crate::base::iana::code::Rcode::NOERROR
 //! [`NxDomain`]: crate::base::iana::code::Rcode::NXDOMAIN
 //! [`ZoneBuilder`]: in_memory::ZoneBuilder
+//! [`ZoneUpdater`]: update::ZoneUpdater
 
 mod answer;
 pub mod error;

--- a/src/zonetree/mod.rs
+++ b/src/zonetree/mod.rs
@@ -123,3 +123,30 @@ pub use self::types::{
 };
 pub use self::walk::WalkOp;
 pub use self::zone::{Zone, ZoneKey};
+
+/// Zone related utilities.
+pub mod util {
+    use crate::base::name::{Label, ToLabelIter};
+    use crate::base::ToName;
+
+    use super::error::OutOfZone;
+    use super::StoredName;
+
+    /// Gets a reverse iterator to the relative part of a name.
+    ///
+    /// Can be used for example to get an iterator over the part of a name
+    /// that is "under" a zone apex name.
+    pub fn rel_name_rev_iter<'l>(
+        base: &StoredName,
+        qname: &'l impl ToName,
+    ) -> Result<impl Iterator<Item = &'l Label> + Clone, OutOfZone> {
+        let mut qname = qname.iter_labels().rev();
+        for apex_label in base.iter_labels().rev() {
+            let qname_label = qname.next();
+            if Some(apex_label) != qname_label {
+                return Err(OutOfZone);
+            }
+        }
+        Ok(qname)
+    }
+}

--- a/src/zonetree/traits.rs
+++ b/src/zonetree/traits.rs
@@ -151,7 +151,7 @@ pub trait WritableZone: Send + Sync {
     /// made since the last commit. Only clients who obtain a [`ReadableZone`]
     /// _after_ invoking this function will be able to see the changes made
     /// since [`open()`] was called.
-    /// 
+    ///
     /// [`open()`]: Self::open
     fn commit(
         &mut self,

--- a/src/zonetree/traits.rs
+++ b/src/zonetree/traits.rs
@@ -145,12 +145,14 @@ pub trait WritableZone: Send + Sync {
 
     /// Complete a write operation for the zone.
     ///
-    /// This function commits the changes accumulated since [`open`] was
+    /// This function commits the changes accumulated since [`open()`] was
     /// invoked. Clients who obtain a [`ReadableZone`] interface to this zone
     /// _before_ this function has been called will not see any of the changes
     /// made since the last commit. Only clients who obtain a [`ReadableZone`]
     /// _after_ invoking this function will be able to see the changes made
-    /// since [`open`] was called.
+    /// since [`open()`] was called.
+    /// 
+    /// [`open()`]: Self::open
     fn commit(
         &mut self,
         bump_soa_serial: bool,

--- a/src/zonetree/traits.rs
+++ b/src/zonetree/traits.rs
@@ -57,9 +57,6 @@ pub trait ZoneStore: Debug + Sync + Send + Any {
                  + 'static),
         >,
     >;
-
-    /// TODO
-    fn as_any(&self) -> &dyn Any;
 }
 
 //------------ ReadableZone --------------------------------------------------

--- a/src/zonetree/tree.rs
+++ b/src/zonetree/tree.rs
@@ -185,7 +185,7 @@ impl ZoneSetNode {
 
 //------------ ZoneSetIter ---------------------------------------------------
 
-/// TODO
+/// An iterator over the [`Zone`]s in a [`ZoneTree`].
 pub struct ZoneSetIter<'a> {
     roots: hash_map::Values<'a, Class, ZoneSetNode>,
     nodes: NodesIter<'a>,

--- a/src/zonetree/types.rs
+++ b/src/zonetree/types.rs
@@ -368,7 +368,8 @@ pub enum ZoneUpdate<R> {
     /// Add record R to the zone.
     AddRecord(R),
 
-    /// Start a batch delete for the specified version (serial) of the zone.
+    /// Start a batch delete for the version of the zone with the given SOA
+    /// record.
     ///
     /// If not already in batching mode, this signals the start of batching
     /// mode. In batching mode one or more batches of updates will be
@@ -391,7 +392,8 @@ pub enum ZoneUpdate<R> {
     /// should be deleted.
     BeginBatchDelete(R),
 
-    /// Start a batch add for the specified version (serial) of the zone.
+    /// Start a batch add for the version of the zone with the given SOA
+    /// record.
     ///
     /// This can only be signalled when already in batching mode, i.e. when
     /// `BeginBatchDelete` has already been signalled.

--- a/src/zonetree/types.rs
+++ b/src/zonetree/types.rs
@@ -254,6 +254,8 @@ pub struct ZoneCut {
 //------------ ZoneDiffBuilder -----------------------------------------------
 
 /// A [`ZoneDiff`] builder.
+/// 
+/// Removes are assumed to occur before adds.
 #[derive(Debug, Default)]
 pub struct ZoneDiffBuilder {
     /// The records added to the Zone.
@@ -264,12 +266,12 @@ pub struct ZoneDiffBuilder {
 }
 
 impl ZoneDiffBuilder {
-    /// TODO
+    /// Creates a new instance of the builder.
     pub fn new() -> Self {
         Default::default()
     }
 
-    /// TODO
+    /// Record in the diff that a resource record was added.
     pub fn add(
         &mut self,
         owner: StoredName,
@@ -279,7 +281,7 @@ impl ZoneDiffBuilder {
         self.added.insert((owner, rtype), rrset);
     }
 
-    /// TODO
+    /// Record in the diff that a resource record was removed.
     pub fn remove(
         &mut self,
         owner: StoredName,
@@ -289,7 +291,15 @@ impl ZoneDiffBuilder {
         self.removed.insert((owner, rtype), rrset);
     }
 
-    /// TODO
+    /// Exchange this builder instnace for an immutable [`ZoneDiff`].
+    /// 
+    /// The start serial should be the zone version to which the diffs should
+    /// be applied. The end serial denotes the zone version that results from
+    /// applying this diff.
+    /// 
+    /// Note: No check is currently done that the start and end serials match
+    /// the SOA records in the removed and added records contained within the
+    /// diff.
     pub fn build(self, start_serial: Serial, end_serial: Serial) -> ZoneDiff {
         ZoneDiff {
             start_serial,
@@ -303,6 +313,8 @@ impl ZoneDiffBuilder {
 //------------ ZoneDiff ------------------------------------------------------
 
 /// The differences between one serial and another for a Zone.
+/// 
+/// Removes are assumed to occur before adds.
 #[derive(Clone, Debug)]
 pub struct ZoneDiff {
     /// The serial number of the Zone which was modified.

--- a/src/zonetree/types.rs
+++ b/src/zonetree/types.rs
@@ -321,11 +321,14 @@ impl ZoneDiff {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ZoneUpdate<R> {
-    /// Delete record R from the specified version (serial) of the zone.
-    DeleteRecord(Serial, R),
+    /// Delete all records in the zone.
+    DeleteAllRecords,
 
-    /// Add record R to the specified version (serial) of the zone.
-    AddRecord(Serial, R),
+    /// Delete record R from the zone.
+    DeleteRecord(R),
+
+    /// Add record R to the zone.
+    AddRecord(R),
 
     /// Start a batch delete for the specified version (serial) of the zone.
     ///
@@ -362,11 +365,10 @@ pub enum ZoneUpdate<R> {
     /// See `BeginBatchDelete` for more information.
     BeginBatchAdd(R),
 
-    /// Updates for the specified version (serial) of the zone can now be
-    /// finalized.
+    /// In progress updates for the zone can now be finalized.
     ///
-    /// This signals the end of a group of related changes to the specified
-    /// version (serial) of the zone.
+    /// This signals the end of a group of related changes for the given SOA
+    /// record of the zone.
     ///
     /// For example this could be used to trigger an atomic commit of a set of
     /// related pending changes.
@@ -378,8 +380,9 @@ pub enum ZoneUpdate<R> {
 impl<R> std::fmt::Display for ZoneUpdate<R> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            ZoneUpdate::DeleteRecord(_, _) => f.write_str("DeleteRecord"),
-            ZoneUpdate::AddRecord(_, _) => f.write_str("AddRecord"),
+            ZoneUpdate::DeleteAllRecords => f.write_str("DeleteAllRecords"),
+            ZoneUpdate::DeleteRecord(_) => f.write_str("DeleteRecord"),
+            ZoneUpdate::AddRecord(_) => f.write_str("AddRecord"),
             ZoneUpdate::BeginBatchDelete(_) => {
                 f.write_str("BeginBatchDelete")
             }

--- a/src/zonetree/types.rs
+++ b/src/zonetree/types.rs
@@ -284,11 +284,40 @@ impl ZoneDiff {
 
 /// An update to be applied to a [`Zone`].
 ///
-/// Note: This enum is marked as `#[non_exhaustive]` to permit addition of
-/// more update operations in future, e.g. to support RFC 2136 Dynamic Updates
+/// # Design
+/// 
+/// The variants of this enum are modelled after the way the AXFR and IXFR
+/// protocols represent updates to zones.
+/// 
+/// AXFR responses can be represented as a sequence of
+/// [`ZoneUpdate::AddRecord`]s.
+/// 
+/// IXFR responses can be represented as a sequence of batches, each
+/// consisting of:
+/// - [`ZoneUpdate::BeginBatchDelete`]
+/// - [`ZoneUpdate::DeleteRecord`]s _(zero or more)_
+/// - [`ZoneUpdate::BeginBatchAdd`]
+/// - [`ZoneUpdate::AddRecord`]s _(zero or more)_
+/// 
+/// Both AXFR and IXFR responses encoded using this enum are terminated by a
+/// final [`ZoneUpdate::Finished`].
+///
+/// # Use within this crate
+///  
+/// [`XfrResponseInterpreter`] can convert received XFR responses into
+/// sequences of [`ZoneUpdate`]s. These can then be consumed by a
+/// [`ZoneUpdater`] to effect changes to an existing [`Zone`].
+/// 
+/// # Future extensions
+/// 
+/// This enum is marked as `#[non_exhaustive]` to permit addition of more
+/// update operations in future, e.g. to support RFC 2136 Dynamic Updates
 /// operations.
 ///
+/// [`XfrResponseInterpreter`]:
+///     crate::net::xfr::protocol::XfrResponseInterpreter
 /// [`Zone`]: crate::zonetree::zone::Zone
+/// [`ZoneUpdater`]: crate::zonetree::update::ZoneUpdater
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ZoneUpdate<R> {

--- a/src/zonetree/types.rs
+++ b/src/zonetree/types.rs
@@ -251,33 +251,71 @@ pub struct ZoneCut {
     pub glue: Vec<StoredRecord>,
 }
 
+//------------ ZoneDiffBuilder -----------------------------------------------
+
+/// A [`ZoneDiff`] builder.
+#[derive(Debug, Default)]
+pub struct ZoneDiffBuilder {
+    /// The records added to the Zone.
+    added: HashMap<(StoredName, Rtype), SharedRrset>,
+
+    /// The records removed from the Zone.
+    removed: HashMap<(StoredName, Rtype), SharedRrset>,
+}
+
+impl ZoneDiffBuilder {
+    /// TODO
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// TODO
+    pub fn add(
+        &mut self,
+        owner: StoredName,
+        rtype: Rtype,
+        rrset: SharedRrset,
+    ) {
+        self.added.insert((owner, rtype), rrset);
+    }
+
+    /// TODO
+    pub fn remove(
+        &mut self,
+        owner: StoredName,
+        rtype: Rtype,
+        rrset: SharedRrset,
+    ) {
+        self.removed.insert((owner, rtype), rrset);
+    }
+
+    /// TODO
+    pub fn build(self, start_serial: Serial, end_serial: Serial) -> ZoneDiff {
+        ZoneDiff {
+            start_serial,
+            end_serial,
+            added: Arc::new(self.added),
+            removed: Arc::new(self.removed),
+        }
+    }
+}
+
 //------------ ZoneDiff ------------------------------------------------------
 
 /// The differences between one serial and another for a Zone.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ZoneDiff {
     /// The serial number of the Zone which was modified.
-    ///
-    /// For a completed diff this must be Some.
-    pub start_serial: Option<Serial>,
+    pub start_serial: Serial,
 
     /// The serial number of the Zone that resulted from the modifications.
-    ///
-    /// For a completed diff this must be Some.
-    pub end_serial: Option<Serial>,
+    pub end_serial: Serial,
 
     /// The records added to the Zone.
-    pub added: HashMap<(StoredName, Rtype), SharedRrset>,
+    pub added: Arc<HashMap<(StoredName, Rtype), SharedRrset>>,
 
     /// The records removed from the Zone.
-    pub removed: HashMap<(StoredName, Rtype), SharedRrset>,
-}
-
-impl ZoneDiff {
-    /// Creates a new empty diff.
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub removed: Arc<HashMap<(StoredName, Rtype), SharedRrset>>,
 }
 
 //------------ ZoneUpdate -----------------------------------------------------

--- a/src/zonetree/types.rs
+++ b/src/zonetree/types.rs
@@ -285,20 +285,20 @@ impl ZoneDiff {
 /// An update to be applied to a [`Zone`].
 ///
 /// # Design
-/// 
+///
 /// The variants of this enum are modelled after the way the AXFR and IXFR
 /// protocols represent updates to zones.
-/// 
+///
 /// AXFR responses can be represented as a sequence of
 /// [`ZoneUpdate::AddRecord`]s.
-/// 
+///
 /// IXFR responses can be represented as a sequence of batches, each
 /// consisting of:
 /// - [`ZoneUpdate::BeginBatchDelete`]
 /// - [`ZoneUpdate::DeleteRecord`]s _(zero or more)_
 /// - [`ZoneUpdate::BeginBatchAdd`]
 /// - [`ZoneUpdate::AddRecord`]s _(zero or more)_
-/// 
+///
 /// Both AXFR and IXFR responses encoded using this enum are terminated by a
 /// final [`ZoneUpdate::Finished`].
 ///
@@ -307,9 +307,9 @@ impl ZoneDiff {
 /// [`XfrResponseInterpreter`] can convert received XFR responses into
 /// sequences of [`ZoneUpdate`]s. These can then be consumed by a
 /// [`ZoneUpdater`] to effect changes to an existing [`Zone`].
-/// 
+///
 /// # Future extensions
-/// 
+///
 /// This enum is marked as `#[non_exhaustive]` to permit addition of more
 /// update operations in future, e.g. to support RFC 2136 Dynamic Updates
 /// operations.
@@ -344,12 +344,20 @@ pub enum ZoneUpdate<R> {
     /// Batching mode makes updates more predictable for the receiver to work
     /// with by limiting the updates that can be signalled next, enabling
     /// receiver logic to be simpler and more efficient.
+    ///
+    /// The record must be a SOA record that matches the SOA record of the
+    /// zone version in which the subsequent [`ZoneUpdate::DeleteRecord`]s
+    /// should be deleted.
     BeginBatchDelete(R),
 
     /// Start a batch add for the specified version (serial) of the zone.
     ///
     /// This can only be signalled when already in batching mode, i.e. when
     /// `BeginBatchDelete` has already been signalled.
+    ///
+    /// The record must be the SOA record to use for the new version of the
+    /// zone under which the subsequent [`ZoneUpdate::AddRecord`]s will be
+    /// added.
     ///
     /// See `BeginBatchDelete` for more information.
     BeginBatchAdd(R),

--- a/src/zonetree/types.rs
+++ b/src/zonetree/types.rs
@@ -254,7 +254,7 @@ pub struct ZoneCut {
 //------------ ZoneDiffBuilder -----------------------------------------------
 
 /// A [`ZoneDiff`] builder.
-/// 
+///
 /// Removes are assumed to occur before adds.
 #[derive(Debug, Default)]
 pub struct ZoneDiffBuilder {
@@ -292,11 +292,11 @@ impl ZoneDiffBuilder {
     }
 
     /// Exchange this builder instnace for an immutable [`ZoneDiff`].
-    /// 
+    ///
     /// The start serial should be the zone version to which the diffs should
     /// be applied. The end serial denotes the zone version that results from
     /// applying this diff.
-    /// 
+    ///
     /// Note: No check is currently done that the start and end serials match
     /// the SOA records in the removed and added records contained within the
     /// diff.
@@ -312,21 +312,21 @@ impl ZoneDiffBuilder {
 
 //------------ ZoneDiff ------------------------------------------------------
 
-/// The differences between one serial and another for a Zone.
-/// 
+/// The differences between one serial and another for a DNS zone.
+///
 /// Removes are assumed to occur before adds.
 #[derive(Clone, Debug)]
 pub struct ZoneDiff {
-    /// The serial number of the Zone which was modified.
+    /// The serial number of the zone which was modified.
     pub start_serial: Serial,
 
-    /// The serial number of the Zone that resulted from the modifications.
+    /// The serial number of the Zzone that resulted from the modifications.
     pub end_serial: Serial,
 
-    /// The records added to the Zone.
+    /// The RRsets added to the zone.
     pub added: Arc<HashMap<(StoredName, Rtype), SharedRrset>>,
 
-    /// The records removed from the Zone.
+    /// The RRsets removed from the zone.
     pub removed: Arc<HashMap<(StoredName, Rtype), SharedRrset>>,
 }
 

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -3,7 +3,7 @@
 //! This module provides a high-level interface for making alterations to the
 //! content of zones without requiring knowledge of the low-level details of
 //! how the [`WritableZone`] trait implemented by [`Zone`] works.
-//! 
+//!
 //! It can be used manually, or in combination with a source of
 //! [`ZoneUpdate`]s such as
 //! [`XfrResponseInterpreter`][crate::net::xfr::protocol::XfrResponseInterpreter].
@@ -12,21 +12,21 @@
 //!
 //! ```no_run
 //! # use std::str::FromStr;
-//! # 
+//! #
 //! # use domain::base::iana::Class;
 //! # use domain::base::MessageBuilder;
 //! # use domain::base::Name;
 //! # use domain::net::xfr::protocol::XfrResponseInterpreter;
 //! # use domain::zonetree::ZoneBuilder;
 //! # use domain::zonetree::update::ZoneUpdater;
-//! # 
+//! #
 //! # #[tokio::main]
 //! # async fn main() {
-//! # 
+//! #
 //! // Given a zone
 //! let builder = ZoneBuilder::new(Name::from_str("example.com").unwrap(), Class::IN);
 //! let zone = builder.build();
-//! 
+//!
 //! // And a ZoneUpdater
 //! let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
 //!
@@ -47,7 +47,7 @@
 //!         updater.apply(update.unwrap()).await.unwrap();
 //!     }
 //! }
-//! # 
+//! #
 //! # }
 //! ```
 use core::future::Future;

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -501,7 +501,7 @@ impl ReopenableZoneWriter {
 
     /// Replaces the current root node write interface with a new one.
     ///
-    /// Call [`commit()`] before calling this method.
+    /// Call [`commit()`][Self::commit] before calling this method.
     async fn reopen(&mut self) -> Result<(), Error> {
         self.writable = Some(self.write.open(true).await?);
         Ok(())
@@ -509,7 +509,8 @@ impl ReopenableZoneWriter {
 
     /// Convenience method to mark all nodes in the tree as removed.
     ///
-    /// Current readers will not be affected until [`commit()`] is called.
+    /// Current readers will not be affected until [`commit()`][Self::commit]
+    /// is called.
     async fn remove_all(&mut self) -> std::io::Result<()> {
         if let Some(writable) = &mut self.writable {
             writable.remove_all().await?;

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -3,185 +3,6 @@
 //! This module provides a high-level interface for making alterations to the
 //! content of zones without requiring knowledge of the low-level details of
 //! how the [`WritableZone`] trait implemented by [`Zone`] works.
-//!
-//! It can be used manually, or in combination with a source of
-//! [`ZoneUpdate`]s such as
-//! [`XfrResponseInterpreter`][crate::net::xfr::protocol::XfrResponseInterpreter].
-//!
-//! <div class="warning">
-//!
-//! `WritableZone::commit()` is invoked by `ZoneUpdater` when it receives
-//! `ZoneUpdate::Finished`. If `ZoneUpdate::Finished` is not passed to
-//! `ZoneUpdater::apply()` there is no guarantee that the applied changes to
-//! the zone will take effect.
-//!
-//! </div>
-//!
-//! # Replacing the content of a zone
-//!
-//! ```
-//! # use std::str::FromStr;
-//! #
-//! # use domain::base::iana::Class;
-//! # use domain::base::MessageBuilder;
-//! # use domain::base::Name;
-//! # use domain::base::ParsedName;
-//! # use domain::base::Record;
-//! # use domain::base::Serial;
-//! # use domain::base::Ttl;
-//! # use domain::base::net::Ipv4Addr;
-//! # use domain::net::xfr::protocol::XfrResponseInterpreter;
-//! # use domain::rdata::A;
-//! # use domain::rdata::Soa;
-//! # use domain::rdata::ZoneRecordData;
-//! # use domain::zonetree::ZoneBuilder;
-//! # use domain::zonetree::types::ZoneUpdate;
-//! # use domain::zonetree::update::ZoneUpdater;
-//! #
-//! # #[tokio::main]
-//! # async fn main() {
-//! #
-//! # let builder = ZoneBuilder::new(Name::from_str("example.com").unwrap(), Class::IN);
-//! # let zone = builder.build();
-//! #
-//! # // Prepare some records to pass to ZoneUpdater
-//! # let serial = Serial::now();
-//! # let mname = ParsedName::from(Name::from_str("mname").unwrap());
-//! # let rname = ParsedName::from(Name::from_str("rname").unwrap());
-//! # let ttl = Ttl::from_secs(0);
-//! # let new_soa_rec = Record::new(
-//! #     ParsedName::from(Name::from_str("example.com").unwrap()),
-//! #     Class::IN,
-//! #     Ttl::from_secs(0),
-//! #     ZoneRecordData::Soa(Soa::new(mname, rname, serial, ttl, ttl, ttl, ttl)),
-//! # );
-//! #
-//! # let a_data = A::new(Ipv4Addr::LOCALHOST);
-//! # let a_rec = Record::new(
-//! #     ParsedName::from(Name::from_str("a.example.com").unwrap()),
-//! #     Class::IN,
-//! #     Ttl::from_secs(0),
-//! #     ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
-//! # );
-//! #
-//! let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
-//! updater.apply(ZoneUpdate::DeleteAllRecords);
-//! updater.apply(ZoneUpdate::AddRecord(a_rec));
-//! updater.apply(ZoneUpdate::Finished(new_soa_rec));
-//! #
-//! # }
-//! ```
-//!
-//! # Altering the content of a zone
-//!
-//! ```rust
-//! # use std::str::FromStr;
-//! #
-//! # use domain::base::iana::Class;
-//! # use domain::base::MessageBuilder;
-//! # use domain::base::Name;
-//! # use domain::base::ParsedName;
-//! # use domain::base::Record;
-//! # use domain::base::Serial;
-//! # use domain::base::Ttl;
-//! # use domain::base::net::Ipv4Addr;
-//! # use domain::base::net::Ipv6Addr;
-//! # use domain::net::xfr::protocol::XfrResponseInterpreter;
-//! # use domain::rdata::A;
-//! # use domain::rdata::Aaaa;
-//! # use domain::rdata::Soa;
-//! # use domain::rdata::ZoneRecordData;
-//! # use domain::zonetree::ZoneBuilder;
-//! # use domain::zonetree::update::ZoneUpdater;
-//! # use domain::zonetree::types::ZoneUpdate;
-//! #
-//! # #[tokio::main]
-//! # async fn main() {
-//! #
-//! # let builder = ZoneBuilder::new(Name::from_str("example.com").unwrap(), Class::IN);
-//! # let zone = builder.build();
-//! #
-//! # // Prepare some records to pass to ZoneUpdater
-//! # let serial = Serial::now();
-//! # let mname = ParsedName::from(Name::from_str("mname").unwrap());
-//! # let rname = ParsedName::from(Name::from_str("rname").unwrap());
-//! # let ttl = Ttl::from_secs(0);
-//! # let new_soa_rec = Record::new(
-//! #     ParsedName::from(Name::from_str("example.com").unwrap()),
-//! #     Class::IN,
-//! #     Ttl::from_secs(0),
-//! #     ZoneRecordData::Soa(Soa::new(mname, rname, serial, ttl, ttl, ttl, ttl)),
-//! # );
-//! #
-//! # let old_a_data = A::new(Ipv4Addr::LOCALHOST);
-//! # let old_a_rec = Record::new(
-//! #     ParsedName::from(Name::from_str("a.example.com").unwrap()),
-//! #     Class::IN,
-//! #     Ttl::from_secs(0),
-//! #     ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
-//! # );
-//! #
-//! # let new_aaaa_data = Aaaa::new(Ipv6Addr::LOCALHOST);
-//! # let new_aaaa_rec = Record::new(
-//! #     ParsedName::from(Name::from_str("a.example.com").unwrap()),
-//! #     Class::IN,
-//! #     Ttl::from_secs(0),
-//! #     ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
-//! # );
-//! #
-//! let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
-//! updater.apply(ZoneUpdate::DeleteRecord(old_a_rec));
-//! updater.apply(ZoneUpdate::AddRecord(new_aaaa_rec));
-//! updater.apply(ZoneUpdate::Finished(new_soa_rec));
-//! #
-//! # }
-//! ```
-//!
-//! # Applying XFR changes to a zone
-//!
-//! ```no_run
-//! # use std::str::FromStr;
-//! #
-//! # use domain::base::iana::Class;
-//! # use domain::base::MessageBuilder;
-//! # use domain::base::Name;
-//! # use domain::base::Serial;
-//! # use domain::net::xfr::protocol::XfrResponseInterpreter;
-//! # use domain::zonetree::ZoneBuilder;
-//! # use domain::zonetree::update::ZoneUpdater;
-//! #
-//! # #[tokio::main]
-//! # async fn main() {
-//! #
-//! // Given a zone
-//! let builder = ZoneBuilder::new(Name::from_str("example.com").unwrap(), Class::IN);
-//! let zone = builder.build();
-//!
-//! // And a ZoneUpdater
-//! let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
-//!
-//! // And an XFR response interpreter
-//! let mut interpreter = XfrResponseInterpreter::new();
-//!
-//! // Iterate over the XFR responses applying the updates to the zone
-//! while !interpreter.is_finished() {
-//!     // Get the next XFR response:
-//!     // For this example this is just a dummy response, which would cause
-//!     // Error::NotValidXfrResponse if this code were run.
-//!     let next_xfr_response = MessageBuilder::new_bytes().into_message();
-//!
-//!     // Convert it to an update iterator
-//!     let it = interpreter.interpret_response(next_xfr_response).unwrap();
-//!
-//!     // Iterate over the updates
-//!     for update in it {
-//!         // Apply each update to the zone
-//!         updater.apply(update.unwrap()).await.unwrap();
-//!     }
-//! }
-//! #
-//! # }
-//! ```
 use core::future::Future;
 use core::pin::Pin;
 
@@ -212,13 +33,187 @@ use super::{WritableZone, WritableZoneNode, Zone, ZoneDiff};
 /// [`ZoneUpdate::DeleteAllRecords`] to `apply` before any other updates.
 ///
 /// Changes to the zone are committed when [`ZoneUpdate::Finished`] is
-/// received.
+/// received, or rolled back if [`ZoneUpdater`] is dropped before receiving
+/// [`ZoneUpdate::Finished`].
 ///
 /// Passing [`ZoneUpdate::BeginBatchDelete`] commits any edits in progress and
 /// starts editing a new zone version.
 ///
-/// For each commit of the zone a diff of the changes made will be stored with
-/// the zone.
+/// For each commit of the zone a diff of the changes made is requested and,
+/// if a diff was actually created, it will be returned by
+/// [`ZoneUpdater::apply()`].
+///
+/// # Usage
+///
+/// [`ZoneUpdater`] can be used manually, or in combination with a source of
+/// [`ZoneUpdate`]s such as
+/// [`XfrResponseInterpreter`][crate::net::xfr::protocol::XfrResponseInterpreter].
+///
+/// # Replacing the content of a zone
+///
+/// ```
+/// # use std::str::FromStr;
+/// #
+/// # use domain::base::iana::Class;
+/// # use domain::base::MessageBuilder;
+/// # use domain::base::Name;
+/// # use domain::base::ParsedName;
+/// # use domain::base::Record;
+/// # use domain::base::Serial;
+/// # use domain::base::Ttl;
+/// # use domain::base::net::Ipv4Addr;
+/// # use domain::net::xfr::protocol::XfrResponseInterpreter;
+/// # use domain::rdata::A;
+/// # use domain::rdata::Soa;
+/// # use domain::rdata::ZoneRecordData;
+/// # use domain::zonetree::ZoneBuilder;
+/// # use domain::zonetree::types::ZoneUpdate;
+/// # use domain::zonetree::update::ZoneUpdater;
+/// #
+/// # #[tokio::main]
+/// # async fn main() {
+/// #
+/// # let builder = ZoneBuilder::new(Name::from_str("example.com").unwrap(), Class::IN);
+/// # let zone = builder.build();
+/// #
+/// # // Prepare some records to pass to ZoneUpdater
+/// # let serial = Serial::now();
+/// # let mname = ParsedName::from(Name::from_str("mname").unwrap());
+/// # let rname = ParsedName::from(Name::from_str("rname").unwrap());
+/// # let ttl = Ttl::from_secs(0);
+/// # let new_soa_rec = Record::new(
+/// #     ParsedName::from(Name::from_str("example.com").unwrap()),
+/// #     Class::IN,
+/// #     Ttl::from_secs(0),
+/// #     ZoneRecordData::Soa(Soa::new(mname, rname, serial, ttl, ttl, ttl, ttl)),
+/// # );
+/// #
+/// # let a_data = A::new(Ipv4Addr::LOCALHOST);
+/// # let a_rec = Record::new(
+/// #     ParsedName::from(Name::from_str("a.example.com").unwrap()),
+/// #     Class::IN,
+/// #     Ttl::from_secs(0),
+/// #     ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
+/// # );
+/// #
+/// let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
+/// updater.apply(ZoneUpdate::DeleteAllRecords);
+/// updater.apply(ZoneUpdate::AddRecord(a_rec));
+/// updater.apply(ZoneUpdate::Finished(new_soa_rec));
+/// #
+/// # }
+/// ```
+///
+/// # Altering the content of a zone
+///
+/// ```rust
+/// # use std::str::FromStr;
+/// #
+/// # use domain::base::iana::Class;
+/// # use domain::base::MessageBuilder;
+/// # use domain::base::Name;
+/// # use domain::base::ParsedName;
+/// # use domain::base::Record;
+/// # use domain::base::Serial;
+/// # use domain::base::Ttl;
+/// # use domain::base::net::Ipv4Addr;
+/// # use domain::base::net::Ipv6Addr;
+/// # use domain::net::xfr::protocol::XfrResponseInterpreter;
+/// # use domain::rdata::A;
+/// # use domain::rdata::Aaaa;
+/// # use domain::rdata::Soa;
+/// # use domain::rdata::ZoneRecordData;
+/// # use domain::zonetree::ZoneBuilder;
+/// # use domain::zonetree::update::ZoneUpdater;
+/// # use domain::zonetree::types::ZoneUpdate;
+/// #
+/// # #[tokio::main]
+/// # async fn main() {
+/// #
+/// # let builder = ZoneBuilder::new(Name::from_str("example.com").unwrap(), Class::IN);
+/// # let zone = builder.build();
+/// #
+/// # // Prepare some records to pass to ZoneUpdater
+/// # let serial = Serial::now();
+/// # let mname = ParsedName::from(Name::from_str("mname").unwrap());
+/// # let rname = ParsedName::from(Name::from_str("rname").unwrap());
+/// # let ttl = Ttl::from_secs(0);
+/// # let new_soa_rec = Record::new(
+/// #     ParsedName::from(Name::from_str("example.com").unwrap()),
+/// #     Class::IN,
+/// #     Ttl::from_secs(0),
+/// #     ZoneRecordData::Soa(Soa::new(mname, rname, serial, ttl, ttl, ttl, ttl)),
+/// # );
+/// #
+/// # let old_a_data = A::new(Ipv4Addr::LOCALHOST);
+/// # let old_a_rec = Record::new(
+/// #     ParsedName::from(Name::from_str("a.example.com").unwrap()),
+/// #     Class::IN,
+/// #     Ttl::from_secs(0),
+/// #     ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
+/// # );
+/// #
+/// # let new_aaaa_data = Aaaa::new(Ipv6Addr::LOCALHOST);
+/// # let new_aaaa_rec = Record::new(
+/// #     ParsedName::from(Name::from_str("a.example.com").unwrap()),
+/// #     Class::IN,
+/// #     Ttl::from_secs(0),
+/// #     ZoneRecordData::A(A::new(Ipv4Addr::LOCALHOST)),
+/// # );
+/// #
+/// let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
+/// updater.apply(ZoneUpdate::DeleteRecord(old_a_rec));
+/// updater.apply(ZoneUpdate::AddRecord(new_aaaa_rec));
+/// updater.apply(ZoneUpdate::Finished(new_soa_rec));
+/// #
+/// # }
+/// ```
+///
+/// # Applying XFR changes to a zone
+///
+/// ```no_run
+/// # use std::str::FromStr;
+/// #
+/// # use domain::base::iana::Class;
+/// # use domain::base::MessageBuilder;
+/// # use domain::base::Name;
+/// # use domain::base::Serial;
+/// # use domain::net::xfr::protocol::XfrResponseInterpreter;
+/// # use domain::zonetree::ZoneBuilder;
+/// # use domain::zonetree::update::ZoneUpdater;
+/// #
+/// # #[tokio::main]
+/// # async fn main() {
+/// #
+/// // Given a zone
+/// let builder = ZoneBuilder::new(Name::from_str("example.com").unwrap(), Class::IN);
+/// let zone = builder.build();
+///
+/// // And a ZoneUpdater
+/// let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
+///
+/// // And an XFR response interpreter
+/// let mut interpreter = XfrResponseInterpreter::new();
+///
+/// // Iterate over the XFR responses applying the updates to the zone
+/// while !interpreter.is_finished() {
+///     // Get the next XFR response:
+///     // For this example this is just a dummy response, which would cause
+///     // Error::NotValidXfrResponse if this code were run.
+///     let next_xfr_response = MessageBuilder::new_bytes().into_message();
+///
+///     // Convert it to an update iterator
+///     let it = interpreter.interpret_response(next_xfr_response).unwrap();
+///
+///     // Iterate over the updates
+///     for update in it {
+///         // Apply each update to the zone
+///         updater.apply(update.unwrap()).await.unwrap();
+///     }
+/// }
+/// #
+/// # }
+/// ```
 pub struct ZoneUpdater {
     /// The zone to be updated.
     zone: Zone,

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -180,7 +180,8 @@ impl ZoneUpdater {
         Ok(qname)
     }
 
-    async fn prep_add_del(
+    /// Given a zone record, obtain a [`WritableZoneNode`] for the owner.
+    async fn get_writable_node_for_owner(
         &mut self,
         rec: ParsedRecord,
     ) -> Result<
@@ -245,6 +246,7 @@ impl ZoneUpdater {
         Ok(())
     }
 
+    /// Find and delete a record in the zone by exact match.
     async fn delete_record(
         &mut self,
         rec: Record<
@@ -253,7 +255,7 @@ impl ZoneUpdater {
         >,
     ) -> Result<(), ()> {
         let (rtype, data, end_node, mut rrset) =
-            self.prep_add_del(rec).await?;
+            self.get_update_child_write_handle(rec).await?;
 
         let writable = self.write.writable.as_ref().unwrap();
 
@@ -302,7 +304,7 @@ impl ZoneUpdater {
         }
 
         let (rtype, data, end_node, mut rrset) =
-            self.prep_add_del(rec).await?;
+            self.get_update_child_write_handle(rec).await?;
 
         let writable = self.write.writable.as_ref().unwrap();
 

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -349,9 +349,7 @@ impl ZoneUpdater {
         &mut self,
         rec: &ParsedRecord,
     ) -> std::io::Result<Option<Box<dyn WritableZoneNode>>> {
-        let owner = rec.owner().to_owned();
-
-        let mut it = rel_name_rev_iter(self.zone.apex_name(), &owner)
+        let mut it = rel_name_rev_iter(self.zone.apex_name(), rec.owner())
             .map_err(|_| IoError::custom("Record owner name out of zone"))?;
 
         let Some(label) = it.next() else {

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -224,8 +224,8 @@ pub struct ZoneUpdater {
     /// a new write state opened.
     write: ReopenableZoneWriter,
 
-    /// Whether or not we entered an IXFR-like batching mode.
-    batching: bool,
+    /// The current state of the updater.
+    state: ZoneUpdaterState,
 }
 
 impl ZoneUpdater {
@@ -245,7 +245,7 @@ impl ZoneUpdater {
             Ok(Self {
                 zone,
                 write,
-                batching: false,
+                state: Default::default(),
             })
         })
     }
@@ -268,7 +268,12 @@ impl ZoneUpdater {
         &mut self,
         update: ZoneUpdate<ParsedRecord>,
     ) -> Result<Option<ZoneDiff>, Error> {
-        trace!("Event: {update}");
+        trace!("Update: {update}");
+
+        if self.state == ZoneUpdaterState::Finished {
+            return Err(Error::Finished);
+        }
+
         match update {
             ZoneUpdate::DeleteAllRecords => {
                 // To completely replace the content of the zone, i.e. with
@@ -294,19 +299,13 @@ impl ZoneUpdater {
             // Batch deletion signals the start of a batch, and the end of any
             // batch addition that was in progress.
             ZoneUpdate::BeginBatchDelete(_old_soa) => {
-                let diff = if self.batching {
-                    // Commit the previous batch.
-                    let diff = self.write.commit().await?;
+                // Commit the previous batch.
+                let diff = self.write.commit().await?;
 
-                    // Open a writer for the new batch.
-                    self.write.reopen().await?;
+                // Open a writer for the new batch.
+                self.write.reopen().await?;
 
-                    diff
-                } else {
-                    None
-                };
-
-                self.batching = true;
+                self.state = ZoneUpdaterState::Batching;
 
                 return Ok(diff);
             }
@@ -314,7 +313,7 @@ impl ZoneUpdater {
             ZoneUpdate::BeginBatchAdd(new_soa) => {
                 // Update the SOA record.
                 self.update_soa(new_soa).await?;
-                self.batching = true;
+                self.state = ZoneUpdaterState::Batching;
             }
 
             ZoneUpdate::Finished(zone_soa) => {
@@ -322,11 +321,24 @@ impl ZoneUpdater {
                 self.update_soa(zone_soa).await?;
 
                 // Commit the previous batch and return any diff produced.
-                return self.write.commit().await;
+                let diff = self.write.commit().await?;
+
+                // Close this updater
+                self.write.close()?;
+                self.state = ZoneUpdaterState::Finished;
+
+                return Ok(diff);
             }
         }
 
         Ok(None)
+    }
+
+    /// Has zone updating finished?
+    ///
+    /// If true, further calls to [`apply()`] will fail.
+    pub fn is_finished(&self) -> bool {
+        self.state == ZoneUpdaterState::Finished
     }
 }
 
@@ -417,7 +429,11 @@ impl ZoneUpdater {
         }
 
         // Replace the RRset in the tree with the new smaller one.
-        tree_node.update_rrset(SharedRrset::new(rrset)).await?;
+        if rrset.is_empty() {
+            tree_node.remove_rrset(rrset.rtype()).await?;
+        } else {
+            tree_node.update_rrset(SharedRrset::new(rrset)).await?;
+        }
 
         Ok(())
     }
@@ -455,7 +471,27 @@ impl ZoneUpdater {
     }
 }
 
-//------------ MultiVersionWriteHandle ----------------------------------------
+//------------ ZoneUpdaterState -----------------------------------------------
+
+/// The current state of a [`ZoneUpdater`].
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+enum ZoneUpdaterState {
+    #[default]
+    Normal,
+
+    /// IXFR-like batching mode.
+    Batching,
+
+    /// Finished.
+    ///
+    /// [`ZoneUpdate::Finished`] was encountered.
+    ///
+    /// The [`ZoneUpdater`] has closed the [`WritableZone`] and can no longer
+    /// be used.
+    Finished,
+}
+
+//------------ ReopenableZoneWriter -------------------------------------------
 
 /// State for writing multiple zone versions in sequence.
 ///
@@ -466,7 +502,7 @@ impl ZoneUpdater {
 /// can be re-opened to write the next version of the zone.
 struct ReopenableZoneWriter {
     /// A write interface to a zone.
-    write: Box<dyn WritableZone>,
+    write: Option<Box<dyn WritableZone>>,
 
     /// A write interface to the root node of a zone for a particular zone
     /// version.
@@ -478,6 +514,7 @@ impl ReopenableZoneWriter {
     async fn new(zone: Zone) -> std::io::Result<Self> {
         let write = zone.write().await;
         let writable = Some(write.open(true).await?);
+        let write = Some(write);
         Ok(Self { write, writable })
     }
 
@@ -491,7 +528,12 @@ impl ReopenableZoneWriter {
             // diff (otherwise commit() will panic).
             drop(writable);
 
-            let diff = self.write.commit(false).await?;
+            let diff = self
+                .write
+                .as_mut()
+                .ok_or(Error::Finished)?
+                .commit(false)
+                .await?;
 
             Ok(diff)
         } else {
@@ -503,7 +545,20 @@ impl ReopenableZoneWriter {
     ///
     /// Call [`commit()`][Self::commit] before calling this method.
     async fn reopen(&mut self) -> Result<(), Error> {
-        self.writable = Some(self.write.open(true).await?);
+        self.writable = Some(
+            self.write
+                .as_mut()
+                .ok_or(Error::Finished)?
+                .open(true)
+                .await?,
+        );
+        Ok(())
+    }
+
+    /// Close all write state, if not closed already.
+    fn close(&mut self) -> Result<(), Error> {
+        self.writable.take();
+        self.write.take().ok_or(Error::Finished)?;
         Ok(())
     }
 
@@ -550,6 +605,9 @@ impl ReopenableZoneWriter {
 #[cfg(test)]
 mod tests {
     use core::str::FromStr;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use std::sync::Arc;
     use std::vec::Vec;
 
     use bytes::BytesMut;
@@ -563,7 +621,7 @@ mod tests {
         Message, MessageBuilder, Name, ParsedName, Record, Serial, Ttl,
     };
     use crate::net::xfr::protocol::XfrResponseInterpreter;
-    use crate::rdata::{Soa, A};
+    use crate::rdata::{Ns, Soa, A};
     use crate::zonetree::ZoneBuilder;
 
     use super::*;
@@ -593,7 +651,7 @@ mod tests {
             .await
             .unwrap();
 
-        updater
+        let diff = updater
             .apply(ZoneUpdate::Finished(soa_rec.clone()))
             .await
             .unwrap();
@@ -621,6 +679,99 @@ mod tests {
             .into_data();
 
         assert_eq!(found_soa_rec, soa);
+
+        // No diff because there is no prior SOA serial
+        assert!(diff.is_none());
+    }
+
+    #[tokio::test]
+    async fn diff_check() {
+        init_logging();
+
+        let zone = mk_empty_zone("example.com");
+
+        let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
+
+        let qname = Name::from_str("example.com").unwrap();
+
+        let s = Serial(20240922);
+        let soa = mk_soa(s);
+        let soa_data = ZoneRecordData::Soa(soa.clone());
+        let soa_rec = Record::new(
+            ParsedName::from(qname.clone()),
+            Class::IN,
+            Ttl::from_secs(0),
+            soa_data,
+        );
+
+        updater
+            .apply(ZoneUpdate::AddRecord(soa_rec.clone()))
+            .await
+            .unwrap();
+
+        let diff = updater
+            .apply(ZoneUpdate::Finished(soa_rec.clone()))
+            .await
+            .unwrap();
+
+        // No diff because there is no prior SOA serial
+        assert!(diff.is_none());
+
+        let soa = mk_soa(s.add(1));
+        let soa_data = ZoneRecordData::Soa(soa.clone());
+        let soa_rec = Record::new(
+            ParsedName::from(qname.clone()),
+            Class::IN,
+            Ttl::from_secs(0),
+            soa_data,
+        );
+
+        assert!(updater.is_finished());
+
+        let res = updater.apply(ZoneUpdate::AddRecord(soa_rec.clone())).await;
+        assert!(matches!(res, Err(crate::zonetree::update::Error::Finished)));
+
+        let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
+
+        updater
+            .apply(ZoneUpdate::AddRecord(soa_rec.clone()))
+            .await
+            .unwrap();
+
+        let diff = updater
+            .apply(ZoneUpdate::Finished(soa_rec.clone()))
+            .await
+            .unwrap();
+
+        let query = MessageBuilder::new_vec();
+        let mut query = query.question();
+        query.push((qname.clone(), Rtype::SOA)).unwrap();
+        let message: Message<Vec<u8>> = query.into();
+
+        let builder = MessageBuilder::new_bytes();
+        let answer: Message<Bytes> = zone
+            .read()
+            .query(qname, Rtype::SOA)
+            .unwrap()
+            .to_message(&message, builder)
+            .into();
+
+        let found_soa_rec = answer
+            .answer()
+            .unwrap()
+            .limit_to::<Soa<_>>()
+            .next()
+            .unwrap()
+            .unwrap()
+            .into_data();
+
+        assert_eq!(found_soa_rec, soa);
+
+        assert!(diff.is_some());
+        let diff = diff.unwrap();
+
+        assert_eq!(diff.start_serial, Serial(20240922));
+        assert_eq!(diff.end_serial, Serial(20240923));
     }
 
     #[tokio::test]
@@ -642,9 +793,11 @@ mod tests {
         let serial = Serial::now();
         let soa = mk_soa(serial);
         add_answer_record(&req, &mut answer, soa.clone());
-        add_answer_record(&req, &mut answer, A::new(Ipv4Addr::LOCALHOST));
-        add_answer_record(&req, &mut answer, A::new(Ipv4Addr::BROADCAST));
-        add_answer_record(&req, &mut answer, soa);
+        let a_1 = A::new(Ipv4Addr::LOCALHOST);
+        add_answer_record(&req, &mut answer, a_1.clone());
+        let a_2 = A::new(Ipv4Addr::BROADCAST);
+        add_answer_record(&req, &mut answer, a_2.clone());
+        add_answer_record(&req, &mut answer, soa.clone());
         let resp = answer.into_message();
 
         // Process the response.
@@ -655,7 +808,429 @@ mod tests {
             updater.apply(update).await.unwrap();
         }
 
-        dbg!(zone);
+        // --------------------------------------------------------------------
+        // Check the contents of the constructed zone.
+        // --------------------------------------------------------------------
+
+        // example.com   SOA
+        let query = MessageBuilder::new_vec();
+        let mut query = query.question();
+        let qname = Name::from_str("example.com").unwrap();
+        query.push((qname.clone(), Rtype::SOA)).unwrap();
+        let message: Message<Vec<u8>> = query.into();
+
+        let builder = MessageBuilder::new_bytes();
+        let answer: Message<Bytes> = zone
+            .read()
+            .query(qname, Rtype::SOA)
+            .unwrap()
+            .to_message(&message, builder)
+            .into();
+
+        let mut answers = answer.answer().unwrap().limit_to::<Soa<_>>();
+        assert_eq!(answers.next().unwrap().unwrap().into_data(), soa);
+        assert_eq!(answers.next(), None);
+
+        // example.   A
+        let query = MessageBuilder::new_vec();
+        let mut query = query.question();
+        let qname = Name::from_str("example.com").unwrap();
+        query.push((qname.clone(), Rtype::A)).unwrap();
+        let message: Message<Vec<u8>> = query.into();
+
+        let builder = MessageBuilder::new_bytes();
+        let answer: Message<Bytes> = zone
+            .read()
+            .query(qname, Rtype::A)
+            .unwrap()
+            .to_message(&message, builder)
+            .into();
+
+        let mut answers = answer.answer().unwrap().limit_to::<A>();
+        assert_eq!(answers.next().unwrap().unwrap().into_data(), a_2);
+        assert_eq!(answers.next().unwrap().unwrap().into_data(), a_1);
+        assert_eq!(answers.next(), None);
+    }
+
+    #[tokio::test]
+    async fn rfc_1995_ixfr_example() {
+        fn mk_rfc_1995_ixfr_example_soa(
+            serial: u32,
+        ) -> Record<ParsedName<Bytes>, ZoneRecordData<Bytes, ParsedName<Bytes>>>
+        {
+            Record::new(
+                ParsedName::from(Name::from_str("JAIN.AD.JP.").unwrap()),
+                Class::IN,
+                Ttl::from_secs(0),
+                Soa::new(
+                    ParsedName::from(
+                        Name::from_str("NS.JAIN.AD.JP.").unwrap(),
+                    ),
+                    ParsedName::from(
+                        Name::from_str("mohta.jain.ad.jp.").unwrap(),
+                    ),
+                    Serial(serial),
+                    Ttl::from_secs(600),
+                    Ttl::from_secs(600),
+                    Ttl::from_secs(3600000),
+                    Ttl::from_secs(604800),
+                )
+                .into(),
+            )
+        }
+
+        init_logging();
+
+        // --------------------------------------------------------------------
+        // Construct a zone according to the example in RFC 1995 section 7.
+        // --------------------------------------------------------------------
+
+        // https://datatracker.ietf.org/doc/html/rfc1995#section-7
+        // 7. Example
+        //    "Given the following three generations of data with the current
+        //     serial number of 3,"
+        let zone = mk_empty_zone("JAIN.AD.JP.");
+
+        let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
+        //    JAIN.AD.JP.         IN SOA NS.JAIN.AD.JP. mohta.jain.ad.jp. (
+        //                                      1 600 600 3600000 604800)
+        let soa_1 = mk_rfc_1995_ixfr_example_soa(1);
+        updater
+            .apply(ZoneUpdate::AddRecord(soa_1.clone()))
+            .await
+            .unwrap();
+
+        //                        IN NS  NS.JAIN.AD.JP.
+        let ns_1 = Record::new(
+            ParsedName::from(Name::from_str("JAIN.AD.JP.").unwrap()),
+            Class::IN,
+            Ttl::from_secs(0),
+            Ns::new(ParsedName::from(
+                Name::from_str("NS.JAIN.AD.JP.").unwrap(),
+            ))
+            .into(),
+        );
+        updater
+            .apply(ZoneUpdate::AddRecord(ns_1.clone()))
+            .await
+            .unwrap();
+
+        //    NS.JAIN.AD.JP.      IN A   133.69.136.1
+        let a_1 = Record::new(
+            ParsedName::from(Name::from_str("NS.JAIN.AD.JP.").unwrap()),
+            Class::IN,
+            Ttl::from_secs(0),
+            A::new(Ipv4Addr::new(133, 69, 136, 1)).into(),
+        );
+        updater
+            .apply(ZoneUpdate::AddRecord(a_1.clone()))
+            .await
+            .unwrap();
+
+        //    NEZU.JAIN.AD.JP.    IN A   133.69.136.5
+        let nezu = Record::new(
+            ParsedName::from(Name::from_str("NEZU.JAIN.AD.JP.").unwrap()),
+            Class::IN,
+            Ttl::from_secs(0),
+            A::new(Ipv4Addr::new(133, 69, 136, 5)).into(),
+        );
+        updater
+            .apply(ZoneUpdate::AddRecord(nezu.clone()))
+            .await
+            .unwrap();
+
+        //    "NEZU.JAIN.AD.JP. is removed and JAIN-BB.JAIN.AD.JP. is added."
+        let diff_1 = updater
+            .apply(ZoneUpdate::BeginBatchDelete(soa_1.clone()))
+            .await
+            .unwrap();
+        updater
+            .apply(ZoneUpdate::DeleteRecord(nezu.clone()))
+            .await
+            .unwrap();
+        let soa_2 = mk_rfc_1995_ixfr_example_soa(2);
+        updater
+            .apply(ZoneUpdate::BeginBatchAdd(soa_2.clone()))
+            .await
+            .unwrap();
+        let a_2 = Record::new(
+            ParsedName::from(Name::from_str("JAIN-BB.JAIN.AD.JP.").unwrap()),
+            Class::IN,
+            Ttl::from_secs(0),
+            A::new(Ipv4Addr::new(133, 69, 136, 4)).into(),
+        );
+        updater
+            .apply(ZoneUpdate::AddRecord(a_2.clone()))
+            .await
+            .unwrap();
+        let a_3 = Record::new(
+            ParsedName::from(Name::from_str("JAIN-BB.JAIN.AD.JP.").unwrap()),
+            Class::IN,
+            Ttl::from_secs(0),
+            A::new(Ipv4Addr::new(192, 41, 197, 2)).into(),
+        );
+        updater
+            .apply(ZoneUpdate::AddRecord(a_3.clone()))
+            .await
+            .unwrap();
+
+        // //    "One of the IP addresses of JAIN-BB.JAIN.AD.JP. is changed."
+        let diff_2 = updater
+            .apply(ZoneUpdate::BeginBatchDelete(soa_2.clone()))
+            .await
+            .unwrap();
+        updater
+            .apply(ZoneUpdate::DeleteRecord(a_2.clone()))
+            .await
+            .unwrap();
+        let soa_3 = mk_rfc_1995_ixfr_example_soa(3);
+        updater
+            .apply(ZoneUpdate::BeginBatchAdd(soa_3.clone()))
+            .await
+            .unwrap();
+        let a_4 = Record::new(
+            ParsedName::from(Name::from_str("JAIN-BB.JAIN.AD.JP.").unwrap()),
+            Class::IN,
+            Ttl::from_secs(0),
+            A::new(Ipv4Addr::new(133, 69, 136, 3)).into(),
+        );
+        updater
+            .apply(ZoneUpdate::AddRecord(a_4.clone()))
+            .await
+            .unwrap();
+
+        let diff_3 = updater
+            .apply(ZoneUpdate::Finished(soa_3.clone()))
+            .await
+            .unwrap();
+
+        // --------------------------------------------------------------------
+        // Check the contents of the constructed zone.
+        // --------------------------------------------------------------------
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let cloned_count = count.clone();
+        zone.read().walk(Box::new(move |_name, _rrset| {
+            cloned_count.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        assert_eq!(count.load(Ordering::SeqCst), 4);
+
+        // JAIN.AD.JP.   SOA
+        let query = MessageBuilder::new_vec();
+        let mut query = query.question();
+        let qname = Name::from_str("JAIN.AD.JP.").unwrap();
+        query.push((qname.clone(), Rtype::SOA)).unwrap();
+        let message: Message<Vec<u8>> = query.into();
+
+        let builder = MessageBuilder::new_bytes();
+        let answer: Message<Bytes> = zone
+            .read()
+            .query(qname, Rtype::SOA)
+            .unwrap()
+            .to_message(&message, builder)
+            .into();
+
+        let mut answers =
+            answer.answer().unwrap().limit_to::<ZoneRecordData<_, _>>();
+        assert_eq!(answers.next().unwrap().unwrap(), soa_3);
+        assert_eq!(answers.next(), None);
+
+        // JAIN.AD.JP.   NS
+        let query = MessageBuilder::new_vec();
+        let mut query = query.question();
+        let qname = Name::from_str("JAIN.AD.JP.").unwrap();
+        query.push((qname.clone(), Rtype::NS)).unwrap();
+        let message: Message<Vec<u8>> = query.into();
+
+        let builder = MessageBuilder::new_bytes();
+        let answer: Message<Bytes> = zone
+            .read()
+            .query(qname, Rtype::NS)
+            .unwrap()
+            .to_message(&message, builder)
+            .into();
+
+        let mut answers =
+            answer.answer().unwrap().limit_to::<ZoneRecordData<_, _>>();
+        assert_eq!(answers.next().unwrap().unwrap(), ns_1);
+        assert_eq!(answers.next(), None);
+
+        // NS.JAIN.AD.JP.   A
+        let query = MessageBuilder::new_vec();
+        let mut query = query.question();
+        let qname = Name::from_str("NS.JAIN.AD.JP.").unwrap();
+        query.push((qname.clone(), Rtype::A)).unwrap();
+        let message: Message<Vec<u8>> = query.into();
+
+        let builder = MessageBuilder::new_bytes();
+        let answer: Message<Bytes> = zone
+            .read()
+            .query(qname, Rtype::A)
+            .unwrap()
+            .to_message(&message, builder)
+            .into();
+
+        let mut answers =
+            answer.answer().unwrap().limit_to::<ZoneRecordData<_, _>>();
+        assert_eq!(answers.next().unwrap().unwrap(), a_1);
+        assert_eq!(answers.next(), None);
+
+        // JAIN-BB.JAIN.AD.JP.   A
+        let query = MessageBuilder::new_vec();
+        let mut query = query.question();
+        let qname = Name::from_str("JAIN-BB.JAIN.AD.JP.").unwrap();
+        query.push((qname.clone(), Rtype::A)).unwrap();
+        let message: Message<Vec<u8>> = query.into();
+
+        let builder = MessageBuilder::new_bytes();
+        let answer: Message<Bytes> = zone
+            .read()
+            .query(qname, Rtype::A)
+            .unwrap()
+            .to_message(&message, builder)
+            .into();
+
+        let mut answers =
+            answer.answer().unwrap().limit_to::<ZoneRecordData<_, _>>();
+        assert_eq!(answers.next().unwrap().unwrap(), a_4);
+        assert_eq!(answers.next().unwrap().unwrap(), a_3);
+        assert_eq!(answers.next(), None);
+
+        //    "or with the following incremental message:"
+
+        // --------------------------------------------------------------------
+        // Check the contents of diff 1:
+        // --------------------------------------------------------------------
+
+        // No prior SOA so no diff.
+        assert!(diff_1.is_none());
+
+        // --------------------------------------------------------------------
+        // Check the contents of diff 2:
+        // --------------------------------------------------------------------
+
+        // Diff from SOA serial 1 to SOA serial 2
+        assert!(diff_2.is_some());
+        let diff_2 = diff_2.unwrap();
+        assert_eq!(diff_2.start_serial, Serial(1));
+        assert_eq!(diff_2.end_serial, Serial(2));
+
+        // Removed: SOA and one A record at NEZU.JAIN.AD.JP.
+        assert_eq!(diff_2.removed.len(), 2);
+        let mut expected = vec![nezu.into_data()];
+        let mut actual = diff_2
+            .removed
+            .get(&(Name::from_str("NEZU.JAIN.AD.JP.").unwrap(), Rtype::A))
+            .unwrap()
+            .data()
+            .to_vec();
+        expected.sort();
+        actual.sort();
+        assert_eq!(expected, actual);
+
+        // Added: SOA and two A records at JAIN-BB.JAIN.AD.JP.
+        assert_eq!(diff_2.added.len(), 2);
+        let mut expected = vec![a_2.clone().into_data(), a_3.into_data()];
+        let mut actual = diff_2
+            .added
+            .get(&(Name::from_str("JAIN-BB.JAIN.AD.JP.").unwrap(), Rtype::A))
+            .unwrap()
+            .data()
+            .to_vec();
+        expected.sort();
+        actual.sort();
+        assert_eq!(expected, actual);
+
+        // --------------------------------------------------------------------
+        // Check the contents of diff 3:
+        // --------------------------------------------------------------------
+
+        // Diff from SOA serial 2 to SOA serial 3
+        assert!(diff_3.is_some());
+        let diff_3 = diff_3.unwrap();
+        assert_eq!(diff_3.start_serial, Serial(2));
+        assert_eq!(diff_3.end_serial, Serial(3));
+
+        // Removed: SOA and one A record at JAIN-BB.JAIN.AD.JP.
+        assert_eq!(diff_3.removed.len(), 2);
+        let mut expected = vec![a_2.into_data()];
+        let mut actual = diff_3
+            .removed
+            .get(&(Name::from_str("JAIN-BB.JAIN.AD.JP.").unwrap(), Rtype::A))
+            .unwrap()
+            .data()
+            .to_vec();
+        expected.sort();
+        actual.sort();
+        assert_eq!(expected, actual);
+
+        // Added: SOA and one A record at JAIN-BB.JAIN.AD.JP.
+        assert_eq!(diff_3.added.len(), 2);
+        let mut expected = vec![a_4.into_data()];
+        let mut actual = diff_3
+            .added
+            .get(&(Name::from_str("JAIN-BB.JAIN.AD.JP.").unwrap(), Rtype::A))
+            .unwrap()
+            .data()
+            .to_vec();
+        expected.sort();
+        actual.sort();
+        assert_eq!(expected, actual);
+    }
+
+    #[tokio::test]
+    async fn check_rollback() {
+        init_logging();
+
+        let zone = mk_empty_zone("example.com");
+
+        let mut updater = ZoneUpdater::new(zone.clone()).await.unwrap();
+
+        // Create an AXFR request to reply to.
+        let req = mk_request("example.com", Rtype::AXFR).into_message();
+
+        // Create an XFR response interpreter.
+        let mut interpreter = XfrResponseInterpreter::new();
+
+        // Create an AXFR response.
+        let mut answer = mk_empty_answer(&req, Rcode::NOERROR);
+        let serial = Serial::now();
+        let soa = mk_soa(serial);
+        add_answer_record(&req, &mut answer, soa.clone());
+        let a_1 = A::new(Ipv4Addr::LOCALHOST);
+        add_answer_record(&req, &mut answer, a_1.clone());
+        let a_2 = A::new(Ipv4Addr::BROADCAST);
+        add_answer_record(&req, &mut answer, a_2.clone());
+        add_answer_record(&req, &mut answer, soa.clone());
+        let resp = answer.into_message();
+
+        // Process the response.
+        let it = interpreter.interpret_response(resp).unwrap();
+
+        for update in it {
+            let update = update.unwrap();
+            // Don't pass ZoneUpdate::Finished to ZoneUpdater thereby preventing
+            // it from commiting the changes to the zone.
+            if !matches!(update, ZoneUpdate::Finished(_)) {
+                updater.apply(update).await.unwrap();
+            }
+        }
+
+        // Drop the ZoneUpdater to show that it definitely doesn't commit.
+        drop(updater);
+
+        // --------------------------------------------------------------------
+        // Check the contents of the constructed zone.
+        // --------------------------------------------------------------------
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let cloned_count = count.clone();
+        zone.read().walk(Box::new(move |_name, _rrset| {
+            cloned_count.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        assert_eq!(count.load(Ordering::SeqCst), 0);
     }
 
     //------------ Helper functions -------------------------------------------
@@ -727,6 +1302,9 @@ pub enum Error {
 
     /// An I/O error occurred while updating the zone.
     IoError(std::io::Error),
+
+    /// The updater has finished and cannot be used anymore.
+    Finished,
 }
 
 //--- From

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -29,25 +29,26 @@ use super::{WritableZone, WritableZoneNode, Zone, ZoneDiff};
 /// writing, edits made and then the changes committed, only then becoming
 /// visible for readers of the zone.
 ///
-/// To completely replace the content of a zone pass
-/// [`ZoneUpdate::DeleteAllRecords`] to `apply` before any other updates.
-///
 /// Changes to the zone are committed when [`ZoneUpdate::Finished`] is
 /// received, or rolled back if [`ZoneUpdater`] is dropped before receiving
 /// [`ZoneUpdate::Finished`].
 ///
-/// Passing [`ZoneUpdate::BeginBatchDelete`] commits any edits in progress and
-/// starts editing a new zone version.
-///
 /// For each commit of the zone a diff of the changes made is requested and,
-/// if a diff was actually created, it will be returned by
-/// [`ZoneUpdater::apply()`].
+/// if a diff was actually created, will be returned by [`apply()`].
 ///
 /// # Usage
 ///
 /// [`ZoneUpdater`] can be used manually, or in combination with a source of
 /// [`ZoneUpdate`]s such as
 /// [`XfrResponseInterpreter`][crate::net::xfr::protocol::XfrResponseInterpreter].
+///
+/// To completely replace the content of a zone pass
+/// [`ZoneUpdate::DeleteAllRecords`] to [`apply()`] before any other updates.
+///
+/// Pass updates to be applied to the zone one at a time to [`apply()`].
+///
+/// Passing [`ZoneUpdate::BeginBatchDelete`] commits any edits in progress and
+/// starts editing a new zone version.
 ///
 /// # Replacing the content of a zone
 ///
@@ -214,6 +215,8 @@ use super::{WritableZone, WritableZoneNode, Zone, ZoneDiff};
 /// #
 /// # }
 /// ```
+///
+/// [`apply()`]: ZoneUpdater::apply()
 pub struct ZoneUpdater {
     /// The zone to be updated.
     zone: Zone,

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -271,7 +271,7 @@ impl ZoneUpdater {
         trace!("Event: {update}");
         match update {
             ZoneUpdate::DeleteAllRecords => {
-                // To completely replace the content of the zone, i.e.
+                // To completely replace the content of the zone, i.e. with
                 // something like an AXFR transfer, we can't add records from
                 // a new version of the zone to an existing zone because if
                 // the old version contained a record which the new version
@@ -287,9 +287,8 @@ impl ZoneUpdater {
 
             ZoneUpdate::AddRecord(rec) => self.add_record(rec).await?,
 
-            // Note: Batches first contain deletions then additions, so batch
-            // deletion signals the start of a batch, and the end of any
-            // previous batch addition.
+            // Batch deletion signals the start of a batch, and the end of any
+            // batch addition that was in progress.
             ZoneUpdate::BeginBatchDelete(_old_soa) => {
                 let diff = if self.batching {
                     // Commit the previous batch.

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -42,13 +42,10 @@ use super::{WritableZone, WritableZoneNode, Zone, ZoneDiff};
 /// [`ZoneUpdate`]s such as
 /// [`XfrResponseInterpreter`][crate::net::xfr::protocol::XfrResponseInterpreter].
 ///
-/// To completely replace the content of a zone pass
-/// [`ZoneUpdate::DeleteAllRecords`] to [`apply()`] before any other updates.
-///
 /// Pass updates to be applied to the zone one at a time to [`apply()`].
 ///
-/// Passing [`ZoneUpdate::BeginBatchDelete`] commits any edits in progress and
-/// starts editing a new zone version.
+/// To completely replace the content of a zone pass
+/// [`ZoneUpdate::DeleteAllRecords`] to [`apply()`] before any other updates.
 ///
 /// # Replacing the content of a zone
 ///
@@ -261,14 +258,12 @@ impl ZoneUpdater {
     /// committed then any diff made by the `Zone` backing store
     /// implementation will be returned.
     ///
-    /// <div class="warning">
+    /// Changes to the zone are committed when [`ZoneUpdate::Finished`] is
+    /// received, or rolled back if [`ZoneUpdater`] is dropped before
+    /// receiving [`ZoneUpdate::Finished`].
     ///
-    /// This method invokes `WritableZone::commit()` when it receives
-    /// `ZoneUpdate::Finished`. If `ZoneUpdate::Finished` is not passed to
-    /// `ZoneUpdater::apply()` there is no guarantee that the applied changes
-    /// to the zone will take effect.
-    ///
-    /// </div>
+    /// Passing [`ZoneUpdate::BeginBatchDelete`] will also commit any edits in
+    /// progress and re-open the zone for editing again.
     pub async fn apply(
         &mut self,
         update: ZoneUpdate<ParsedRecord>,

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -314,10 +314,8 @@ impl ZoneUpdater {
             }
 
             ZoneUpdate::Finished(zone_soa) => {
-                if !self.batching {
-                    // Update the SOA record.
-                    self.update_soa(zone_soa).await?;
-                }
+                // Update the SOA record.
+                self.update_soa(zone_soa).await?;
 
                 // Commit the previous batch and return any diff produced.
                 return self.write.commit().await;

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -243,7 +243,7 @@ impl ZoneUpdater {
     /// Use [`apply`][Self::apply] to apply changes to the zone.
     pub fn new(
         zone: Zone,
-    ) -> Pin<Box<dyn Future<Output = std::io::Result<Self>>>> {
+    ) -> Pin<Box<dyn Future<Output = std::io::Result<Self>> + Send>> {
         Box::pin(async move {
             let write = WriteState::new(zone.clone()).await?;
 

--- a/src/zonetree/zone.rs
+++ b/src/zonetree/zone.rs
@@ -13,15 +13,6 @@ use super::traits::WritableZone;
 use super::types::StoredName;
 use super::{parsed, ReadableZone, ZoneStore};
 
-//------------ ZoneKey -------------------------------------------------------
-
-/// A key that uniquely identifies a zone.
-///
-/// A zone is identified by the owner name of the apex and its class. Every
-/// record in a zone must be at or under the apex owner name and be of the
-/// same class.
-pub type ZoneKey = (StoredName, Class);
-
 //------------ Zone ----------------------------------------------------------
 
 /// A single DNS zone.
@@ -73,14 +64,6 @@ impl Zone {
     ) -> Pin<Box<dyn Future<Output = Box<dyn WritableZone>> + Send + Sync>>
     {
         self.store.clone().write()
-    }
-
-    /// Gets a key that uniquely identifies this zone.
-    ///
-    /// Note: Assumes that there is only ever one instance of a zone with a
-    /// given apex name and class in a set of zones.
-    pub fn key(&self) -> ZoneKey {
-        (self.apex_name().clone(), self.class())
     }
 }
 

--- a/src/zonetree/zone.rs
+++ b/src/zonetree/zone.rs
@@ -15,7 +15,11 @@ use super::{parsed, ReadableZone, ZoneStore};
 
 //------------ ZoneKey -------------------------------------------------------
 
-/// TODO
+/// A key that uniquely identifies a zone.
+/// 
+/// A zone is identified by the owner name of the apex and its class. Every
+/// record in a zone must be at or under the apex owner name and be of the
+/// same class.
 pub type ZoneKey = (StoredName, Class);
 
 //------------ Zone ----------------------------------------------------------
@@ -40,7 +44,8 @@ impl Zone {
         }
     }
 
-    /// TODO
+    /// Exchange this [`Zone`] wrapper for the actual underlying backing store
+    /// implementation.
     pub fn into_inner(self) -> Arc<dyn ZoneStore> {
         self.store
     }

--- a/src/zonetree/zone.rs
+++ b/src/zonetree/zone.rs
@@ -21,12 +21,6 @@ pub struct Zone {
     store: Arc<dyn ZoneStore>,
 }
 
-impl AsRef<dyn ZoneStore> for Zone {
-    fn as_ref(&self) -> &dyn ZoneStore {
-        self.store.as_ref()
-    }
-}
-
 impl Zone {
     /// Creates a new [`Zone`] instance with the given data.
     pub fn new(data: impl ZoneStore + 'static) -> Self {
@@ -35,14 +29,6 @@ impl Zone {
         }
     }
 
-    /// Exchange this [`Zone`] wrapper for the actual underlying backing store
-    /// implementation.
-    pub fn into_inner(self) -> Arc<dyn ZoneStore> {
-        self.store
-    }
-}
-
-impl Zone {
     /// Gets the CLASS of this zone.
     pub fn class(&self) -> Class {
         self.store.class()

--- a/src/zonetree/zone.rs
+++ b/src/zonetree/zone.rs
@@ -16,7 +16,7 @@ use super::{parsed, ReadableZone, ZoneStore};
 //------------ ZoneKey -------------------------------------------------------
 
 /// A key that uniquely identifies a zone.
-/// 
+///
 /// A zone is identified by the owner name of the apex and its class. Every
 /// record in a zone must be at or under the apex owner name and be of the
 /// same class.


### PR DESCRIPTION
Taken from the `xfr` branch in order to split PR https://github.com/NLnetLabs/domain/pull/335 into several smaller PRs.

Note: None of the changes in this PR are breaking as they only affect the unstable zonetree and XFR related parts of `domain`.

The major changes in this PR are the addition of `ZoneUpdater`, `ZoneDiffBuilder` and `ZoneDiff` types.

`ZoneUpdater` takes the `ZoneUpdate`s produced by `XfrZoneUpdateIterator` (added in PR #375, enhanced slightly in this PR) and applies them to a `Zone`, optionally creating a `ZoneDiff` in the process (to be used by a later PR which will serve IXFR out based on created zone diffs).

This PR also makes a number of smaller related changes: (in no particular order)
- Added, improved and fixed various RustDoc texts.

- `ZoneUpdate` related changes:
  - Renamed the inner record type of `ZoneUpdate` from `XfrRecord` to `ParsedRecord` as it is not XFR specific.
  - Added variant `ZoneUpdate::DeleteAllRecords` which is now emitted at the start of an AXFR update by `XfrZoneUpdateIterator`. `ZoneUpdater` uses this to "remove" all records in the zone before adding the new records. ("remove" in quotes because the remove is a marker operation that is non-destructive so that existing readers continue to see the existing zone version as it should be while the new zone version is being created).
  - Removed the superfluous serial number data members associated with some `ZoneUpdate` variants.

- `zonetree::in_memory` changes:
  - Factor out `ZoneApex::prepare_name()` as `zonetree::util::rel_name_rev_iter()` as it is also now used by `ZoneUpdater`.
  - Improve some naming, e.g. there was mix of terms `remove` and `clean`, all references to `clean` have now been renamed to `remove` based names instead.
  - Altered the logic in `Versioned::remove_all()` (formerly `Versioned::clean()`) as it made destructive changes to the zone that would have impacted readers of the current zone version while the new zone version was being created.
  - Adds an `arc_into_inner()` function for Rust <1.70.0 which doesn't have `Arc::into_inner()`. For our purposes I think it's good enough, it was based on the actual Rust 1.70.0 code, and once our MSRV moves up from 1.68.2 to 1.70.0 and beyond we will be able to get rid of this function (and also the newly added dependency on the `rustversion` crate that came with this change).

- Additional trait bounds where needed.

- Removed some unused code.

Note: This PR contains some unit tests but Stelline tests are left to a later PR.

The diff construction and manner in which diffs are referenced feels suboptimal and ugly and simplistic in places and overly complex in others, and none of these changes are intended to be memory or processor efficient at this point. However, this is currently more about getting all of the puzzle pieces for initial XFR support together in an initial form than any of this being perfect.