### PR TITLE
Add NXNAME RR type and invalid query type EDE

### DIFF
--- a/src/base/iana/exterr.rs
+++ b/src/base/iana/exterr.rs
@@ -149,6 +149,9 @@ int_enum! {
     /// is otherwise configured to support. Examples of this include
     /// its most recent zone being too old or having expired.
     (INVALID_DATA => 24, b"Invalid Data")
+
+    /// The requested resource record type should not appear in a query.
+    (INVALID_QUERY_TYPE => 30, b"Invalid Query Type")
 }
 
 /// Start of the private range for EDE codes.

--- a/src/base/iana/rtype.rs
+++ b/src/base/iana/rtype.rs
@@ -364,6 +364,11 @@ int_enum! {
     /// See RFC 7043.
     (EUI64 => 109, b"EUI64")
 
+    /// NXNAME.
+    ///
+    /// IANA-Reserved.
+    (NXNAME => 128, b"NXNAME")
+
     /// Transaction key.
     ///
     /// See RFC 2930.


### PR DESCRIPTION
Adding NXNAME resource record type and the EDE code to reject invalid queries for it
[EDE 30](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#:~:text=30-,Invalid%20Query%20Type,-%5Bdraft%2Dietf) and [NXNAME](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#:~:text=NXDOMAIN%20indicator%20for%20Compact%20Denial%20of%20Existence) are both IANA reserved

