### PR TITLE
Derive Arbitrary (via new optional feature) for some types to enable fuzz testing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,9 +227,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "domain"
 version = "0.10.3"
 dependencies = [
+ "arbitrary",
  "arc-swap",
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ name = "domain"
 path = "src/lib.rs"
 
 [dependencies]
+arbitrary      = { version = "1.4.1", optional = true, features = ["derive"] }
 octseq         = { version = "0.5.2", default-features = false }
 time           = { version = "0.3.1", default-features = false }
 rand           = { version = "0.8", optional = true }
@@ -77,6 +78,9 @@ unstable-validate = ["bytes", "std", "ring"]
 unstable-validator = ["unstable-validate", "zonefile", "unstable-client-transport"]
 unstable-xfr = ["net"]
 unstable-zonetree = ["futures-util", "parking_lot", "rustversion", "serde", "std", "tokio", "tracing", "unstable-xfr", "zonefile"]
+
+# Support for testing
+arbitrary = ["dep:arbitrary"]
 
 [dev-dependencies]
 lazy_static        = { version = "1.4.0" }

--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -13,6 +13,7 @@ macro_rules! int_enum {
                                         $value:expr, $mnemonic:expr) )* ) => {
         $(#[$attr])*
         #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
         pub struct $ianatype($inttype);
 
         impl $ianatype {

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -50,6 +50,7 @@ use std::vec::Vec;
 /// [`Display`]: std::fmt::Display
 #[derive(Clone)]
 #[repr(transparent)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Name<Octs: ?Sized>(Octs);
 
 impl Name<()> {

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -712,6 +712,7 @@ impl<Octs: AsRef<[u8]>> ZonefileFmt for Nsec3param<Octs> {
 /// no whitespace allowed.
 #[derive(Clone)]
 #[repr(transparent)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Nsec3Salt<Octs: ?Sized>(Octs);
 
 impl Nsec3Salt<()> {


### PR DESCRIPTION
Useful for applications that use `domain` types in their own fuzz tests.