### PR TITLE
[resolver/stub] Allow adding connections dynamically

### DIFF
--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -103,7 +103,7 @@ impl StubResolver {
         &self.options
     }
 
-    /// Add a new connection to the running resolver.
+    /// Adds a new connection to the running resolver.
     pub async fn add_connection(
         &self,
         connection: Box<

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -103,6 +103,21 @@ impl StubResolver {
         &self.options
     }
 
+    /// Add a new connection to the running resolver.
+    pub async fn add_connection(
+        &self,
+        connection: Box<
+            dyn SendRequest<RequestMessage<Vec<u8>>> + Send + Sync,
+        >,
+    ) {
+        self.get_transport()
+            .await
+            .expect("The 'redundant::Connection' task should not fail")
+            .add(connection)
+            .await
+            .expect("The 'redundant::Connection' task should not fail");
+    }
+
     pub async fn query<N: ToName, Q: Into<Question<N>>>(
         &self,
         question: Q,


### PR DESCRIPTION
This can be used to side-step 'ResolvConf' and the underlying default 'multi_stream' connection type with a custom one, e.g. for testing.  We need this right now in order to support Stelline testing for `ldns-update`.