### PR TITLE
Check example compilation in the CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
         rust: [1.78.0, stable, beta, nightly]
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,25 @@ jobs:
       # TODO: Emit matrix elements based on inspecting Cargo.toml so that
       # each example runs as its own GitHub Actions step/job?
       run: |
-        # Generate the set of cargo check --example X --features Y commands to run
-        # and store them in a temporary script:
+        # Generate the set of cargo check --example X --features Y commands to
+        # run and store them in a temporary script. This command works by
+        # extracting the example blocks from the Cargo.toml file and the set
+        # of features that the block indicates are needed to run the example.
+        # E.g. given this block in Cargo.toml:
+        # 
+        #   [[example]]
+        #   name = "lookup"
+        #   required-features = ["resolv"]
+        #
+        # It outputs a line that looks like this:
+        #
+        #   cargo check --example lookup --features resolv
+        #
+        # One line per example is output and the set of lines directed to a temporary
+        # shell script file which is then run in the next step.
+
         cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten)"' | tr -d '[]"' > ${{ runner.temp }}/check-examples.sh
 
         # Run the temporary script:
+
         bash ${{ runner.temp }}/check-examples.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       run: |
         # Generate the set of cargo check --example X --features Y commands to run
         # and store them in a temporary script:
-        cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten)"' | tr -d '[]"') > ${{ runner.temp }}/check-examples.sh
+        cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten)"' | tr -d '[]"' > ${{ runner.temp }}/check-examples.sh
 
         # Run the temporary script:
         ${{ runner.temp }}/check-examples.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         # One line per example is output and the set of lines directed to a temporary
         # shell script file which is then run in the next step.
 
-        cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten)"' | tr -d '[]"' > ${{ runner.temp }}/check-examples.sh
+        cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten | join(","))"' > ${{ runner.temp }}/check-examples.sh
 
         # Run the temporary script:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,9 @@ jobs:
   # [1]: https://github.com/rust-lang/cargo/issues/4663)
   build-examples:
     name: Build examples
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
         rust: [1.78.0, stable, beta, nightly]
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,4 +95,4 @@ jobs:
         cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten)"' | tr -d '[]"' > ${{ runner.temp }}/check-examples.sh
 
         # Run the temporary script:
-        ${{ runner.temp }}/check-examples.sh
+        bash ${{ runner.temp }}/check-examples.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       run: cargo fmt --all -- --check
     - run: cargo check --no-default-features --all-targets
     - run: cargo test --all-features
+
   minimal-versions:
     name: Check minimal versions
     runs-on: ubuntu-latest
@@ -60,4 +61,37 @@ jobs:
       run: |
         cargo +nightly update -Z minimal-versions
         cargo check --all-features --all-targets --locked
-      
+
+  # Note: This deliberately doesn't try to run the examples as some of them
+  # don't terminate and/or attempt to make network connections that will fail
+  # or perhaps be a nuisance to real name servers if run regularly by CI.
+  #
+  # Note: This is just a band aid, ideally there would be a way for Cargo to
+  # build/run examples using the feature set specified in Cargo.toml itself,
+  # but that isn't currently possible (see [1]).
+  # 
+  # [1]: https://github.com/rust-lang/cargo/issues/4663)
+  build-examples:
+    name: Build examples
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [1.78.0, stable, beta, nightly]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v2
+      with:
+        rust-version: ${{ matrix.rust }}
+    - name: Compile all examples
+      shell: bash
+      # TODO: Emit matrix elements based on inspecting Cargo.toml so that
+      # each example runs as its own GitHub Actions step/job?
+      run: |
+        while IFS= read -r cmd
+        do
+          echo "Running command: $cmd"
+          $cmd
+        done <<< $(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten)"' | tr -d '[]"')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,9 @@ jobs:
       # TODO: Emit matrix elements based on inspecting Cargo.toml so that
       # each example runs as its own GitHub Actions step/job?
       run: |
-        while IFS= read -r cmd
-        do
-          echo "Running command: $cmd"
-          $cmd
-        done <<< $(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten)"' | tr -d '[]"')
+        # Generate the set of cargo check --example X --features Y commands to run
+        # and store them in a temporary script:
+        cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[] | select(.kind[] | contains("example")) | "cargo check --example \(.name) --features \(."required-features" | flatten)"' | tr -d '[]"') > ${{ runner.temp }}/check-examples.sh
+
+        # Run the temporary script:
+        ${{ runner.temp }}/check-examples.sh


### PR DESCRIPTION
This PR adds a job to the `CI` workflow which `cargo check`s the crate examples to make sure they don't fail immediately to compile because the set of features specified for them in `Cargo.toml` is incorrect.

As it uses `jq` and `tr` I limited it to running on Linux (maybe it would work on Mac?).

I included all the versions of Rust we use for the main build and test job, maybe that is excessive?

An example failing (correctly) run can be seen here: https://github.com/NLnetLabs/domain/actions/runs/11740551147/job/32707334314#step:4:1 _(which I cancelled as soon as it failed)_

The summary on the workflow run handily shows what failed, e.g.:

![afbeelding](https://github.com/user-attachments/assets/a398d1b5-6c7c-4257-a7e3-4b28b1c135d6)
