### PR TITLE
Servers should drop received DNS response messages.

### DIFF
--- a/src/net/server/connection.rs
+++ b/src/net/server/connection.rs
@@ -670,12 +670,22 @@ where
 
                 match Message::from_octets(buf) {
                     Err(err) => {
+                        // TO DO: Count this event?
                         tracing::warn!(
                             "Failed while parsing request message: {err}"
                         );
                         return Err(ConnectionEvent::ServiceError(
                             ServiceError::FormatError,
                         ));
+                    }
+
+                    // https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.1
+                    // 4.1.1. Header section format
+                    //   "QR   A one bit field that specifies whether this
+                    //         message is a query (0), or a response (1)."
+                    Ok(msg) if msg.header().qr() => {
+                        // TO DO: Count this event?
+                        trace!("Ignoring received message because it is a reply, not a query.");
                     }
 
                     Ok(msg) => {

--- a/src/net/server/dgram.rs
+++ b/src/net/server/dgram.rs
@@ -511,7 +511,18 @@ where
                     tokio::spawn(async move {
                         match Message::from_octets(buf) {
                             Err(err) => {
-                                tracing::warn!("Failed while parsing request message: {err}");
+                                // TO DO: Count this event?
+                                warn!("Failed while parsing request message: {err}");
+                            }
+
+                            // https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.1
+                            // 4.1.1. Header section format
+                            //   "QR   A one bit field that specifies whether
+                            //         this message is a query (0), or a
+                            //         response (1)."
+                            Ok(msg) if msg.header().qr() => {
+                                // TO DO: Count this event?
+                                trace!("Ignoring received message because it is a reply, not a query.");
                             }
 
                             Ok(msg) => {


### PR DESCRIPTION
I just noticed that the UDP and TCP server code will happily propagate any received DNS message for processing by the service stack, even if the received message has the QR header bit set to 1, i.e. it is a reply, not a query.

Middleware and customer service code shouldn't have to check every received message to make sure they are not unexpectedly replies rather than queries, so ignore them in the servers.