### PR TITLE
HINFO display CPU and OS using quoted format

### DIFF
--- a/src/base/zonefile_fmt.rs
+++ b/src/base/zonefile_fmt.rs
@@ -334,4 +334,17 @@ mod test {
             record.display_zonefile(false).to_string()
         );
     }
+
+    #[test]
+    fn hinfo_record() {
+        use crate::rdata::Hinfo;
+        let record = create_record(Hinfo::<Vec<u8>>::new(
+            "Windows".parse().unwrap(),
+            "Windows Server".parse().unwrap(),
+        ));
+        assert_eq!(
+            "example.com. 3600 IN HINFO \"Windows\" \"Windows Server\"",
+            record.display_zonefile(false).to_string()
+        );
+    }
 }


### PR DESCRIPTION
This is the behavior of dig:
![image](https://github.com/user-attachments/assets/2806fcab-2910-46e7-9ccb-53862a3e864b)
