### PR TITLE
Rewrite `net::client::redundant`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,14 +70,14 @@ tsig        = ["bytes", "ring", "smallvec"]
 zonefile    = ["bytes", "serde", "std"]
 
 # Unstable features
-unstable-client-transport = ["moka", "net", "tracing"]
+unstable-client-transport = ["moka", "dep:parking_lot", "net", "tracing"]
 unstable-server-transport = ["arc-swap", "chrono/clock", "libc", "net", "siphasher", "tracing"]
 unstable-sign = ["std", "dep:secrecy", "unstable-validate"]
 unstable-stelline = ["tokio/test-util", "tracing", "tracing-subscriber", "tsig", "unstable-client-transport", "unstable-server-transport", "zonefile"]
 unstable-validate = ["bytes", "std", "ring"]
 unstable-validator = ["unstable-validate", "zonefile", "unstable-client-transport"]
 unstable-xfr = ["net"]
-unstable-zonetree = ["futures-util", "parking_lot", "rustversion", "serde", "std", "tokio", "tracing", "unstable-xfr", "zonefile"]
+unstable-zonetree = ["futures-util", "dep:parking_lot", "rustversion", "serde", "std", "tokio", "tracing", "unstable-xfr", "zonefile"]
 
 # Support for testing
 arbitrary = ["dep:arbitrary"]

