### PR TITLE
Empty NSEC3 salt should be a dash in zone presentation format.

### DIFF
--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -1493,6 +1493,7 @@ mod test {
     use std::vec::Vec;
 
     #[test]
+    #[allow(clippy::redundant_closure)] // lifetimes ...
     fn nsec3_compose_parse_scan() {
         let mut rtype = RtypeBitmapBuilder::new_vec();
         rtype.add(Rtype::A).unwrap();
@@ -1516,6 +1517,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::redundant_closure)] // lifetimes ...
     fn nsec3_compose_parse_scan_empty_salt() {
         let mut rtype = RtypeBitmapBuilder::new_vec();
         rtype.add(Rtype::A).unwrap();
@@ -1539,6 +1541,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::redundant_closure)] // lifetimes ...
     fn nsec3param_compose_parse_scan() {
         let rdata = Nsec3param::new(
             Nsec3HashAlg::SHA1,

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -1095,7 +1095,7 @@ where
 ///
 /// This hash is used instead of the actual owner name in an NSEC3 record.
 ///
-/// The hash can never be longer than 255 octets since its lenght is encoded
+/// The hash can never be longer than 255 octets since its length is encoded
 /// as a single octet.
 ///
 /// For its presentation format, the hash uses an unpadded Base 32 encoding


### PR DESCRIPTION
[RFC 5155 section 3.3](https://www.rfc-editor.org/rfc/rfc5155.html#section-3.3) says:

>    o  The Salt field is represented as a sequence of case-insensitive
>         hexadecimal digits.  Whitespace is not allowed within the
>         sequence.  The Salt field is represented as "-" (without the
>         quotes) when the Salt Length field has a value of 0.

This PR adjusts the Display impl to render empty salt as `-`.