### PR TITLE
Consistently refer to zonefile r/w as experimental.

### DIFF
--- a/src/zonefile/mod.rs
+++ b/src/zonefile/mod.rs
@@ -1,4 +1,4 @@
-//! Reading and writing of zonefiles.
+//! Experimental reading and writing of zonefiles.
 #![cfg(feature = "zonefile")]
 #![cfg_attr(docsrs, doc(cfg(feature = "zonefile")))]
 


### PR DESCRIPTION
The main page of the RustDoc (`lib.rs`) says ([rendered](https://docs.rs/domain/latest/domain/)):

```
zonefile: Experimental reading and writing of zone files, i.e. the textual representation of DNS data.
zonetree: Experimental storing and querying of zone trees.
```

But then the module list below says:

```
zonefile [zonefile] Reading and writing of zonefiles.
zonetree [unstable-zonetree] Experimental storing and querying of zone trees.
```

Why does one say experimental in both cases and the other not?

This PR synchronizes the two by saying "experimental" in both places.