### PR TITLE
Restore 'Display' behaviour for 'SecAlg' etc

### DIFF
--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -440,7 +440,11 @@ macro_rules! int_enum_zonefile_fmt_decimal {
                 p: &mut impl $crate::base::zonefile_fmt::Formatter,
             ) -> $crate::base::zonefile_fmt::Result {
                 p.write_token(self.to_int())?;
-                p.write_comment(format_args!("{}: {}", $name, self))
+                if let Some(mnemonic) = self.to_mnemonic_str() {
+                    p.write_comment(format_args!("{}: {}", $name, mnemonic))
+                } else {
+                    p.write_comment($name)
+                }
             }
         }
     };

--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -209,12 +209,7 @@ macro_rules! int_enum_str_decimal {
 
         impl core::fmt::Display for $ianatype {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                write!(f, "{}", self.to_int())?;
-
-                if let Some(m) = self.to_mnemonic_str() {
-                    write!(f, "({m})")?;
-                }
-                Ok(())
+                write!(f, "{}", self.to_int())
             }
         }
 

--- a/src/base/zonefile_fmt.rs
+++ b/src/base/zonefile_fmt.rs
@@ -277,8 +277,8 @@ mod test {
         assert_eq!(
             [
                 "example.com. 3600 IN DS ( 5414\t; key tag",
-                "                          15\t; algorithm: 15(ED25519)",
-                "                          2\t; digest type: 2(SHA-256)",
+                "                          15\t; algorithm: ED25519",
+                "                          2\t; digest type: SHA-256",
                 "                          DEADBEEF )",
             ]
             .join("\n"),


### PR DESCRIPTION
The doc comment for 'int_enum_str_decimal' explicitly states that the 'FromStr' impl expects a decimal number and that the 'Display' impl will also output a decimal number.  However, 'Display' was also adding the mnemonic for the number.