### PR TITLE
Support zone file formatting using tabs instead of spaces.

### DIFF
--- a/src/base/dig_printer.rs
+++ b/src/base/dig_printer.rs
@@ -24,7 +24,7 @@ impl<'a, Octs: AsRef<[u8]>> fmt::Display for DigPrinter<'a, Octs> {
         writeln!(
             f,
             ";; ->>HEADER<<- opcode: {}, rcode: {}, id: {}",
-            header.opcode().display_zonefile(false),
+            header.opcode().display_zonefile(false, false),
             header.rcode(),
             header.id()
         )?;
@@ -161,7 +161,7 @@ fn write_record_item(
     let parsed = item.to_any_record::<AllRecordData<_, _>>();
 
     match parsed {
-        Ok(item) => writeln!(f, "{}", item.display_zonefile(false)),
+        Ok(item) => writeln!(f, "{}", item.display_zonefile(false, false)),
         Err(_) => writeln!(
             f,
             "; {} {} {} {} <invalid data>",

--- a/src/base/zonefile_fmt.rs
+++ b/src/base/zonefile_fmt.rs
@@ -42,7 +42,11 @@ pub trait ZonefileFmt {
     ///
     /// The returned object will be displayed as zonefile when printed or
     /// written using `fmt::Display`.
-    fn display_zonefile(&self, multiline: bool, tabbed: bool) -> ZoneFileDisplay<'_, Self> {
+    fn display_zonefile(
+        &self,
+        multiline: bool,
+        tabbed: bool,
+    ) -> ZoneFileDisplay<'_, Self> {
         ZoneFileDisplay {
             inner: self,
             multiline,

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -1608,7 +1608,7 @@ mod test {
             Nsec3::scan,
             &rdata,
         );
-        assert_eq!(&format!("{}", rdata.display_zonefile(false)), "1 10 11 626172 CPNMU A SRV");
+        assert_eq!(&format!("{}", rdata.display_zonefile(false, false)), "1 10 11 626172 CPNMU A SRV");
     }
 
     #[test]
@@ -1632,7 +1632,7 @@ mod test {
             Nsec3::scan,
             &rdata,
         );
-        assert_eq!(&format!("{}", rdata.display_zonefile(false)), "1 10 11 - CPNMU A SRV");
+        assert_eq!(&format!("{}", rdata.display_zonefile(false, false)), "1 10 11 - CPNMU A SRV");
     }
 
     #[test]

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -81,7 +81,6 @@ impl<N, D> SortedRecords<N, D> {
         self.rrsets().find(|rrset| rrset.rtype() == Rtype::SOA)
     }
 
-
     pub fn iter(&self) -> Iter<'_, Record<N, D>> {
         self.records.iter()
     }

--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -31,6 +31,7 @@ use crate::zonetree::types::StoredRecordData;
 use crate::zonetree::StoredName;
 
 use super::{SignRaw, SigningKey};
+use core::slice::Iter;
 
 //------------ SortedRecords -------------------------------------------------
 
@@ -78,6 +79,11 @@ impl<N, D> SortedRecords<N, D> {
         D: RecordData,
     {
         self.rrsets().find(|rrset| rrset.rtype() == Rtype::SOA)
+    }
+
+
+    pub fn iter(&self) -> Iter<'_, Record<N, D>> {
+        self.records.iter()
     }
 }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -322,7 +322,7 @@ impl<Octs: AsRef<[u8]>> Key<Octs> {
             w,
             "{} IN DNSKEY {}",
             self.owner().fmt_with_dot(),
-            self.to_dnskey().display_zonefile(false),
+            self.to_dnskey().display_zonefile(false, false),
         )
     }
 


### PR DESCRIPTION
Based on initial internal feedback this is expected to be updated to use a separate `FormatWriter`.

It also currently wrongly uses tabs between record fields AND between rdata values, while rdata values should be padded by spaces.

This PR is about matching current LDNS zone file output format.

It may make more sense for this not to be part of `domain` at all if possible as I can imagine that formatting is an opinionated thing?