### PR TITLE
Internal message printer exposed as `display_dig_style`

### DIFF
--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -13,6 +13,7 @@
 use super::header::{Header, HeaderCounts, HeaderSection};
 use super::iana::{Class, OptRcode, Rcode, Rtype};
 use super::message_builder::{AdditionalBuilder, AnswerBuilder, PushError};
+use super::message_printer::MessagePrinter;
 use super::name::ParsedName;
 use super::opt::{Opt, OptRecord};
 use super::question::Question;
@@ -662,6 +663,13 @@ impl<Octs: Octets + ?Sized> Message<Octs> {
         self.opt()
             .map(|opt| opt.rcode(self.header()))
             .unwrap_or_else(|| self.header().rcode().into())
+    }
+}
+
+/// # Printing
+impl<Octs: AsRef<[u8]>> Message<Octs> {
+    pub fn display_dig_style(&self) -> impl core::fmt::Display + '_ {
+        MessagePrinter { msg: self }
     }
 }
 

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -668,6 +668,13 @@ impl<Octs: Octets + ?Sized> Message<Octs> {
 
 /// # Printing
 impl<Octs: AsRef<[u8]>> Message<Octs> {
+    /// Create a wrapper that displays the message in a dig style
+    ///
+    /// The dig style resembles a zonefile format (see also [`ZonefileFmt`]),
+    /// with additional lines that are commented out that contain information
+    /// about the header, OPT record and more.
+    ///
+    /// [`ZonefileFmt`]: super::zonefile_fmt::ZonefileFmt
     pub fn display_dig_style(&self) -> impl core::fmt::Display + '_ {
         DigPrinter { msg: self }
     }

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -10,10 +10,10 @@
 //!
 //! [`Message`]: struct.Message.html
 
+use super::dig_printer::DigPrinter;
 use super::header::{Header, HeaderCounts, HeaderSection};
 use super::iana::{Class, OptRcode, Rcode, Rtype};
 use super::message_builder::{AdditionalBuilder, AnswerBuilder, PushError};
-use super::message_printer::MessagePrinter;
 use super::name::ParsedName;
 use super::opt::{Opt, OptRecord};
 use super::question::Question;
@@ -669,7 +669,7 @@ impl<Octs: Octets + ?Sized> Message<Octs> {
 /// # Printing
 impl<Octs: AsRef<[u8]>> Message<Octs> {
     pub fn display_dig_style(&self) -> impl core::fmt::Display + '_ {
-        MessagePrinter { msg: self }
+        DigPrinter { msg: self }
     }
 }
 

--- a/src/base/message_printer.rs
+++ b/src/base/message_printer.rs
@@ -1,0 +1,171 @@
+use core::fmt;
+
+use crate::rdata::AllRecordData;
+
+use super::zonefile_fmt::ZonefileFmt;
+use super::ParsedRecord;
+use super::{opt::AllOptData, Message, Rtype};
+
+/// Interal type for printing a message
+///
+/// This is only exposed to users of this library as `impl fmt::Display`.
+pub(super) struct MessagePrinter<'a, Octs> {
+    pub msg: &'a Message<Octs>,
+}
+
+impl<'a, Octs: AsRef<[u8]>> fmt::Display for MessagePrinter<'a, Octs> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = self.msg.for_slice_ref();
+
+        // Header
+        let header = msg.header();
+        let counts = msg.header_counts();
+
+        writeln!(
+            f,
+            ";; ->>HEADER<<- opcode: {}, rcode: {}, id: {}",
+            header.opcode().display_zonefile(false),
+            header.rcode(),
+            header.id()
+        )?;
+        write!(f, ";; flags: {}", header.flags())?;
+        writeln!(
+            f,
+            "; QUERY: {}, ANSWER: {}, AUTHORITY: {}, ADDITIONAL: {}",
+            counts.qdcount(),
+            counts.ancount(),
+            counts.nscount(),
+            counts.arcount()
+        )?;
+
+        // We need this later
+        let opt = msg.opt();
+
+        if let Some(opt) = opt.as_ref() {
+            writeln!(f, "\n;; OPT PSEUDOSECTION:")?;
+            writeln!(
+                f,
+                "; EDNS: version {}; flags: {}; udp: {}",
+                opt.version(),
+                opt.dnssec_ok(),
+                opt.udp_payload_size()
+            )?;
+            for option in opt.opt().iter::<AllOptData<_, _>>() {
+                use AllOptData::*;
+
+                match option {
+                    Ok(opt) => match opt {
+                        Nsid(nsid) => writeln!(f, "; NSID: {}", nsid)?,
+                        Dau(dau) => writeln!(f, "; DAU: {}", dau)?,
+                        Dhu(dhu) => writeln!(f, "; DHU: {}", dhu)?,
+                        N3u(n3u) => writeln!(f, "; N3U: {}", n3u)?,
+                        Expire(expire) => {
+                            writeln!(f, "; EXPIRE: {}", expire)?
+                        }
+                        TcpKeepalive(opt) => {
+                            writeln!(f, "; TCPKEEPALIVE: {}", opt)?
+                        }
+                        Padding(padding) => {
+                            writeln!(f, "; PADDING: {}", padding)?
+                        }
+                        ClientSubnet(opt) => {
+                            writeln!(f, "; CLIENTSUBNET: {}", opt)?
+                        }
+                        Cookie(cookie) => {
+                            writeln!(f, "; COOKIE: {}", cookie)?
+                        }
+                        Chain(chain) => writeln!(f, "; CHAIN: {}", chain)?,
+                        KeyTag(keytag) => {
+                            writeln!(f, "; KEYTAG: {}", keytag)?
+                        }
+                        ExtendedError(extendederror) => {
+                            writeln!(f, "; EDE: {}", extendederror)?
+                        }
+                        Other(other) => {
+                            writeln!(f, "; {}", other.code())?;
+                        }
+                        _ => writeln!(f, "Unknown OPT")?,
+                    },
+                    Err(err) => {
+                        writeln!(f, "; ERROR: bad option: {}.", err)?;
+                    }
+                }
+            }
+        }
+
+        // Question
+        let questions = msg.question();
+        if counts.qdcount() > 0 {
+            writeln!(f, ";; QUESTION SECTION:")?;
+            for item in questions {
+                let Ok(item) = item else {
+                    writeln!(f, "; <invalid message>")?;
+                    return Ok(());
+                };
+                writeln!(f, "; {}", item)?;
+            }
+        }
+
+        // Answer
+        let section = questions.answer().unwrap();
+        if counts.ancount() > 0 {
+            writeln!(f, "\n;; ANSWER SECTION:")?;
+            for item in section {
+                let Ok(item) = item else {
+                    writeln!(f, "; <invalid message>")?;
+                    return Ok(());
+                };
+                write_record_item(f, &item)?;
+            }
+        }
+
+        // Authority
+        let section = section.next_section().unwrap().unwrap();
+        if counts.nscount() > 0 {
+            writeln!(f, "\n;; AUTHORITY SECTION:")?;
+            for item in section {
+                let Ok(item) = item else {
+                    writeln!(f, "; <invalid message>")?;
+                    return Ok(());
+                };
+                write_record_item(f, &item)?;
+            }
+        }
+
+        // Additional
+        let section = section.next_section().unwrap().unwrap();
+        if counts.arcount() > 1 || (opt.is_none() && counts.arcount() > 0) {
+            writeln!(f, "\n;; ADDITIONAL SECTION:")?;
+            for item in section {
+                let Ok(item) = item else {
+                    writeln!(f, "; <invalid message>")?;
+                    return Ok(());
+                };
+                if item.rtype() != Rtype::OPT {
+                    write_record_item(f, &item)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn write_record_item(
+    f: &mut impl fmt::Write,
+    item: &ParsedRecord<&[u8]>,
+) -> Result<(), fmt::Error> {
+    let parsed = item.to_any_record::<AllRecordData<_, _>>();
+
+    match parsed {
+        Ok(item) => writeln!(f, "{}", item.display_zonefile(false)),
+        Err(_) => writeln!(
+            f,
+            "; {} {} {} {} <invalid data>",
+            item.owner(),
+            item.ttl().as_secs(),
+            item.class(),
+            item.rtype()
+        ),
+    }
+}

--- a/src/base/message_printer.rs
+++ b/src/base/message_printer.rs
@@ -84,7 +84,6 @@ impl<'a, Octs: AsRef<[u8]>> fmt::Display for MessagePrinter<'a, Octs> {
                         Other(other) => {
                             writeln!(f, "; {}", other.code())?;
                         }
-                        _ => writeln!(f, "Unknown OPT")?,
                     },
                     Err(err) => {
                         writeln!(f, "; ERROR: bad option: {}.", err)?;

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -113,6 +113,7 @@ pub mod header;
 pub mod iana;
 pub mod message;
 pub mod message_builder;
+mod message_printer;
 pub mod name;
 pub mod net;
 pub mod opt;

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -109,11 +109,11 @@ pub use self::serial::Serial;
 
 pub mod charstr;
 pub mod cmp;
+mod dig_printer;
 pub mod header;
 pub mod iana;
 pub mod message;
 pub mod message_builder;
-mod message_printer;
 pub mod name;
 pub mod net;
 pub mod opt;

--- a/src/base/zonefile_fmt.rs
+++ b/src/base/zonefile_fmt.rs
@@ -32,8 +32,15 @@ impl<T: ZonefileFmt + ?Sized> fmt::Display for ZoneFileDisplay<'_, T> {
 
 /// Show a value as zonefile format
 pub trait ZonefileFmt {
+    /// Format the item as zonefile fmt into a [`fmt::Formatter`]
+    ///
+    /// This method is meant for use in a `fmt::Display` implementation.
     fn fmt(&self, p: &mut impl Formatter) -> Result;
 
+    /// Display the item as a zonefile
+    ///
+    /// The returned object will be displayed as zonefile when printed or
+    /// written using `fmt::Display`.
     fn display_zonefile(&self, pretty: bool) -> ZoneFileDisplay<'_, Self> {
         ZoneFileDisplay {
             inner: self,


### PR DESCRIPTION
For use in `dnsi` and `dnst` (`update` in particular). Heavily based on the dig output in `dnsi`: https://github.com/NLnetLabs/dnsi/blob/main/src/output/dig.rs. I'm not really sure about the error handling here, so feel free to scrutinize.