### PR TITLE
Rewrite `NameBuilder`

### DIFF
--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -243,7 +243,8 @@ impl Name<Bytes> {
 
     /// Creates a domain name atop a Bytes from its string representation.
     pub fn bytes_from_str(s: &str) -> Result<Self, ScanError> {
-        FromStr::from_str(s)
+        let name: Name<Vec<u8>> = s.parse()?;
+        Ok(Self(name.0.into()))
     }
 }
 
@@ -941,11 +942,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, Octs> serde::Deserialize<'de> for Name<Octs>
 where
-    Octs: FromBuilder + DeserializeOctets<'de>,
-    <Octs as FromBuilder>::Builder: FreezeBuilder<Octets = Octs>
-        + EmptyBuilder
-        + AsRef<[u8]>
-        + AsMut<[u8]>,
+    Octs: AsRef<[u8]> + for<'a> TryFrom<&'a [u8]> + DeserializeOctets<'de>,
 {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
@@ -956,11 +953,9 @@ where
 
         impl<'de, Octs> serde::de::Visitor<'de> for InnerVisitor<'de, Octs>
         where
-            Octs: FromBuilder + DeserializeOctets<'de>,
-            <Octs as FromBuilder>::Builder: FreezeBuilder<Octets = Octs>
-                + EmptyBuilder
-                + AsRef<[u8]>
-                + AsMut<[u8]>,
+            Octs: AsRef<[u8]>
+                + for<'a> TryFrom<&'a [u8]>
+                + DeserializeOctets<'de>,
         {
             type Value = Name<Octs>;
 
@@ -999,11 +994,9 @@ where
 
         impl<'de, Octs> serde::de::Visitor<'de> for NewtypeVisitor<Octs>
         where
-            Octs: FromBuilder + DeserializeOctets<'de>,
-            <Octs as FromBuilder>::Builder: EmptyBuilder
-                + FreezeBuilder<Octets = Octs>
-                + AsRef<[u8]>
-                + AsMut<[u8]>,
+            Octs: AsRef<[u8]>
+                + for<'a> TryFrom<&'a [u8]>
+                + DeserializeOctets<'de>,
         {
             type Value = Name<Octs>;
 

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -727,7 +727,7 @@ where
         let mut builder = NameBuilder::new([0u8; 256]);
         builder.scan_name(name)?;
         // Append an empty slice for a root label.
-        builder.append_slice(&[]);
+        builder.append_slice(&[])?;
         builder
             .as_absolute()
             .map(Option::unwrap) // We ensure there is a root label.

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -1,768 +1,348 @@
 //! Building a domain name.
 //!
-//! This is a private module for tidiness. `NameBuilder` and `PushError`
+//! This is a private module for tidiness. `NameBuilder` and `BuildError`
 //! are re-exported by the parent module.
 
-use super::super::scan::{BadSymbol, Symbol, SymbolCharsError, Symbols};
+use core::borrow::{Borrow, BorrowMut};
+use core::fmt;
+
 use super::absolute::Name;
-use super::relative::{RelativeName, RelativeNameError};
+use super::relative::RelativeName;
+use super::uncertain::UncertainName;
 use super::traits::{ToName, ToRelativeName};
 use super::Label;
-#[cfg(feature = "bytes")]
-use bytes::BytesMut;
-use core::fmt;
-use octseq::builder::{EmptyBuilder, FreezeBuilder, OctetsBuilder, ShortBuf};
-#[cfg(feature = "std")]
-use std::vec::Vec;
 
 //------------ NameBuilder --------------------------------------------------
 
-/// Builds a domain name step by step by appending data.
+/// An incremental builder for domain names.
 ///
-/// The domain name builder is the most fundamental way to construct a new
-/// domain name. It wraps an octets builder that assembles the name step by
-/// step.
+/// A [`NameBuilder`] manages a buffer and provides high-level operations to
+/// incrementally construct a domain name in that buffer.  The domain name can
+/// be built out of individual bytes and/or whole labels.  Once building is
+/// complete, an absolute or relative domain name can be extracted.
 ///
-/// The methods [`push`][Self::push] and [`append_slice`][Self::append_slice]
-/// to add the octets of a label to end of the builder. Once a label is
-/// complete, [`end_label`][Self::end_label] finishes the current label and
-/// starts a new one.
+/// This type does not support internationalized domain names directly.  Such
+/// domain names must be punycoded before being passed in.
 ///
-/// The method [`append_label`][Self::append_label] combines this process
-/// and appends the given octets as a label.
+/// # Usage
 ///
-/// The name builder currently is not aware of internationalized domain
-/// names. The octets passed to it are used as is and are not converted.
+/// To construct the builder, call [`new()`] (providing a pre-constructed
+/// buffer) or [`default()`] (automatically constructing a buffer).
+///
+/// [`new()`]: Self::new()
+/// [`default()`]: Self::default()
+///
+/// If the domain name being constructed is already available as a sequence of
+/// labels (where each label is a slice of bytes), call [`append_label()`]
+/// repeatedly.  If a label is available as a sequence of byte slices, it can be
+/// incrementally constructed with [`append_slice()`], terminating with
+/// [`end_label()`].
+///
+/// [`append_label()`]: Self::append_label()
+/// [`append_slice()`]: Self::append_slice()
+/// [`end_label()`]: Self::end_label()
+///
+/// Special care must be taken with absolute domain names, which contain a root
+/// label (which is of zero length).  The root label must attached with a call
+/// to [`append()`], without calling [`end_label()`] after it.
+///
+/// Once the entire domain name has been constructed, it can be extracted out of
+/// the builder.  Depending on the type of domain name required, call
+/// [`as_absolute()`], [`as_relative()`], or [`as_uncertain()`].  These are also
+/// available as [`From`] implementations.
+///
+/// [`as_absolute()`]: Self::as_absolute()
+/// [`as_relative()`]: Self::as_relative()
+/// [`as_uncertain()`]: Self::as_uncertain()
 #[derive(Clone)]
-pub struct NameBuilder<Builder> {
+pub struct NameBuilder<Buffer: ?Sized> {
+    /// The offset to write the next byte to.
+    write_offset: u8,
+
+    /// The offset of the length octet of the current label.
+    ///
+    /// Invariants:
+    ///
+    /// - `label_offset <= write_offset`
+    ///   - if `label_offset < write_offset`:
+    ///     - a label is currently being built.
+    ///     - `buffer[label_offset] == 0`.
+    label_offset: u8,
+
     /// The buffer to build the name in.
-    builder: Builder,
-
-    /// The position in `octets` where the current label started.
     ///
-    /// If this is `None` we currently do not have a label.
-    head: Option<usize>,
+    /// Invariants:
+    ///
+    /// - `buffer[.. write_offset]` is initialized.
+    buffer: Buffer,
 }
 
-impl<Builder> NameBuilder<Builder> {
-    /// Creates a new domain name builder from an octets builder.
+/// # Preparing
+impl<Buffer> NameBuilder<Buffer> {
+    /// Construct a new [`NameBuilder`] using the given buffer.
     ///
-    /// Whatever is in the buffer already is considered to be a relative
-    /// domain name. Since that may not be the case, this function is
-    /// unsafe.
-    pub(super) unsafe fn from_builder_unchecked(builder: Builder) -> Self {
-        NameBuilder {
-            builder,
-            head: None,
+    /// Any existing contents in the buffer will be ignored and overwritten.
+    #[must_use]
+    pub const fn new(buffer: Buffer) -> Self {
+        Self {
+            write_offset: 0,
+            label_offset: 0,
+            buffer,
         }
     }
-
-    /// Creates a new, empty name builder.
-    #[must_use]
-    pub fn new() -> Self
-    where
-        Builder: EmptyBuilder,
-    {
-        unsafe { NameBuilder::from_builder_unchecked(Builder::empty()) }
-    }
-
-    /// Creates a new, empty builder with a given capacity.
-    #[must_use]
-    pub fn with_capacity(capacity: usize) -> Self
-    where
-        Builder: EmptyBuilder,
-    {
-        unsafe {
-            NameBuilder::from_builder_unchecked(Builder::with_capacity(
-                capacity,
-            ))
-        }
-    }
-
-    /// Creates a new domain name builder atop an existing octets builder.
-    ///
-    /// The function checks that whatever is in the builder already
-    /// consititutes a correctly encoded relative domain name.
-    pub fn from_builder(builder: Builder) -> Result<Self, RelativeNameError>
-    where
-        Builder: OctetsBuilder + AsRef<[u8]>,
-    {
-        RelativeName::check_slice(builder.as_ref())?;
-        Ok(unsafe { NameBuilder::from_builder_unchecked(builder) })
-    }
 }
 
-#[cfg(feature = "std")]
-impl NameBuilder<Vec<u8>> {
-    /// Creates an empty domain name builder atop a `Vec<u8>`.
-    #[must_use]
-    pub fn new_vec() -> Self {
-        Self::new()
-    }
-
-    /// Creates an empty builder atop a `Vec<u8>` with given capacity.
-    ///
-    /// Names are limited to a length of 255 octets, but you can provide any
-    /// capacity you like here.
-    #[must_use]
-    pub fn vec_with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
-    }
-}
-
-#[cfg(feature = "bytes")]
-impl NameBuilder<BytesMut> {
-    /// Creates an empty domain name bulider atop a bytes value.
-    pub fn new_bytes() -> Self {
-        Self::new()
-    }
-
-    /// Creates an empty bulider atop a bytes value with given capacity.
-    ///
-    /// Names are limited to a length of 255 octets, but you can provide any
-    /// capacity you like here.
-    pub fn bytes_with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
-    }
-}
-
-impl<Builder: AsRef<[u8]>> NameBuilder<Builder> {
-    /// Returns the already assembled domain name as an octets slice.
-    pub fn as_slice(&self) -> &[u8] {
-        self.builder.as_ref()
-    }
-
-    /// Returns the length of the already assembled domain name.
+impl<Buffer: ?Sized> NameBuilder<Buffer> {
+    /// The total size of the built domain name, in bytes.
     pub fn len(&self) -> usize {
-        self.builder.as_ref().len()
+        self.write_offset as usize
     }
 
-    /// Returns whether the name is still empty.
+    /// Whether the builder is empty.
     pub fn is_empty(&self) -> bool {
-        self.builder.as_ref().is_empty()
+        self.write_offset == 0
     }
 }
 
-impl<Builder> NameBuilder<Builder>
-where
-    Builder: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>,
-{
-    /// Returns whether there currently is a label under construction.
+/// # Building
+impl<Buffer: ?Sized> NameBuilder<Buffer>
+where Buffer: Borrow<[u8; 256]> + BorrowMut<[u8; 256]> {
+    /// Append a whole label as a slice of bytes.
     ///
-    /// This returns `false` if the name is still empty or if the last thing
-    /// that happend was a call to [`end_label`].
+    /// The label is added to the end of the domain name.
     ///
-    /// [`end_label`]: NameBuilder::end_label
-    pub fn in_label(&self) -> bool {
-        self.head.is_some()
-    }
+    /// # Errors
+    ///
+    /// Returns an error if the label is too big, or if appending it to the
+    /// domain name would make the domain name too big.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a label was already being built.
+    pub fn append_label(&mut self, label: &[u8]) -> Result<(), BuildError> {
+        assert!(self.label_offset == self.write_offset,
+            "cannot append a whole label to a partially-built one");
 
-    /// Attempts to append a slice to the underlying builder.
-    ///
-    /// This method doesn’t perform any checks but only does the necessary
-    /// error conversion.
-    fn _append_slice(&mut self, slice: &[u8]) -> Result<(), PushError> {
-        self.builder
-            .append_slice(slice)
-            .map_err(|_| PushError::ShortBuf)
-    }
+        // Ensure the new label will fit.
+        self.can_fit_label(label.len())?;
 
-    /// Pushes an octet to the end of the domain name.
-    ///
-    /// Starts a new label if necessary. Returns an error if pushing the
-    /// octet would exceed the size limits for labels or domain names.
-    pub fn push(&mut self, ch: u8) -> Result<(), PushError> {
-        let len = self.len();
-        if len >= 254 {
-            return Err(PushError::LongName);
-        }
-        if let Some(head) = self.head {
-            if len - head > Label::MAX_LEN {
-                return Err(PushError::LongLabel);
-            }
-            self._append_slice(&[ch])?;
-        } else {
-            self.head = Some(len);
-            self._append_slice(&[0, ch])?;
-        }
+        let buffer = self.buffer.borrow_mut();
+        buffer[self.write_offset as usize] = label.len() as u8;
+        buffer[self.write_offset as usize + 1 ..][.. label.len()]
+            .copy_from_slice(label);
+        self.write_offset += (1 + label.len()) as u8;
+        self.label_offset = self.write_offset;
+
         Ok(())
     }
 
-    /// Pushes a symbol to the end of the domain name.
+    /// Append a slice of bytes to the current label.
     ///
-    /// The symbol is iterpreted as part of the presentation format of a
-    /// domain name, i.e., an unescaped dot is considered a label separator.
-    pub fn push_symbol(&mut self, sym: Symbol) -> Result<(), FromStrError> {
-        if matches!(sym, Symbol::Char('.')) {
-            if !self.in_label() {
-                return Err(PresentationErrorEnum::EmptyLabel.into());
-            }
-            self.end_label();
-            Ok(())
-        } else if matches!(sym, Symbol::SimpleEscape(b'['))
-            && !self.in_label()
-        {
-            Err(LabelFromStrErrorEnum::BinaryLabel.into())
-        } else {
-            self.push(sym.into_octet()?).map_err(Into::into)
-        }
-    }
+    /// If no label exists, a new label will be created.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the label being built is too big, or if appending it
+    /// to the current domain name would make the domain name too big.
+    pub fn append_slice(&mut self, data: &[u8]) -> Result<(), BuildError> {
+        // Ensure the label being built will fit.
+        self.can_fit_label(data.len() + self.cur_label()
+                .map_or(0, |l| l.len()))?;
 
-    /// Appends the content of an octets slice to the end of the domain name.
-    ///
-    /// Starts a new label if necessary. Returns an error if pushing
-    /// would exceed the size limits for labels or domain names.
-    ///
-    /// If `slice` is empty, does absolutely nothing.
-    pub fn append_slice(&mut self, slice: &[u8]) -> Result<(), PushError> {
-        if slice.is_empty() {
-            return Ok(());
+        let buffer = self.buffer.borrow_mut();
+        if self.label_offset == self.write_offset {
+            // Start a new label.
+            buffer[self.write_offset as usize] = 0;
+            self.write_offset += 1;
         }
-        if let Some(head) = self.head {
-            if slice.len() > Label::MAX_LEN - (self.len() - head) {
-                return Err(PushError::LongLabel);
-            }
-        } else {
-            if slice.len() > Label::MAX_LEN {
-                return Err(PushError::LongLabel);
-            }
-            if self.len() + slice.len() > 254 {
-                return Err(PushError::LongName);
-            }
-            self.head = Some(self.len());
-            self._append_slice(&[0])?;
-        }
-        self._append_slice(slice)?;
+
+        // Append the new data.
+        buffer[self.write_offset as usize ..][.. data.len()]
+            .copy_from_slice(data);
+        self.write_offset += data.len() as u8;
+
         Ok(())
     }
 
-    /// Ends the current label.
+    /// End the current label, if any.
     ///
-    /// If there isn’t a current label, does nothing.
+    /// # Panics
+    ///
+    /// Panics if this is a root label (i.e. has zero length).
     pub fn end_label(&mut self) {
-        if let Some(head) = self.head {
-            let len = self.len() - head - 1;
-            self.builder.as_mut()[head] = len as u8;
-            self.head = None;
+        if self.label_offset < self.write_offset {
+            let len = self.write_offset - self.label_offset - 1;
+            assert!(len > 0, "cannot end a root label");
+            self.buffer.borrow_mut()[self.label_offset as usize] = len;
         }
     }
 
-    /// Appends an octets slice as a complete label.
+    /// Check that a label can be appended to this builder.
     ///
-    /// If there currently is a label under construction, it will be ended
-    /// before appending `label`.
-    ///
-    /// Returns an error if `label` exceeds the label size limit of 63 bytes
-    /// or appending the label would exceed the domain name size limit of
-    /// 255 bytes.
-    pub fn append_label(&mut self, label: &[u8]) -> Result<(), PushError> {
-        let head = self.head;
-        self.end_label();
-        if let Err(err) = self.append_slice(label) {
-            self.head = head;
-            return Err(err);
+    /// This ignores any partially-built label already in the builder; its size
+    /// should be included in the provided `label_size` parameter.
+    const fn can_fit_label(&self, label_size: usize) -> Result<(), BuildError> {
+        if label_size > Label::MAX_LEN {
+            Err(BuildError::LongLabel)
+        } else if self.label_offset as usize + 1 + label_size > Name::MAX_LEN {
+            Err(BuildError::LongName)
+        } else {
+            Ok(())
         }
-        self.end_label();
-        Ok(())
+    }
+}
+
+/// # Inspecting
+impl<Buffer: ?Sized> NameBuilder<Buffer>
+where Buffer: Borrow<[u8; 256]> {
+    /// The domain name built thus far.
+    ///
+    /// This does not include any partially-built label.
+    pub fn cur_slice(&self) -> &[u8] {
+        &self.buffer.borrow()[.. self.label_offset as usize]
     }
 
-    /// Appends a label with the decimal representation of `u8`.
+    /// The current label being built, if any.
     ///
-    /// If there currently is a label under construction, it will be ended
-    /// before appending `label`.
+    /// This does not include the length octet for the label.
+    pub fn cur_label(&self) -> Option<&[u8]> {
+        if self.label_offset < self.write_offset {
+            let label = self.label_offset as usize;
+            let write = self.write_offset as usize;
+            Some(&self.buffer.borrow()[label + 1 .. write])
+        } else {
+            None
+        }
+    }
+}
+
+/// # Extracting
+impl<Buffer: ?Sized> NameBuilder<Buffer>
+where Buffer: Borrow<[u8; 256]> {
+    /// Extract an absolute domain name from the builder.
     ///
-    /// Returns an error if appending would result in a name longer than 254
-    /// bytes.
-    pub fn append_dec_u8_label(
-        &mut self,
-        value: u8,
-    ) -> Result<(), PushError> {
-        self.end_label();
-        let hecto = value / 100;
-        if hecto > 0 {
-            self.push(hecto + b'0')?;
+    /// If the name does not end with the root label (which has length zero),
+    /// [`None`] is returned.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the octet sequence type underlying the [`Name`] cannot
+    /// allocate enough space to store the domain name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a non-empty label was in the process of being built.
+    pub fn as_absolute<'a, Octs>(&'a self)
+        -> Result<Option<Name<Octs>>, Octs::Error>
+    where Octs: TryFrom<&'a [u8]> {
+        assert!(self.write_offset <= self.label_offset + 1,
+            "cannot extract a domain name while a label is being built");
+
+        if self.write_offset == self.label_offset {
+            let buffer = &self.buffer.borrow()[.. self.write_offset as usize];
+            let octseq = Octs::try_from(buffer)?;
+            Ok(Some(unsafe {
+                // SAFETY: `buffer` contains a valid name that was built through
+                // `NameBuilder`.  A single root label is present, at the end.
+                Name::from_octets_unchecked(octseq)
+            }))
+        } else {
+            Ok(None)
         }
-        let deka = (value / 10) % 10;
-        if hecto > 0 || deka > 0 {
-            self.push(deka + b'0')?;
-        }
-        self.push(value % 10 + b'0')?;
-        self.end_label();
-        Ok(())
     }
 
-    /// Appends a label with the hex digit.
+    /// Extract a relative domain name from the builder.
     ///
-    /// If there currently is a label under construction, it will be ended
-    /// before appending `label`.
+    /// # Errors
     ///
-    /// Returns an error if appending would result in a name longer than 254
-    /// bytes.
-    pub fn append_hex_digit_label(
-        &mut self,
-        nibble: u8,
-    ) -> Result<(), PushError> {
-        fn hex_digit(nibble: u8) -> u8 {
-            match nibble & 0x0F {
-                0 => b'0',
-                1 => b'1',
-                2 => b'2',
-                3 => b'3',
-                4 => b'4',
-                5 => b'5',
-                6 => b'6',
-                7 => b'7',
-                8 => b'8',
-                9 => b'9',
-                10 => b'A',
-                11 => b'B',
-                12 => b'C',
-                13 => b'D',
-                14 => b'E',
-                15 => b'F',
-                _ => unreachable!(),
-            }
-        }
+    /// Fails if the octet sequence type underlying the [`RelativeName`] cannot
+    /// allocate enough space to store the domain name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a label was in the process of being built.
+    pub fn as_relative<'a, Octs>(&'a self)
+        -> Result<RelativeName<Octs>, Octs::Error>
+    where Octs: TryFrom<&'a [u8]> {
+        assert!(self.label_offset == self.write_offset,
+            "cannot extract a domain name while a label is being built");
 
-        self.end_label();
-        self.push(hex_digit(nibble))?;
-        self.end_label();
-        Ok(())
-    }
-
-    /// Appends a relative domain name.
-    ///
-    /// If there currently is a label under construction, it will be ended
-    /// before appending `name`.
-    ///
-    /// Returns an error if appending would result in a name longer than 254
-    /// bytes.
-    //
-    //  XXX NEEDS TESTS
-    pub fn append_name<N: ToRelativeName>(
-        &mut self,
-        name: &N,
-    ) -> Result<(), PushNameError> {
-        let head = self.head.take();
-        self.end_label();
-        if self.len() + usize::from(name.compose_len()) > 254 {
-            self.head = head;
-            return Err(PushNameError::LongName);
-        }
-        for label in name.iter_labels() {
-            label
-                .compose(&mut self.builder)
-                .map_err(|_| PushNameError::ShortBuf)?;
-        }
-        Ok(())
-    }
-
-    /// Appends a name from a sequence of symbols.
-    ///
-    /// If there currently is a label under construction, it will be ended
-    /// before appending `chars`.
-    ///
-    /// The character sequence must result in a domain name in representation
-    /// format. That is, its labels should be separated by dots,
-    /// actual dots, white space, backslashes  and byte values that are not
-    /// printable ASCII characters should be escaped.
-    ///
-    /// The last label will only be ended if the last character was a dot.
-    /// Thus, you can determine if that was the case via
-    /// [`in_label`][Self::in_label].
-    pub fn append_symbols<Sym: IntoIterator<Item = Symbol>>(
-        &mut self,
-        symbols: Sym,
-    ) -> Result<(), FromStrError> {
-        symbols
-            .into_iter()
-            .try_for_each(|symbol| self.push_symbol(symbol))
-    }
-
-    /// Appends a name from a sequence of characters.
-    ///
-    /// If there currently is a label under construction, it will be ended
-    /// before appending `chars`.
-    ///
-    /// The character sequence must result in a domain name in representation
-    /// format. That is, its labels should be separated by dots,
-    /// actual dots, white space and backslashes should be escaped by a
-    /// preceeding backslash, and any byte value that is not a printable
-    /// ASCII character should be encoded by a backslash followed by its
-    /// three digit decimal value.
-    ///
-    /// The last label will only be ended if the last character was a dot.
-    /// Thus, you can determine if that was the case via
-    /// [`in_label`][Self::in_label].
-    pub fn append_chars<C: IntoIterator<Item = char>>(
-        &mut self,
-        chars: C,
-    ) -> Result<(), FromStrError> {
-        Symbols::with(chars.into_iter(), |symbols| {
-            self.append_symbols(symbols)
+        let buffer = &self.buffer.borrow()[.. self.write_offset as usize];
+        let octseq = Octs::try_from(buffer)?;
+        Ok(unsafe {
+            // SAFETY: `buffer` contains a valid name that was built through
+            // `NameBuilder`.  No root labels are present.
+            // TODO: Worry about a 255-byte relative name?
+            RelativeName::from_octets_unchecked(octseq)
         })
     }
 
-    /// Finishes building the name and returns the resulting relative name.
+    /// Extract an absolute or relative domain name from the builder.
     ///
-    /// If there currently is a label being built, ends the label first
-    /// before returning the name. I.e., you don’t have to call [`end_label`]
-    /// explicitely.
+    /// # Errors
     ///
-    /// This method converts the builder into a relative name. If you would
-    /// like to turn it into an absolute name, use [`into_name`] which
-    /// appends the root label before finishing.
+    /// Fails if the octet sequence type underlying the [`UncertainName`] cannot
+    /// allocate enough space to store the domain name.
     ///
-    /// [`end_label`]: NameBuilder::end_label
-    /// [`into_name`]: NameBuilder::into_name
-    pub fn finish(mut self) -> RelativeName<Builder::Octets>
-    where
-        Builder: FreezeBuilder,
-    {
-        self.end_label();
-        unsafe { RelativeName::from_octets_unchecked(self.builder.freeze()) }
-    }
-
-    /// Appends the root label to the name and returns it as a [`Name`].
+    /// # Panics
     ///
-    /// If there currently is a label under construction, ends the label.
-    /// Then adds the empty root label and transforms the name into a
-    /// [`Name`].
-    pub fn into_name(mut self) -> Result<Name<Builder::Octets>, PushError>
-    where
-        Builder: FreezeBuilder,
-    {
-        self.end_label();
-        self._append_slice(&[0])?;
-        Ok(unsafe { Name::from_octets_unchecked(self.builder.freeze()) })
-    }
+    /// Panics if a non-empty label was in the process of being built.
+    pub fn as_uncertain<'a, Octs>(&'a self)
+        -> Result<UncertainName<Octs>, Octs::Error>
+    where Octs: TryFrom<&'a [u8]> {
+        assert!(self.write_offset <= self.label_offset + 1,
+            "cannot extract a domain name while a label is being built");
 
-    /// Appends an origin and returns the resulting [`Name`].
-    ///
-    /// If there currently is a label under construction, ends the label.
-    /// Then adds the `origin` and transforms the name into a
-    /// [`Name`].
-    //
-    //  XXX NEEDS TESTS
-    pub fn append_origin<N: ToName>(
-        mut self,
-        origin: &N,
-    ) -> Result<Name<Builder::Octets>, PushNameError>
-    where
-        Builder: FreezeBuilder,
-    {
-        self.end_label();
-        if self.len() + usize::from(origin.compose_len()) > Name::MAX_LEN {
-            return Err(PushNameError::LongName);
-        }
-        for label in origin.iter_labels() {
-            label
-                .compose(&mut self.builder)
-                .map_err(|_| PushNameError::ShortBuf)?;
-        }
-        Ok(unsafe { Name::from_octets_unchecked(self.builder.freeze()) })
-    }
-}
-
-//--- Default
-
-impl<Builder: EmptyBuilder> Default for NameBuilder<Builder> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-//--- AsRef
-
-impl<Builder: AsRef<[u8]>> AsRef<[u8]> for NameBuilder<Builder> {
-    fn as_ref(&self) -> &[u8] {
-        self.builder.as_ref()
-    }
-}
-
-//------------ Santa’s Little Helpers ----------------------------------------
-
-/// Parses the contents of an escape sequence from `chars`.
-///
-/// The backslash should already have been taken out of `chars`.
-pub(super) fn parse_escape<C>(
-    chars: &mut C,
-    in_label: bool,
-) -> Result<u8, LabelFromStrError>
-where
-    C: Iterator<Item = char>,
-{
-    let ch = chars.next().ok_or(SymbolCharsError::short_input())?;
-    if ch.is_ascii_digit() {
-        let v = ch.to_digit(10).unwrap() * 100
-            + chars
-                .next()
-                .ok_or(SymbolCharsError::short_input())
-                .and_then(|c| {
-                    c.to_digit(10).ok_or(SymbolCharsError::bad_escape())
-                })?
-                * 10
-            + chars
-                .next()
-                .ok_or(SymbolCharsError::short_input())
-                .and_then(|c| {
-                    c.to_digit(10).ok_or(SymbolCharsError::bad_escape())
-                })?;
-        if v > 255 {
-            return Err(SymbolCharsError::bad_escape().into());
-        }
-        Ok(v as u8)
-    } else if ch == '[' {
-        // `\[` at the start of a label marks a binary label which we don’t
-        // support. Within a label, the sequence is fine.
-        if in_label {
-            Ok(b'[')
+        let buffer = &self.buffer.borrow()[.. self.write_offset as usize];
+        let octseq = Octs::try_from(buffer)?;
+        if self.write_offset == self.label_offset {
+            Ok(unsafe {
+                // SAFETY: `buffer` contains a valid name that was built through
+                // `NameBuilder`.  A single root label is present, at the end.
+                Name::from_octets_unchecked(octseq).into()
+            })
         } else {
-            Err(LabelFromStrErrorEnum::BinaryLabel.into())
+            Ok(unsafe {
+                // SAFETY: `buffer` contains a valid name that was built through
+                // `NameBuilder`.  No root labels are present.
+                // TODO: Worry about a 255-byte relative name?
+                RelativeName::from_octets_unchecked(octseq).into()
+            })
         }
-    } else {
-        Ok(ch as u8)
     }
 }
 
-//============ Error Types ===================================================
+impl<Buffer: Default> Default for NameBuilder<Buffer> {
+    fn default() -> Self {
+        Self::new(Buffer::default())
+    }
+}
 
-//------------ PushError -----------------------------------------------------
+// TODO: impl 'ToName' / 'ToRelativeName'
 
-/// An error happened while trying to push data to a domain name builder.
+//------------ BuildError ----------------------------------------------------
+
+/// An error in building a domain name.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PushError {
-    /// The current label would exceed the limit of 63 bytes.
+pub enum BuildError {
+    /// The label being built would exceed the 63-byte limit.
     LongLabel,
 
-    /// The name would exceed the limit of 255 bytes.
-    LongName,
-
-    /// The buffer is too short to contain the name.
-    ShortBuf,
-}
-
-//--- From
-
-impl From<ShortBuf> for PushError {
-    fn from(_: ShortBuf) -> PushError {
-        PushError::ShortBuf
-    }
-}
-
-//--- Display and Error
-
-impl fmt::Display for PushError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            PushError::LongLabel => f.write_str("long label"),
-            PushError::LongName => f.write_str("long domain name"),
-            PushError::ShortBuf => ShortBuf.fmt(f),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for PushError {}
-
-//------------ PushNameError -------------------------------------------------
-
-/// An error happened while trying to push a name to a domain name builder.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PushNameError {
-    /// The name would exceed the limit of 255 bytes.
-    LongName,
-
-    /// The buffer is too short to contain the name.
-    ShortBuf,
-}
-
-//--- From
-
-impl From<ShortBuf> for PushNameError {
-    fn from(_: ShortBuf) -> Self {
-        PushNameError::ShortBuf
-    }
-}
-
-//--- Display and Error
-
-impl fmt::Display for PushNameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            PushNameError::LongName => f.write_str("long domain name"),
-            PushNameError::ShortBuf => ShortBuf.fmt(f),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for PushNameError {}
-
-//------------ LabelFromStrError ---------------------------------------------
-
-/// An error occured while reading a label from a string.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct LabelFromStrError(LabelFromStrErrorEnum);
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum LabelFromStrErrorEnum {
-    SymbolChars(SymbolCharsError),
-
-    BadSymbol(BadSymbol),
-
-    /// A binary label was encountered.
-    BinaryLabel,
-
-    /// The label would exceed the limit of 63 bytes.
-    LongLabel,
-}
-
-//--- From
-
-impl From<LabelFromStrErrorEnum> for LabelFromStrError {
-    fn from(inner: LabelFromStrErrorEnum) -> Self {
-        Self(inner)
-    }
-}
-
-impl From<SymbolCharsError> for LabelFromStrError {
-    fn from(err: SymbolCharsError) -> Self {
-        Self(LabelFromStrErrorEnum::SymbolChars(err))
-    }
-}
-
-impl From<BadSymbol> for LabelFromStrError {
-    fn from(err: BadSymbol) -> Self {
-        Self(LabelFromStrErrorEnum::BadSymbol(err))
-    }
-}
-
-//--- Display and Error
-
-impl fmt::Display for LabelFromStrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            LabelFromStrErrorEnum::SymbolChars(err) => err.fmt(f),
-            LabelFromStrErrorEnum::BadSymbol(err) => err.fmt(f),
-            LabelFromStrErrorEnum::BinaryLabel => {
-                f.write_str("a binary label was encountered")
-            }
-            LabelFromStrErrorEnum::LongLabel => {
-                f.write_str("label length limit exceeded")
-            }
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for LabelFromStrError {}
-
-//------------ FromStrError --------------------------------------------------
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum FromStrError {
-    /// The string content was wrongly formatted.
-    Presentation(PresentationError),
-
-    /// The buffer is too short to contain the name.
-    ShortBuf,
-}
-
-impl FromStrError {
-    pub(super) fn empty_label() -> Self {
-        Self::Presentation(PresentationErrorEnum::EmptyLabel.into())
-    }
-}
-
-//--- From
-
-impl From<PushError> for FromStrError {
-    fn from(err: PushError) -> FromStrError {
-        match err {
-            PushError::LongLabel => LabelFromStrErrorEnum::LongLabel.into(),
-            PushError::LongName => PresentationErrorEnum::LongName.into(),
-            PushError::ShortBuf => FromStrError::ShortBuf,
-        }
-    }
-}
-
-impl From<PushNameError> for FromStrError {
-    fn from(err: PushNameError) -> FromStrError {
-        match err {
-            PushNameError::LongName => PresentationErrorEnum::LongName.into(),
-            PushNameError::ShortBuf => FromStrError::ShortBuf,
-        }
-    }
-}
-
-impl<T: Into<PresentationError>> From<T> for FromStrError {
-    fn from(err: T) -> Self {
-        Self::Presentation(err.into())
-    }
-}
-
-//--- Display and Error
-
-impl fmt::Display for FromStrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            FromStrError::Presentation(err) => err.fmt(f),
-            FromStrError::ShortBuf => ShortBuf.fmt(f),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for FromStrError {}
-
-//------------ PresentationError ---------------------------------------------
-
-/// An illegal presentation format was encountered.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PresentationError(PresentationErrorEnum);
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum PresentationErrorEnum {
-    BadLabel(LabelFromStrError),
-
-    /// An empty label was encountered.
-    EmptyLabel,
-
-    /// The name has more than 255 characters.
+    /// The name being built would exceed the 255-byte limit.
     LongName,
 }
 
-//--- From
-
-impl From<PresentationErrorEnum> for PresentationError {
-    fn from(err: PresentationErrorEnum) -> Self {
-        Self(err)
-    }
-}
-
-impl<T: Into<LabelFromStrError>> From<T> for PresentationError {
-    fn from(err: T) -> Self {
-        Self(PresentationErrorEnum::BadLabel(err.into()))
-    }
-}
-
-//--- Display and Error
-
-impl fmt::Display for PresentationError {
+impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            PresentationErrorEnum::BadLabel(ref err) => err.fmt(f),
-            PresentationErrorEnum::EmptyLabel => f.write_str("empty label"),
-            PresentationErrorEnum::LongName => {
-                f.write_str("long domain name")
-            }
-        }
+        f.write_str(match *self {
+            Self::LongLabel => "domain name label longer than 63 bytes",
+            Self::LongName => "domain name longer than 255 bytes",
+        })
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for PresentationError {}
+impl std::error::Error for BuildError {}
 
 //============ Testing =======================================================
 
@@ -773,96 +353,98 @@ mod test {
 
     #[test]
     fn compose() {
-        let mut builder = NameBuilder::new_vec();
-        builder.push(b'w').unwrap();
+        let mut builder = NameBuilder::new([0u8; 256]);
+        builder.append_slice(b"w").unwrap();
         builder.append_slice(b"ww").unwrap();
         builder.end_label();
         builder.append_slice(b"exa").unwrap();
-        builder.push(b'm').unwrap();
-        builder.push(b'p').unwrap();
+        builder.append_slice(b"m").unwrap();
+        builder.append_slice(b"p").unwrap();
         builder.append_slice(b"le").unwrap();
         builder.end_label();
         builder.append_slice(b"com").unwrap();
-        assert_eq!(builder.finish().as_slice(), b"\x03www\x07example\x03com");
+        builder.end_label();
+        assert_eq!(builder.cur_slice(), b"\x03www\x07example\x03com");
     }
 
     #[test]
     fn build_by_label() {
-        let mut builder = NameBuilder::new_vec();
+        let mut builder = NameBuilder::new([0u8; 256]);
         builder.append_label(b"www").unwrap();
         builder.append_label(b"example").unwrap();
         builder.append_label(b"com").unwrap();
-        assert_eq!(builder.finish().as_slice(), b"\x03www\x07example\x03com");
+        assert_eq!(builder.cur_slice(), b"\x03www\x07example\x03com");
     }
 
     #[test]
     fn build_mixed() {
-        let mut builder = NameBuilder::new_vec();
-        builder.push(b'w').unwrap();
+        let mut builder = NameBuilder::new([0u8; 256]);
+        builder.append_slice(b"w").unwrap();
         builder.append_slice(b"ww").unwrap();
         builder.append_label(b"example").unwrap();
         builder.append_slice(b"com").unwrap();
-        assert_eq!(builder.finish().as_slice(), b"\x03www\x07example\x03com");
+        assert_eq!(builder.cur_slice(), b"\x03www\x07example\x03com");
     }
 
     #[test]
     fn name_limit() {
-        let mut builder = NameBuilder::new_vec();
+        let mut builder = NameBuilder::new([0u8; 256]);
         for _ in 0..25 {
             // 9 bytes label is 10 bytes in total
             builder.append_label(b"123456789").unwrap();
         }
 
-        assert_eq!(builder.append_label(b"12345"), Err(PushError::LongName));
+        assert_eq!(builder.append_label(b"12345"), Err(BuildError::LongName));
         assert_eq!(builder.clone().append_label(b"1234"), Ok(()));
 
-        assert_eq!(builder.append_slice(b"12345"), Err(PushError::LongName));
+        assert_eq!(builder.append_slice(b"12345"), Err(BuildError::LongName));
         assert_eq!(builder.clone().append_slice(b"1234"), Ok(()));
 
         assert_eq!(builder.append_slice(b"12"), Ok(()));
-        assert_eq!(builder.push(b'3'), Ok(()));
-        assert_eq!(builder.push(b'4'), Err(PushError::LongName))
+        assert_eq!(builder.append_slice(b"3"), Ok(()));
+        assert_eq!(builder.append_slice(b"4"), Err(BuildError::LongName));
     }
 
     #[test]
     fn label_limit() {
-        let mut builder = NameBuilder::new_vec();
+        let mut builder = NameBuilder::new([0u8; 256]);
         builder.append_label(&[0u8; 63][..]).unwrap();
         assert_eq!(
             builder.append_label(&[0u8; 64][..]),
-            Err(PushError::LongLabel)
+            Err(BuildError::LongLabel)
         );
         assert_eq!(
             builder.append_label(&[0u8; 164][..]),
-            Err(PushError::LongLabel)
+            Err(BuildError::LongLabel)
         );
 
         builder.append_slice(&[0u8; 60][..]).unwrap();
         builder.clone().append_label(b"123").unwrap();
-        assert_eq!(builder.append_slice(b"1234"), Err(PushError::LongLabel));
+        assert_eq!(builder.append_slice(b"1234"), Err(BuildError::LongLabel));
         builder.append_slice(b"12").unwrap();
-        builder.push(b'3').unwrap();
-        assert_eq!(builder.push(b'4'), Err(PushError::LongLabel));
+        builder.append_slice(b"3").unwrap();
+        assert_eq!(builder.append_slice(b"4"), Err(BuildError::LongLabel));
     }
 
     #[test]
     fn finish() {
-        let mut builder = NameBuilder::new_vec();
+        let mut builder = NameBuilder::new([0u8; 256]);
         builder.append_label(b"www").unwrap();
         builder.append_label(b"example").unwrap();
         builder.append_slice(b"com").unwrap();
-        assert_eq!(builder.finish().as_slice(), b"\x03www\x07example\x03com");
+        assert_eq!(builder.cur_slice(), b"\x03www\x07example\x03com");
     }
 
     #[test]
-    fn into_name() {
-        let mut builder = NameBuilder::new_vec();
+    fn as_absolute() {
+        let mut builder = NameBuilder::new([0u8; 256]);
         builder.append_label(b"www").unwrap();
         builder.append_label(b"example").unwrap();
         builder.append_slice(b"com").unwrap();
+        let name: Option<Name<&[u8]>> = builder.as_absolute().unwrap();
         assert_eq!(
-            builder.into_name().unwrap().as_slice(),
-            b"\x03www\x07example\x03com\x00"
+            name.as_ref().map(Name::as_slice),
+            Some(&b"\x03www\x07example\x03com\x00"[..])
         );
     }
 }

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -7,9 +7,9 @@ use core::borrow::{Borrow, BorrowMut};
 use core::fmt;
 
 use super::absolute::Name;
+use super::label::Label;
 use super::relative::RelativeName;
 use super::uncertain::UncertainName;
-use super::{Label, ToLabelIter};
 use crate::base::scan::{self, Symbol, Symbols};
 
 //------------ NameBuilder --------------------------------------------------

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -408,7 +408,7 @@ where
         Octs: TryFrom<&'a [u8]>,
     {
         assert!(
-            !self.cur_label().is_some_and(|l| !l.is_empty()),
+            self.cur_label().map_or(true, |l| l.is_empty()),
             "cannot extract a domain name while a label is being built"
         );
 
@@ -445,7 +445,7 @@ where
         Octs: TryFrom<&'a [u8]>,
     {
         assert!(
-            !self.cur_label().is_some_and(|l| !l.is_empty()),
+            self.cur_label().map_or(true, |l| l.is_empty()),
             "cannot extract a domain name while a label is being built"
         );
 

--- a/src/base/name/mod.rs
+++ b/src/base/name/mod.rs
@@ -92,9 +92,7 @@
 //! [_punycode_]: <https://datatracker.ietf.org/doc/html/rfc3492>
 
 pub use self::absolute::{Name, NameError};
-pub use self::builder::{
-    FromStrError, NameBuilder, PresentationError, PushError, PushNameError,
-};
+pub use self::builder::{BuildError, NameBuilder, ScanError};
 pub use self::chain::{Chain, ChainIter, LongChainError, UncertainChainIter};
 pub use self::label::{
     Label, LabelTypeError, LongLabelError, OwnedLabel, SliceLabelsIter,
@@ -102,7 +100,7 @@ pub use self::label::{
 };
 pub use self::parsed::{ParsedName, ParsedNameIter, ParsedSuffixIter};
 pub use self::relative::{
-    NameIter, RelativeFromStrError, RelativeName, RelativeNameError,
+    NameIter, RelativeName, RelativeNameError, RelativeScanError,
     StripSuffixError,
 };
 pub use self::traits::{FlattenInto, ToLabelIter, ToName, ToRelativeName};

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -418,11 +418,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, Octets> serde::Deserialize<'de> for UncertainName<Octets>
 where
-    Octets: FromBuilder + DeserializeOctets<'de>,
-    <Octets as FromBuilder>::Builder: EmptyBuilder
-        + FreezeBuilder<Octets = Octets>
-        + AsRef<[u8]>
-        + AsMut<[u8]>,
+    Octets: AsRef<[u8]> + for<'a> TryFrom<&'a [u8]> + DeserializeOctets<'de>,
 {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
@@ -433,11 +429,9 @@ where
 
         impl<'de, Octets> serde::de::Visitor<'de> for InnerVisitor<'de, Octets>
         where
-            Octets: FromBuilder + DeserializeOctets<'de>,
-            <Octets as FromBuilder>::Builder: EmptyBuilder
-                + FreezeBuilder<Octets = Octets>
-                + AsRef<[u8]>
-                + AsMut<[u8]>,
+            Octets: AsRef<[u8]>
+                + for<'a> TryFrom<&'a [u8]>
+                + DeserializeOctets<'de>,
         {
             type Value = UncertainName<Octets>;
 
@@ -478,11 +472,9 @@ where
 
         impl<'de, Octets> serde::de::Visitor<'de> for NewtypeVisitor<Octets>
         where
-            Octets: FromBuilder + DeserializeOctets<'de>,
-            <Octets as FromBuilder>::Builder: EmptyBuilder
-                + FreezeBuilder<Octets = Octets>
-                + AsRef<[u8]>
-                + AsMut<[u8]>,
+            Octets: AsRef<[u8]>
+                + for<'a> TryFrom<&'a [u8]>
+                + DeserializeOctets<'de>,
         {
             type Value = UncertainName<Octets>;
 

--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -128,7 +128,7 @@ impl<N: ToName> From<(N, Rtype)> for Question<N> {
     }
 }
 
-impl<N: FromStr<Err = name::FromStrError>> FromStr for Question<N> {
+impl<N: FromStr<Err = name::ScanError>> FromStr for Question<N> {
     type Err = FromStrError;
 
     /// Parses a question from a string.
@@ -380,13 +380,11 @@ pub enum FromStrError {
 
 //--- From
 
-impl From<name::FromStrError> for FromStrError {
-    fn from(err: name::FromStrError) -> FromStrError {
+impl From<name::ScanError> for FromStrError {
+    fn from(err: name::ScanError) -> FromStrError {
         match err {
-            name::FromStrError::Presentation(err) => {
-                Self::Presentation(err.into())
-            }
-            name::FromStrError::ShortBuf => Self::ShortBuf,
+            name::ScanError::ShortBuf => Self::ShortBuf,
+            err => Self::Presentation(err.into()),
         }
     }
 }
@@ -419,7 +417,7 @@ pub struct PresentationError(PresentationErrorEnum);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PresentationErrorEnum {
-    BadName(name::PresentationError),
+    BadName(name::ScanError),
     MissingQname,
     MissingClassAndQtype,
     MissingQtype,
@@ -436,8 +434,8 @@ impl From<PresentationErrorEnum> for PresentationError {
     }
 }
 
-impl From<name::PresentationError> for PresentationError {
-    fn from(err: name::PresentationError) -> Self {
+impl From<name::ScanError> for PresentationError {
+    fn from(err: name::ScanError) -> Self {
         Self(PresentationErrorEnum::BadName(err))
     }
 }

--- a/src/resolv/stub/conf.rs
+++ b/src/resolv/stub/conf.rs
@@ -707,8 +707,8 @@ impl convert::From<io::Error> for Error {
     }
 }
 
-impl convert::From<name::FromStrError> for Error {
-    fn from(_: name::FromStrError) -> Error {
+impl convert::From<name::ScanError> for Error {
+    fn from(_: name::ScanError) -> Error {
         Error::ParseError
     }
 }

--- a/src/stelline/parse_stelline.rs
+++ b/src/stelline/parse_stelline.rs
@@ -478,6 +478,7 @@ fn parse_section<Lines: Iterator<Item = Result<String, std::io::Error>>>(
 
         match section {
             Section::Question => {
+                use core::str::FromStr;
                 sections
                     .question
                     .push(Question::from_str(clean_line).unwrap());

--- a/src/validator/context.rs
+++ b/src/validator/context.rs
@@ -2307,9 +2307,6 @@ pub enum Error {
     /// Error adding data while building a DNS message.
     PushError,
 
-    /// Error adding a label to a name.
-    PushNameError,
-
     /// Error reading from a file.
     ReadError(Arc<std::io::Error>),
 
@@ -2323,15 +2320,9 @@ impl From<inplace::Error> for Error {
     }
 }
 
-impl From<name::PushError> for Error {
-    fn from(_: name::PushError) -> Self {
+impl From<name::BuildError> for Error {
+    fn from(_: name::BuildError) -> Self {
         Error::PushError
-    }
-}
-
-impl From<name::PushNameError> for Error {
-    fn from(_: name::PushNameError) -> Self {
-        Error::PushNameError
     }
 }
 
@@ -2355,7 +2346,6 @@ impl fmt::Display for Error {
             Error::OctetsConversion => write!(f, "OctetsConversion"),
             Error::ParseError => write!(f, "ParseError"),
             Error::PushError => write!(f, "PushError"),
-            Error::PushNameError => write!(f, "PushNameError"),
             Error::ReadError(_) => write!(f, "FormError"),
             Error::ShortMessage => write!(f, "ShortMEssage"),
         }
@@ -2370,7 +2360,6 @@ impl error::Error for Error {
             Error::OctetsConversion => None,
             Error::ParseError => None,
             Error::PushError => None,
-            Error::PushNameError => None,
             Error::ReadError(err) => Some(err),
             Error::ShortMessage => None,
         }


### PR DESCRIPTION
This is primarily a performance enhancement.  The idea is to require the storage backing `NameBuilder` to always provide a fixed 256-byte array, rather than performing any dynamic allocations.  Since `NameBuilder`s are transient objects, allocating a few more bytes won't hurt, especially if they can be put on the stack.

I initially intended to make `NameBuilder` just take a reference to a `[u8; 256]` array somewhere in the caller's code.  However, this would make it harder to store `NameBuilder` (because you also need to store the backing buffer somewhere, and you can quickly run into self-referential lifetime issues).  Instead, I use a `Buffer` parameter that should implement `Borrow` and `BorrowMut` (not `AsRef` / `AsMut` as they don't have the blanket `impl Borrow<T> for T`).

This work will lead up to #388, making it easier to build domain names quickly.  Note that I've dropped all support for `Symbol` here.