### PR TITLE
Attempt to give more context on unknown record type zone file parsing errors.

### DIFF
--- a/src/base/scan.rs
+++ b/src/base/scan.rs
@@ -270,6 +270,9 @@ macro_rules! declare_error_trait {
 
             /// Creates an error when there are trailing tokens.
             fn trailing_tokens() -> Self;
+
+            /// Unknown record type.
+            fn unknown_rtype(rtype: crate::base::iana::Rtype) -> Self;
         }
     }
 }
@@ -299,6 +302,13 @@ impl ScannerError for std::io::Error {
 
     fn trailing_tokens() -> Self {
         std::io::Error::new(std::io::ErrorKind::Other, "trailing data")
+    }
+
+    fn unknown_rtype(rtype: crate::base::iana::Rtype) -> Self {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("unknown record type {rtype}"),
+        )
     }
 }
 
@@ -1193,6 +1203,10 @@ impl ScannerError for StrError {
 
     fn trailing_tokens() -> Self {
         Self::custom("trailing data")
+    }
+
+    fn unknown_rtype(_rtype: crate::base::iana::Rtype) -> Self {
+        Self::custom("unknown record type")
     }
 }
 

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -111,9 +111,7 @@ macro_rules! rdata_types {
                             }
                         )* )* )*
                         _ => {
-                            Err(S::Error::custom(
-                                "unknown record type with concrete data"
-                            ))
+                            Err(S::Error::unknown_rtype(rtype))
                         }
                     }
                 }

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -1422,75 +1422,87 @@ enum ItemCat {
 
 /// An error returned by the entry scanner.
 #[derive(Clone, Debug)]
-pub struct EntryError(&'static str);
+pub enum EntryError {
+    UnknownRtype(Rtype),
+    Other(&'static str),
+}
 
 impl EntryError {
     fn bad_symbol(_err: SymbolOctetsError) -> Self {
-        EntryError("bad symbol")
+        Self::Other("bad symbol")
     }
 
     fn bad_charstr() -> Self {
-        EntryError("bad charstr")
+        Self::Other("bad charstr")
     }
 
     fn bad_name() -> Self {
-        EntryError("bad name")
+        Self::Other("bad name")
     }
 
     fn unbalanced_parens() -> Self {
-        EntryError("unbalanced parens")
+        Self::Other("unbalanced parens")
     }
 
     fn missing_last_owner() -> Self {
-        EntryError("missing last owner")
+        Self::Other("missing last owner")
     }
 
     fn missing_origin() -> Self {
-        EntryError("missing origin")
+        Self::Other("missing origin")
     }
 
     fn expected_rtype() -> Self {
-        EntryError("expected rtype")
+        Self::Other("expected rtype")
     }
 
     fn unknown_control() -> Self {
-        EntryError("unknown control")
+        Self::Other("unknown control")
     }
 }
 
 impl ScannerError for EntryError {
     fn custom(msg: &'static str) -> Self {
-        EntryError(msg)
+        Self::Other(msg)
     }
 
     fn end_of_entry() -> Self {
-        Self("unexpected end of entry")
+        Self::Other("unexpected end of entry")
     }
 
     fn short_buf() -> Self {
-        Self("short buffer")
+        Self::Other("short buffer")
     }
 
     fn trailing_tokens() -> Self {
-        Self("trailing tokens")
+        Self::Other("trailing tokens")
+    }
+
+    fn unknown_rtype(rtype: crate::base::iana::Rtype) -> Self {
+        Self::UnknownRtype(rtype)
     }
 }
 
 impl From<SymbolOctetsError> for EntryError {
     fn from(_: SymbolOctetsError) -> Self {
-        EntryError("symbol octets error")
+        Self::Other("symbol octets error")
     }
 }
 
 impl From<BadSymbol> for EntryError {
     fn from(_: BadSymbol) -> Self {
-        EntryError("bad symbol")
+        Self::Other("bad symbol")
     }
 }
 
 impl fmt::Display for EntryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.0.as_ref())
+        match self {
+            EntryError::UnknownRtype(rtype) => {
+                write!(f, "unknown record type {rtype}")
+            }
+            EntryError::Other(msg) => f.write_str(msg),
+        }
     }
 }
 


### PR DESCRIPTION
This came about because I encountered error messages like:

```
Invalid zone file: 58:9: unknown record type
```

Which record type? If I have access to the source file still at the time of inspecting the error then I can determine the RTYPE from the input file, but if the file is gone or was never available due to being XFR or taken from a database or something then the lack of the actual RTYPE is quite annoying.

I suspect this is a breaking change, as I think the zone file parsing was released before we added unstable support for parsing into a zone tree.

Note: This PR doesn't fully extend `StrError` as in my scenario I don't seem to use it, perhaps we should augment that more, and doesn't update any tests.