### PR TITLE
FIX: Don't loop forever if an RR CLASS doesn't match the apex CLASS.

### DIFF
--- a/src/sign/records.rs
+++ b/src/sign/records.rs
@@ -492,11 +492,10 @@ impl<'a, N, D> RecordsIter<'a, N, D> {
     where
         N: ToName,
     {
-        while let Some(first) = self.slice.first() {
-            if first.class() != apex.class() {
-                continue;
-            }
-            if apex == first || first.owner().ends_with(apex.owner()) {
+        for rr in self.slice {
+            if rr.class() == apex.class()
+                && (apex == rr || rr.owner().ends_with(apex.owner()))
+            {
                 break;
             }
             self.slice = &self.slice[1..]


### PR DESCRIPTION
Fixes #456 in my local testing.