### PR TITLE
Use base16 for DS (de)serialization.

### DIFF
--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -1735,7 +1735,7 @@ pub struct Ds<Octs> {
     digest_type: DigestAlg,
     #[cfg_attr(
         feature = "serde",
-        serde(with = "crate::utils::base64::serde")
+        serde(with = "crate::utils::base16::serde")
     )]
     digest: Octs,
 }


### PR DESCRIPTION
https://rfc-annotations.research.icann.org/rfc4034.html#section-5.3 says _"The Digest MUST be represented as a sequence of case-insensitive hexadecimal digits"_ so use base 16 for the related (de)serialiazation to be consistent with the display format.