--- a/examples/client-transports.rs
+++ b/examples/client-transports.rs
@@ -191,19 +191,12 @@ async fn main() {
     drop(request);
 
     // Create a transport connection for redundant connections.
-    let (redun, transp) = redundant::Connection::new();
-
-    // Start the run function on a separate task.
-    let run_fut = transp.run();
-    tokio::spawn(async move {
-        run_fut.await;
-        println!("redundant run terminated");
-    });
+    let redun = redundant::Connection::new();
 
     // Add the previously created transports.
-    redun.add(Box::new(udptcp_conn.clone())).await.unwrap();
-    redun.add(Box::new(tcp_conn.clone())).await.unwrap();
-    redun.add(Box::new(tls_conn.clone())).await.unwrap();
+    redun.add(Box::new(udptcp_conn.clone()));
+    redun.add(Box::new(tcp_conn.clone()));
+    redun.add(Box::new(tls_conn.clone()));
 
     // Start a few queries.
     for i in 1..10 {

--- a/examples/client-transports.rs
+++ b/examples/client-transports.rs
@@ -191,12 +191,14 @@ async fn main() {
     drop(request);
 
     // Create a transport connection for redundant connections.
-    let redun = redundant::Connection::new();
+    let redun = redundant::Connection::<
+        Box<dyn SendRequest<RequestMessage<Vec<u8>>> + Send + Sync>,
+    >::new();
 
     // Add the previously created transports.
-    redun.add(Box::new(udptcp_conn.clone()));
-    redun.add(Box::new(tcp_conn.clone()));
-    redun.add(Box::new(tls_conn.clone()));
+    redun.add(Box::new(udptcp_conn.clone()) as _);
+    redun.add(Box::new(tcp_conn.clone()) as _);
+    redun.add(Box::new(tls_conn.clone()) as _);
 
     // Start a few queries.
     for i in 1..10 {

--- a/examples/query-routing.rs
+++ b/examples/query-routing.rs
@@ -88,22 +88,21 @@ async fn example_redundant(
     dst1: &str,
     dst2: &str,
 ) -> redundant::Connection<RequestMessage<Vec<u8>>> {
-    let (redun, transport) = redundant::Connection::new();
-    tokio::spawn(transport.run());
+    let redun = redundant::Connection::new();
     let server_addr = SocketAddr::new(IpAddr::from_str(dst1).unwrap(), 53);
     let udp_connect = UdpConnect::new(server_addr);
     let tcp_connect = TcpConnect::new(server_addr);
     let (conn, transport) =
         dgram_stream::Connection::new(udp_connect, tcp_connect);
     tokio::spawn(transport.run());
-    redun.add(Box::new(conn)).await.unwrap();
+    redun.add(Box::new(conn));
     let server_addr = SocketAddr::new(IpAddr::from_str(dst2).unwrap(), 53);
     let udp_connect = UdpConnect::new(server_addr);
     let tcp_connect = TcpConnect::new(server_addr);
     let (conn, transport) =
         dgram_stream::Connection::new(udp_connect, tcp_connect);
     tokio::spawn(transport.run());
-    redun.add(Box::new(conn)).await.unwrap();
+    redun.add(Box::new(conn));
 
     redun
 }

--- a/src/net/client/dgram_stream.rs
+++ b/src/net/client/dgram_stream.rs
@@ -208,7 +208,7 @@ where
             match &mut self.state {
                 QueryState::StartUdpRequest => {
                     let msg = self.request_msg.clone();
-                    let request = self.udp_conn.send_request(msg);
+                    let request = (*self.udp_conn).send_request(msg);
                     self.state = QueryState::GetUdpResponse(request);
                     continue;
                 }

--- a/src/net/client/redundant.rs
+++ b/src/net/client/redundant.rs
@@ -454,17 +454,17 @@ impl Default for TransportStats {
 //------------ RequestTransport ----------------------------------------------
 
 /// A transport within the context of a request.
-struct RequestTransport<Req> {
+struct RequestTransport<Conn> {
     /// The underlying transport.
-    transport: Arc<Transport<Req>>,
+    transport: Arc<Transport<Conn>>,
 
     /// The expected timeout for the transport.
     timeout: Duration,
 }
 
-impl<Req> RequestTransport<Req> {
+impl<Conn> RequestTransport<Conn> {
     /// Construct a new [`RequestTransport`].
-    pub fn new(transport: Arc<Transport<Req>>) -> Self {
+    pub fn new(transport: Arc<Transport<Conn>>) -> Self {
         let timeout = transport.stats.lock().timeout;
         Self { transport, timeout }
     }

--- a/src/net/client/redundant.rs
+++ b/src/net/client/redundant.rs
@@ -1,58 +1,56 @@
-//! A transport that multiplexes requests over multiple redundant transports.
+//! Multiplexing requests over redundant transports.
+//!
+//! This module offers a client-side transport for adding redundancy to a DNS
+//! query pipeline.  A [`Connection`] can be created and multiple equivalent
+//! transports can be added to it.  Requests routed through the [`Connection`]
+//! will first be sent to the fastest transport, then to the second-fastest,
+//! etc.  Statistics about the response time for each transport are collected
+//! and used to estimate the average and an upper bound; [`Connection`] uses
+//! this to decide how long to wait before trying each next transport.
 
 use bytes::Bytes;
 
-use futures_util::stream::FuturesUnordered;
-use futures_util::StreamExt;
+use futures_util::stream;
+use futures_util::{FutureExt, StreamExt};
 
 use octseq::Octets;
 
-use rand::random;
+use rand::seq::SliceRandom;
+use rand::Rng;
 
+use core::future::ready;
+use core::mem;
+use core::{fmt, pin::pin};
 use std::boxed::Box;
-use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::vec::Vec;
 
-use tokio::sync::{mpsc, oneshot};
-use tokio::time::{sleep_until, Duration, Instant};
+use parking_lot::{Mutex, RwLock};
+
+use tokio::time::{Duration, Instant};
 
 use crate::base::iana::OptRcode;
 use crate::base::Message;
 use crate::net::client::request::{Error, GetResponse, SendRequest};
 
-/*
-Basic algorithm:
-- keep track of expected response time for every upstream
-- start with the upstream with the lowest expected response time
-- set a timer to the expect response time.
-- if the timer expires before reply arrives, send the query to the next lowest
-  and set a timer
-- when a reply arrives update the expected response time for the relevant
-  upstream and for the ones that failed.
-
-Based on a random number generator:
-- pick a different upstream rather then the best but set the timer to the
-  expected response time of the best.
-*/
-
-/// Capacity of the channel that transports [ChanReq].
-const DEF_CHAN_CAP: usize = 8;
-
-/// Time in milliseconds for the initial response time estimate.
-const DEFAULT_RT_MS: u64 = 300;
-
-/// The initial response time estimate for unused connections.
-const DEFAULT_RT: Duration = Duration::from_millis(DEFAULT_RT_MS);
-
-/// Maintain a moving average for the measured response time and the
-/// square of that. The window is SMOOTH_N.
-const SMOOTH_N: f64 = 8.;
-
-/// Chance to probe a worse connection.
-const PROBE_P: f64 = 0.05;
+// NOTE:
+//
+// The implementation estimates the mean and variance of the response time of
+// each transport.  For each request, transports are tried from fastest to
+// slowest.  Each transport is assigned a timeout; if a response does not
+// arrive before the timeout, the next transport in the list is attempted.
+// However, the previous request is not canceled; both run concurrently.
+//
+// The timeout is set to 3 standard deviations greater than the mean.  If the
+// response times are normally distributed, this timeout should cover 99.7% of
+// cases.
+//
+// Particularly slow transports may get sidelined, preventing new information
+// about them from being learnt.  Occasionally, a randomly chosen transport is
+// brought to the front of the list, so it can be tested.
 
 //------------ Config ---------------------------------------------------------
 
@@ -101,696 +99,352 @@ impl Config {
     }
 }
 
-//------------ Connection -----------------------------------------------------
+//------------ Connection ----------------------------------------------------
 
-/// This type represents a transport connection.
-#[derive(Debug)]
-pub struct Connection<Req>
-where
-    Req: Send + Sync,
-{
-    /// User configuation.
+/// A request multiplexer over redundant transports.
+#[derive(Default, Debug)]
+pub struct Connection<Req> {
+    /// Configuration for the transport.
     config: Config,
 
-    /// To send a request to the runner.
-    sender: mpsc::Sender<ChanReq<Req>>,
+    /// A set of known transports.
+    ///
+    /// This is an unordered list.  Transports are occasionally added and
+    /// removed, but this is a rare occurrence -- we focus on read speed.
+    ///
+    /// Within each transport, runtime statistics can be modified without
+    /// locking the entire list for mutation.
+    transports: RwLock<Vec<Arc<Transport<Req>>>>,
 }
 
-impl<Req: Clone + Debug + Send + Sync + 'static> Connection<Req> {
-    /// Create a new connection.
-    pub fn new() -> (Self, Transport<Req>) {
-        Self::with_config(Default::default())
+impl<Req> Connection<Req> {
+    /// Construct a new [`Connection`].
+    pub fn new() -> Self {
+        Self::with_config(Config::default())
     }
 
-    /// Create a new connection with a given config.
-    pub fn with_config(config: Config) -> (Self, Transport<Req>) {
-        let (sender, receiver) = mpsc::channel(DEF_CHAN_CAP);
-        (Self { config, sender }, Transport::new(receiver))
-    }
-
-    /// Add a transport connection.
-    pub async fn add(
-        &self,
-        conn: Box<dyn SendRequest<Req> + Send + Sync>,
-    ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(ChanReq::Add(AddReq { conn, tx }))
-            .await
-            .expect("send should not fail");
-        rx.await.expect("receive should not fail")
-    }
-
-    /// Implementation of the query method.
-    async fn request_impl(
-        self,
-        request_msg: Req,
-    ) -> Result<Message<Bytes>, Error> {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(ChanReq::GetRT(RTReq { tx }))
-            .await
-            .expect("send should not fail");
-        let conn_rt = rx.await.expect("receive should not fail")?;
-        Query::new(self.config, request_msg, conn_rt, self.sender.clone())
-            .get_response()
-            .await
-    }
-}
-
-impl<Req> Clone for Connection<Req>
-where
-    Req: Send + Sync,
-{
-    fn clone(&self) -> Self {
+    /// Construct a new [`Connection`] with the given configuration.
+    pub fn with_config(config: Config) -> Self {
         Self {
-            config: self.config,
-            sender: self.sender.clone(),
+            config,
+            transports: RwLock::new(Vec::new()),
         }
     }
+
+    /// Add a new transport.
+    pub fn add(&self, transport: Box<dyn SendRequest<Req> + Send + Sync>) {
+        // Prepare the new transport.
+        let transport = Arc::new(Transport::new(transport));
+
+        // Add the transport, locking for as little time as possible.
+        self.transports.write().push(transport);
+    }
 }
 
-impl<Req: Clone + Debug + Send + Sync + 'static> SendRequest<Req>
+impl<Req: Clone + Send + Sync + 'static> SendRequest<Req>
     for Connection<Req>
 {
     fn send_request(
         &self,
         request_msg: Req,
     ) -> Box<dyn GetResponse + Send + Sync> {
-        Box::new(Request {
-            fut: Box::pin(self.clone().request_impl(request_msg)),
-        })
-    }
-}
+        /// A wrapper type for a multiplexed request.
+        struct Request(
+            Pin<
+                Box<
+                    dyn Future<Output = Result<Message<Bytes>, Error>>
+                        + Send
+                        + Sync,
+                >,
+            >,
+        );
 
-//------------ Request -------------------------------------------------------
-
-/// An active request.
-struct Request {
-    /// The underlying future.
-    fut: Pin<
-        Box<dyn Future<Output = Result<Message<Bytes>, Error>> + Send + Sync>,
-    >,
-}
-
-impl Request {
-    /// Async function that waits for the future stored in Query to complete.
-    async fn get_response_impl(&mut self) -> Result<Message<Bytes>, Error> {
-        (&mut self.fut).await
-    }
-}
-
-impl GetResponse for Request {
-    fn get_response(
-        &mut self,
-    ) -> Pin<
-        Box<
-            dyn Future<Output = Result<Message<Bytes>, Error>>
-                + Send
-                + Sync
-                + '_,
-        >,
-    > {
-        Box::pin(self.get_response_impl())
-    }
-}
-
-impl Debug for Request {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        f.debug_struct("Request")
-            .field("fut", &format_args!("_"))
-            .finish()
-    }
-}
-
-//------------ Query --------------------------------------------------------
-
-/// This type represents an active query request.
-#[derive(Debug)]
-struct Query<Req>
-where
-    Req: Send + Sync,
-{
-    /// User configuration.
-    config: Config,
-
-    /// The state of the query
-    state: QueryState,
-
-    /// The request message
-    request_msg: Req,
-
-    /// List of connections identifiers and estimated response times.
-    conn_rt: Vec<ConnRT>,
-
-    /// Channel to send requests to the run function.
-    sender: mpsc::Sender<ChanReq<Req>>,
-
-    /// List of futures for outstanding requests.
-    fut_list: FuturesUnordered<
-        Pin<Box<dyn Future<Output = FutListOutput> + Send + Sync>>,
-    >,
-
-    /// Transport error that should be reported if nothing better shows
-    /// up.
-    deferred_transport_error: Option<Error>,
-
-    /// Reply that should be returned to the user if nothing better shows
-    /// up.
-    deferred_reply: Option<Message<Bytes>>,
-
-    /// The result from one of the connectons.
-    result: Option<Result<Message<Bytes>, Error>>,
-
-    /// Index of the connection that returned a result.
-    res_index: usize,
-}
-
-/// The various states a query can be in.
-#[derive(Debug)]
-enum QueryState {
-    /// The initial state
-    Init,
-
-    /// Start a request on a specific connection.
-    Probe(usize),
-
-    /// Report the response time for a specific index in the list.
-    Report(usize),
-
-    /// Wait for one of the requests to finish.
-    Wait,
-}
-
-/// The commands that can be sent to the run function.
-enum ChanReq<Req>
-where
-    Req: Send + Sync,
-{
-    /// Add a connection
-    Add(AddReq<Req>),
-
-    /// Get the list of estimated response times for all connections
-    GetRT(RTReq),
-
-    /// Start a query
-    Query(RequestReq<Req>),
-
-    /// Report how long it took to get a response
-    Report(TimeReport),
-
-    /// Report that a connection failed to provide a timely response
-    Failure(TimeReport),
-}
-
-impl<Req> Debug for ChanReq<Req>
-where
-    Req: Send + Sync,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        f.debug_struct("ChanReq").finish()
-    }
-}
-
-/// Request to add a new connection
-struct AddReq<Req> {
-    /// New connection to add
-    conn: Box<dyn SendRequest<Req> + Send + Sync>,
-
-    /// Channel to send the reply to
-    tx: oneshot::Sender<AddReply>,
-}
-
-/// Reply to an Add request
-type AddReply = Result<(), Error>;
-
-/// Request to give the estimated response times for all connections
-struct RTReq /*<Octs>*/ {
-    /// Channel to send the reply to
-    tx: oneshot::Sender<RTReply>,
-}
-
-/// Reply to a RT request
-type RTReply = Result<Vec<ConnRT>, Error>;
-
-/// Request to start a request
-struct RequestReq<Req>
-where
-    Req: Send + Sync,
-{
-    /// Identifier of connection
-    id: u64,
-
-    /// Request message
-    request_msg: Req,
-
-    /// Channel to send the reply to
-    tx: oneshot::Sender<RequestReply>,
-}
-
-impl<Req: Debug> Debug for RequestReq<Req>
-where
-    Req: Send + Sync,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        f.debug_struct("RequestReq")
-            .field("id", &self.id)
-            .field("request_msg", &self.request_msg)
-            .finish()
-    }
-}
-
-/// Reply to a request request.
-type RequestReply = Result<Box<dyn GetResponse + Send + Sync>, Error>;
-
-/// Report the amount of time until success or failure.
-#[derive(Debug)]
-struct TimeReport {
-    /// Identifier of the transport connection.
-    id: u64,
-
-    /// Time spend waiting for a reply.
-    elapsed: Duration,
-}
-
-/// Connection statistics to compute the estimated response time.
-struct ConnStats {
-    /// Aproximation of the windowed average of response times.
-    mean: f64,
-
-    /// Aproximation of the windowed average of the square of response times.
-    mean_sq: f64,
-}
-
-/// Data required to schedule requests and report timing results.
-#[derive(Clone, Debug)]
-struct ConnRT {
-    /// Estimated response time.
-    est_rt: Duration,
-
-    /// Identifier of the connection.
-    id: u64,
-
-    /// Start of a request using this connection.
-    start: Option<Instant>,
-}
-
-/// Result of the futures in fut_list.
-type FutListOutput = (usize, Result<Message<Bytes>, Error>);
-
-impl<Req: Clone + Send + Sync + 'static> Query<Req> {
-    /// Create a new query object.
-    fn new(
-        config: Config,
-        request_msg: Req,
-        mut conn_rt: Vec<ConnRT>,
-        sender: mpsc::Sender<ChanReq<Req>>,
-    ) -> Self {
-        let conn_rt_len = conn_rt.len();
-        conn_rt.sort_unstable_by(conn_rt_cmp);
-
-        // Do we want to probe a less performant upstream?
-        if conn_rt_len > 1 && random::<f64>() < PROBE_P {
-            let index: usize = 1 + random::<usize>() % (conn_rt_len - 1);
-
-            // Give the probe some head start. We may need a separate
-            // configuration parameter. A multiple of min_rt. Just use
-            // min_rt for now.
-            let min_rt = conn_rt.iter().map(|e| e.est_rt).min().unwrap();
-
-            let mut e = conn_rt.remove(index);
-            e.est_rt = min_rt;
-            conn_rt.insert(0, e);
-        }
-
-        Self {
-            config,
-            request_msg,
-            conn_rt,
-            sender,
-            state: QueryState::Init,
-            fut_list: FuturesUnordered::new(),
-            deferred_transport_error: None,
-            deferred_reply: None,
-            result: None,
-            res_index: 0,
-        }
-    }
-
-    /// Implementation of get_response.
-    async fn get_response(&mut self) -> Result<Message<Bytes>, Error> {
-        loop {
-            match self.state {
-                QueryState::Init => {
-                    if self.conn_rt.is_empty() {
-                        return Err(Error::NoTransportAvailable);
-                    }
-                    self.state = QueryState::Probe(0);
-                    continue;
-                }
-                QueryState::Probe(ind) => {
-                    self.conn_rt[ind].start = Some(Instant::now());
-                    let fut = start_request(
-                        ind,
-                        self.conn_rt[ind].id,
-                        self.sender.clone(),
-                        self.request_msg.clone(),
-                    );
-                    self.fut_list.push(Box::pin(fut));
-                    let timeout = Instant::now() + self.conn_rt[ind].est_rt;
-                    loop {
-                        tokio::select! {
-                            res = self.fut_list.next() => {
-                                let res = res.expect("res should not be empty");
-                                match res.1 {
-                                    Err(ref err) => {
-                                        if self.config.defer_transport_error {
-                                            if self.deferred_transport_error.is_none() {
-                                                self.deferred_transport_error = Some(err.clone());
-                                            }
-                                            if res.0 == ind {
-                                                // The current upstream finished,
-                                                // try the next one, if any.
-                                                self.state =
-                                                if ind+1 < self.conn_rt.len() {
-                                                    QueryState::Probe(ind+1)
-                                                }
-                                                else
-                                                {
-                                                    QueryState::Wait
-                                                };
-                                                // Break out of receive loop
-                                                break;
-                                            }
-                                            // Just continue receiving
-                                            continue;
-                                        }
-                                        // Return error to the user.
-                                    }
-                                    Ok(ref msg) => {
-                                        if skip(msg, &self.config) {
-                                            if self.deferred_reply.is_none() {
-                                                self.deferred_reply = Some(msg.clone());
-                                            }
-                                            if res.0 == ind {
-                                                // The current upstream finished,
-                                                // try the next one, if any.
-                                                self.state =
-                                                    if ind+1 < self.conn_rt.len() {
-                                                        QueryState::Probe(ind+1)
-                                                    }
-                                                    else
-                                                    {
-                                                        QueryState::Wait
-                                                    };
-                                                // Break out of receive loop
-                                                break;
-                                            }
-                                            // Just continue receiving
-                                            continue;
-                                        }
-                                        // Now we have a reply that can be
-                                        // returned to the user.
-                                    }
-                                }
-                                self.result = Some(res.1);
-                                self.res_index= res.0;
-
-                                self.state = QueryState::Report(0);
-                                // Break out of receive loop
-                                break;
-                            }
-                            _ = sleep_until(timeout) => {
-                                // Move to the next Probe state if there
-                                // are more upstreams to try, otherwise
-                                // move to the Wait state.
-                                self.state =
-                                if ind+1 < self.conn_rt.len() {
-                                    QueryState::Probe(ind+1)
-                                }
-                                else {
-                                    QueryState::Wait
-                                };
-                                // Break out of receive loop
-                                break;
-                            }
-                        }
-                    }
-                    // Continue with state machine loop
-                    continue;
-                }
-                QueryState::Report(ind) => {
-                    if ind >= self.conn_rt.len()
-                        || self.conn_rt[ind].start.is_none()
-                    {
-                        // Nothing more to report. Return result.
-                        let res = self
-                            .result
-                            .take()
-                            .expect("result should not be empty");
-                        return res;
-                    }
-
-                    let start = self.conn_rt[ind]
-                        .start
-                        .expect("start time should not be empty");
-                    let elapsed = start.elapsed();
-                    let time_report = TimeReport {
-                        id: self.conn_rt[ind].id,
-                        elapsed,
-                    };
-                    let report = if ind == self.res_index {
-                        // Succesfull entry
-                        ChanReq::Report(time_report)
-                    } else {
-                        // Failed entry
-                        ChanReq::Failure(time_report)
-                    };
-
-                    // Send could fail but we don't care.
-                    let _ = self.sender.send(report).await;
-
-                    self.state = QueryState::Report(ind + 1);
-                    continue;
-                }
-                QueryState::Wait => {
-                    loop {
-                        if self.fut_list.is_empty() {
-                            // We have nothing left. There should be a reply or
-                            // an error. Prefer a reply over an error.
-                            if self.deferred_reply.is_some() {
-                                let msg = self
-                                    .deferred_reply
-                                    .take()
-                                    .expect("just checked for Some");
-                                return Ok(msg);
-                            }
-                            if self.deferred_transport_error.is_some() {
-                                let err = self
-                                    .deferred_transport_error
-                                    .take()
-                                    .expect("just checked for Some");
-                                return Err(err);
-                            }
-                            panic!("either deferred_reply or deferred_error should be present");
-                        }
-                        let res = self.fut_list.next().await;
-                        let res = res.expect("res should not be empty");
-                        match res.1 {
-                            Err(ref err) => {
-                                if self.config.defer_transport_error {
-                                    if self.deferred_transport_error.is_none()
-                                    {
-                                        self.deferred_transport_error =
-                                            Some(err.clone());
-                                    }
-                                    // Just continue with the next future, or
-                                    // finish if fut_list is empty.
-                                    continue;
-                                }
-                                // Return error to the user.
-                            }
-                            Ok(ref msg) => {
-                                if skip(msg, &self.config) {
-                                    if self.deferred_reply.is_none() {
-                                        self.deferred_reply =
-                                            Some(msg.clone());
-                                    }
-                                    // Just continue with the next future, or
-                                    // finish if fut_list is empty.
-                                    continue;
-                                }
-                                // Return reply to user.
-                            }
-                        }
-                        self.result = Some(res.1);
-                        self.res_index = res.0;
-                        self.state = QueryState::Report(0);
-                        // Break out of loop to continue with the state machine
-                        break;
-                    }
-                    continue;
-                }
+        impl GetResponse for Request {
+            fn get_response(
+                &mut self,
+            ) -> Pin<
+                Box<
+                    dyn Future<Output = Result<Message<Bytes>, Error>>
+                        + Send
+                        + Sync
+                        + '_,
+                >,
+            > {
+                Box::pin(&mut self.0)
             }
         }
+
+        impl fmt::Debug for Request {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                f.write_str("redundant::Request")
+            }
+        }
+
+        let config = self.config;
+        let transports = self.prep_transports();
+        let future = Self::request(config, transports, request_msg);
+
+        Box::new(Request(Box::pin(future)))
+    }
+}
+
+impl<Req: Clone> Connection<Req> {
+    /// Multiplex a request through known transports.
+    ///
+    /// The given list of transports will be queried, in order.  If a request
+    /// does not finish within the associated timeout (which should be quite
+    /// rare), a request for the next transport is started concurrently.
+    async fn request(
+        config: Config,
+        transports: Vec<RequestTransport<Req>>,
+        request: Req,
+    ) -> Result<Message<Bytes>, Error> {
+        // Ensure at least one transport is available.
+        if transports.is_empty() {
+            return Err(Error::NoTransportAvailable);
+        }
+
+        // A deferred result.
+        let mut deferred_result = None;
+
+        // The total number of transports.
+        let num_transports = transports.len();
+
+        let result = stream::iter(transports)
+            // For each transport, request from it, then wait out its timeout.
+            .scan(Duration::ZERO, |timeout, transport| {
+                let request = request.clone();
+                let timeout = mem::replace(timeout, transport.timeout);
+                tokio::time::sleep(timeout)
+                    .map(|()| Some(transport.transport.request(request)))
+            })
+            // Execute all requests concurrently, as they are produced.
+            .buffer_unordered(num_transports)
+            // Defer unwanted results in case more useful ones arrive.
+            .filter_map(|result| match result {
+                Ok(msg) if skip(&msg, &config) => {
+                    if deferred_result.as_ref().map_or(true, Result::is_err) {
+                        deferred_result = Some(Ok(msg));
+                    }
+                    ready(None)
+                }
+
+                Err(err) if config.defer_transport_error => {
+                    if deferred_result.is_none() {
+                        deferred_result = Some(Err(err));
+                    }
+                    ready(None)
+                }
+
+                // In all other cases, finish immediately.
+                result => ready(Some(result)),
+            });
+
+        pin!(result)
+            .next()
+            .await
+            .or(deferred_result)
+            .expect("at least one transport finished a request")
+    }
+
+    /// Prepare a sorted list of transports to query.
+    ///
+    /// The live set of transports will be snapshotted and sorted by timeout.
+    /// Occasionally, a slower transport may be assigned a low timeout so that
+    /// information about it can be updated.
+    fn prep_transports(&self) -> Vec<RequestTransport<Req>> {
+        // Take a snapshot of the transport list.
+        let mut transports = self
+            .transports
+            .read()
+            .iter()
+            .cloned()
+            .map(RequestTransport::new)
+            .collect::<Vec<_>>();
+
+        // Occasionally the probe slow transports.
+        let mut rng = rand::thread_rng();
+        if transports.len() > 1 && rng.gen_bool(0.05) {
+            let min_timeout = transports
+                .iter()
+                .map(|transport| transport.timeout)
+                .min()
+                .expect("there are at least two transports");
+
+            // Pick a random transport and try to get it probed early.
+            transports
+                .choose_mut(&mut rng)
+                .expect("there are at least two transports")
+                .timeout = min_timeout;
+        }
+
+        // Sort the transports by lowest timeout; we will query in this order.
+        transports.sort_unstable_by_key(|t| t.timeout);
+
+        transports
     }
 }
 
 //------------ Transport -----------------------------------------------------
 
-/// Type that actually implements the connection.
-#[derive(Debug)]
-pub struct Transport<Req>
-where
-    Req: Send + Sync,
-{
-    /// Receive side of the channel used by the runner.
-    receiver: mpsc::Receiver<ChanReq<Req>>,
+/// A transport known to [`Connection`].
+struct Transport<Req> {
+    /// The underlying request sender.
+    sender: Box<dyn SendRequest<Req> + Send + Sync>,
+
+    /// Statistics about this transport.
+    ///
+    /// This is updated after every request-response using this transport.
+    stats: Mutex<TransportStats>,
 }
 
-impl<Req: Clone + Send + Sync + 'static> Transport<Req> {
-    /// Implementation of the new method.
-    fn new(receiver: mpsc::Receiver<ChanReq<Req>>) -> Self {
-        Self { receiver }
+impl<Req> Transport<Req> {
+    /// Construct a new [`Transport`].
+    pub fn new(sender: Box<dyn SendRequest<Req> + Send + Sync>) -> Self {
+        Self {
+            sender,
+            stats: Default::default(),
+        }
     }
 
-    /// Run method.
-    pub async fn run(mut self) {
-        let mut next_id: u64 = 10;
-        let mut conn_stats: Vec<ConnStats> = Vec::new();
-        let mut conn_rt: Vec<ConnRT> = Vec::new();
-        let mut conns: Vec<Box<dyn SendRequest<Req> + Send + Sync>> =
-            Vec::new();
+    /// Query this transport.
+    async fn request(
+        self: Arc<Self>,
+        request: Req,
+    ) -> Result<Message<Bytes>, Error> {
+        /// A drop guard for collecting statistics.
+        struct Guard<'a> {
+            /// Whether the request actually finished.
+            finished: bool,
 
-        loop {
-            let req = match self.receiver.recv().await {
-                Some(req) => req,
-                None => break, // All references to connection objects are
-                               // dropped. Shutdown.
-            };
-            match req {
-                ChanReq::Add(add_req) => {
-                    let id = next_id;
-                    next_id += 1;
-                    conn_stats.push(ConnStats {
-                        mean: (DEFAULT_RT_MS as f64) / 1000.,
-                        mean_sq: 0.,
-                    });
-                    conn_rt.push(ConnRT {
-                        id,
-                        est_rt: DEFAULT_RT,
-                        start: None,
-                    });
-                    conns.push(add_req.conn);
+            /// When the request started.
+            start_time: Instant,
 
-                    // Don't care if send fails
-                    let _ = add_req.tx.send(Ok(()));
-                }
-                ChanReq::GetRT(rt_req) => {
-                    // Don't care if send fails
-                    let _ = rt_req.tx.send(Ok(conn_rt.clone()));
-                }
-                ChanReq::Query(request_req) => {
-                    let opt_ind =
-                        conn_rt.iter().position(|e| e.id == request_req.id);
-                    match opt_ind {
-                        Some(ind) => {
-                            let query = conns[ind]
-                                .send_request(request_req.request_msg);
-                            // Don't care if send fails
-                            let _ = request_req.tx.send(Ok(query));
-                        }
-                        None => {
-                            // Don't care if send fails
-                            let _ = request_req
-                                .tx
-                                .send(Err(Error::RedundantTransportNotFound));
-                        }
-                    }
-                }
-                ChanReq::Report(time_report) => {
-                    let opt_ind =
-                        conn_rt.iter().position(|e| e.id == time_report.id);
-                    if let Some(ind) = opt_ind {
-                        let elapsed = time_report.elapsed.as_secs_f64();
-                        conn_stats[ind].mean +=
-                            (elapsed - conn_stats[ind].mean) / SMOOTH_N;
-                        let elapsed_sq = elapsed * elapsed;
-                        conn_stats[ind].mean_sq +=
-                            (elapsed_sq - conn_stats[ind].mean_sq) / SMOOTH_N;
-                        let mean = conn_stats[ind].mean;
-                        let var = conn_stats[ind].mean_sq - mean * mean;
-                        let std_dev =
-                            if var < 0. { 0. } else { f64::sqrt(var) };
-                        let est_rt = mean + 3. * std_dev;
-                        conn_rt[ind].est_rt = Duration::from_secs_f64(est_rt);
-                    }
-                }
-                ChanReq::Failure(time_report) => {
-                    let opt_ind =
-                        conn_rt.iter().position(|e| e.id == time_report.id);
-                    if let Some(ind) = opt_ind {
-                        let elapsed = time_report.elapsed.as_secs_f64();
-                        if elapsed < conn_stats[ind].mean {
-                            // Do not update the mean if a
-                            // failure took less time than the
-                            // current mean.
-                            continue;
-                        }
-                        conn_stats[ind].mean +=
-                            (elapsed - conn_stats[ind].mean) / SMOOTH_N;
-                        let elapsed_sq = elapsed * elapsed;
-                        conn_stats[ind].mean_sq +=
-                            (elapsed_sq - conn_stats[ind].mean_sq) / SMOOTH_N;
-                        let mean = conn_stats[ind].mean;
-                        let var = conn_stats[ind].mean_sq - mean * mean;
-                        let std_dev =
-                            if var < 0. { 0. } else { f64::sqrt(var) };
-                        let est_rt = mean + 3. * std_dev;
-                        conn_rt[ind].est_rt = Duration::from_secs_f64(est_rt);
-                    }
+            /// The transport statistics.
+            stats: &'a Mutex<TransportStats>,
+        }
+
+        impl<'a> Drop for Guard<'a> {
+            fn drop(&mut self) {
+                let elapsed = self.start_time.elapsed();
+                let mut stats = self.stats.lock();
+
+                // Update on completion, or if the request took too long.
+                if self.finished || elapsed.as_secs_f64() > stats.mean {
+                    stats.account(elapsed);
                 }
             }
+        }
+
+        // Collect statistics even if the future is canceled.
+        let mut guard = Guard {
+            finished: false,
+            start_time: Instant::now(),
+            stats: &self.stats,
+        };
+
+        // Perform the actual request.
+        let result = self.sender.send_request(request).get_response().await;
+
+        // Inform the drop guard that the request completed.
+        guard.finished = true;
+
+        result
+    }
+}
+
+impl<Req> fmt::Debug for Transport<Req> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Transport")
+            .field("sender", &format_args!("_"))
+            .field("stats", &self.stats)
+            .finish()
+    }
+}
+
+//------------ TransportStats ------------------------------------------------
+
+/// Statistics about a transport.
+#[derive(Clone, Debug)]
+struct TransportStats {
+    /// The average response time in the window.
+    ///
+    /// If this is NaN, the window was empty.
+    mean: f64,
+
+    /// The average of the square of the response time in the window.
+    ///
+    /// If this is NaN, the window was empty.
+    mean_sq: f64,
+
+    /// A computed timeout for requests to the transport.
+    ///
+    /// This value is three standard deviations past the mean.  Assuming the
+    /// transport request times follow a normal distribution, there is a 99.7%
+    /// chance a random transport request will fit within this timeout.
+    ///
+    /// If this is NaN, the window was empty.
+    timeout: Duration,
+}
+
+impl TransportStats {
+    /// Account for the given response time.
+    fn account(&mut self, rt: Duration) {
+        let rt = rt.as_secs_f64();
+
+        if self.mean.is_nan() {
+            // This is the first response time -- overwrite the averages.
+            self.mean = rt;
+            self.mean_sq = rt * rt;
+        } else {
+            // Adjust the averages by 1/8th.
+            //
+            // After 8 iterations of the same response time, the previous
+            // average has a weight of about 34%.  After 8 more iterations,
+            // its weight is about 12%.
+            self.mean = (rt + 7. * self.mean) / 8.;
+            self.mean_sq = (rt * rt + 7. * self.mean_sq) / 8.;
+        }
+
+        // Compute the variance and standard deviation.
+        let variance = self.mean_sq - self.mean * self.mean;
+        let std_dev = variance.max(0.).sqrt();
+
+        // Determine the appropriate timeout value.
+        self.timeout = Duration::from_secs_f64(self.mean + 3. * std_dev);
+    }
+}
+
+impl Default for TransportStats {
+    fn default() -> Self {
+        Self {
+            mean: f64::NAN,
+            mean_sq: f64::NAN,
+            timeout: Duration::from_millis(300),
         }
     }
 }
 
+//------------ RequestTransport ----------------------------------------------
+
+/// A transport within the context of a request.
+struct RequestTransport<Req> {
+    /// The underlying transport.
+    transport: Arc<Transport<Req>>,
+
+    /// The expected timeout for the transport.
+    timeout: Duration,
+}
+
+impl<Req> RequestTransport<Req> {
+    /// Construct a new [`RequestTransport`].
+    pub fn new(transport: Arc<Transport<Req>>) -> Self {
+        let timeout = transport.stats.lock().timeout;
+        Self { transport, timeout }
+    }
+}
+
 //------------ Utility --------------------------------------------------------
-
-/// Async function to send a request and wait for the reply.
-///
-/// This gives a single future that we can put in a list.
-async fn start_request<Req>(
-    index: usize,
-    id: u64,
-    sender: mpsc::Sender<ChanReq<Req>>,
-    request_msg: Req,
-) -> (usize, Result<Message<Bytes>, Error>)
-where
-    Req: Send + Sync,
-{
-    let (tx, rx) = oneshot::channel();
-    sender
-        .send(ChanReq::Query(RequestReq {
-            id,
-            request_msg,
-            tx,
-        }))
-        .await
-        .expect("send is expected to work");
-    let mut request = match rx.await.expect("receive is expected to work") {
-        Err(err) => return (index, Err(err)),
-        Ok(request) => request,
-    };
-    let reply = request.get_response().await;
-
-    (index, reply)
-}
-
-/// Compare ConnRT elements based on estimated response time.
-fn conn_rt_cmp(e1: &ConnRT, e2: &ConnRT) -> Ordering {
-    e1.est_rt.cmp(&e2.est_rt)
-}
 
 /// Return if this reply should be skipped or not.
 fn skip<Octs: Octets>(msg: &Message<Octs>, config: &Config) -> bool {

--- a/src/net/client/redundant.rs
+++ b/src/net/client/redundant.rs
@@ -150,17 +150,12 @@ where
         request_msg: Req,
     ) -> Box<dyn GetResponse + Send + Sync> {
         /// A wrapper type for a multiplexed request.
-        struct Request(
-            Pin<
-                Box<
-                    dyn Future<Output = Result<Message<Bytes>, Error>>
-                        + Send
-                        + Sync,
-                >,
-            >,
-        );
+        struct Request<Fut>(Pin<Box<Fut>>);
 
-        impl GetResponse for Request {
+        impl<Fut> GetResponse for Request<Fut>
+        where
+            Fut: Future<Output = Result<Message<Bytes>, Error>> + Send + Sync,
+        {
             fn get_response(
                 &mut self,
             ) -> Pin<
@@ -175,7 +170,7 @@ where
             }
         }
 
-        impl fmt::Debug for Request {
+        impl<Fut> fmt::Debug for Request<Fut> {
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                 f.write_str("redundant::Request")
             }

--- a/src/net/client/request.rs
+++ b/src/net/client/request.rs
@@ -128,6 +128,17 @@ impl<T: SendRequest<RequestMessage<Octs>> + ?Sized, Octs: Octets>
     }
 }
 
+impl<T: SendRequest<RequestMessage<Octs>> + ?Sized, Octs: Octets>
+    SendRequest<RequestMessage<Octs>> for Arc<T>
+{
+    fn send_request(
+        &self,
+        request_msg: RequestMessage<Octs>,
+    ) -> Box<dyn GetResponse + Send + Sync> {
+        (**self).send_request(request_msg)
+    }
+}
+
 //------------ SendRequestMulti -----------------------------------------------
 
 /// Trait for starting a DNS request based on a request composer.

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -1,5 +1,5 @@
 //! TSIG interop testing with other DNS implementations.
-#![cfg(all(feature = "bytes", feature = "std"))]
+#![cfg(all(feature = "bytes", feature = "std", feature = "tsig"))]
 
 mod common;
 

--- a/tests/net-client-cache.rs
+++ b/tests/net-client-cache.rs
@@ -71,11 +71,7 @@ async fn test_transport_error() {
     let stelline = parse_file(&file, TEST_FILE_TRANSPORT_ERROR);
 
     let step_value = Arc::new(CurrStepValue::new());
-    let (redun, redun_tran) = redundant::Connection::new();
-    tokio::spawn(async move {
-        redun_tran.run().await;
-        println!("redundant conn run terminated");
-    });
+    let redun = Arc::new(redundant::Connection::new());
     // let clock = FakeClock::new();
     let cached = cache::Connection::new(redun.clone()); //_with_time(redun.clone(), clock.clone());
 
@@ -103,7 +99,7 @@ async fn test_transport_error() {
         ms_tran.run().await;
         println!("multi conn run terminated");
     });
-    redun.add(Box::new(ms)).await.unwrap();
+    redun.add(Box::new(ms));
 
     let mut request = cached.send_request(req);
     let reply = request.get_response().await;

--- a/tests/net-client.rs
+++ b/tests/net-client.rs
@@ -106,14 +106,8 @@ fn redundant() {
         });
 
         // Redundant add previous connection.
-        let (redun, transp) = redundant::Connection::new();
-        let run_fut = transp.run();
-        tokio::spawn(async move {
-            run_fut.await;
-            println!("redundant conn run terminated");
-        });
-
-        redun.add(Box::new(ms.clone())).await.unwrap();
+        let redun = redundant::Connection::new();
+        redun.add(Box::new(ms.clone()));
 
         do_client_simple(&stelline, &step_value, redun).await;
     });


### PR DESCRIPTION
This is a low-priority PR for simplifying the `Redundant` client transport.  I've managed to replace a large and difficult state machine with a much simpler control flow, making good use of the `futures_util` crate.  The module has become significantly smaller and easier to understand.