### PR TITLE
Support client crates that use the standard Rust log framework instead of Tokio Tracing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "heapless",
  "lazy_static",
  "libc",
+ "log",
  "mock_instant",
  "moka",
  "octseq",
@@ -1333,6 +1334,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ smallvec       = { version = "1.3", optional = true }
 tokio          = { version = "1.33", optional = true, features = ["io-util", "macros", "net", "time", "sync", "rt-multi-thread" ] }
 tokio-rustls   = { version = "0.26", optional = true, default-features = false }
 tokio-stream   = { version = "0.1.1", optional = true }
-tracing        = { version = "0.1.40", optional = true }
+tracing        = { version = "0.1.40", optional = true, features = ["log"] }
 tracing-subscriber = { version = "0.3.18", optional = true, features = ["env-filter"] }
 
 [features]
@@ -55,10 +55,10 @@ default     = ["std", "rand"]
 # Support for libraries
 bytes       = ["dep:bytes", "octseq/bytes"]
 heapless    = ["dep:heapless", "octseq/heapless"]
-log         = ["dep:log", "tracing/log"]
 serde       = ["dep:serde", "octseq/serde"]
 smallvec    = ["dep:smallvec", "octseq/smallvec"]
 std         = ["dep:hashbrown", "bytes?/std", "octseq/std", "time/std"]
+tracing     = ["dep:log", "dep:tracing"]
 
 # Cryptographic backends
 ring    = ["dep:ring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures-util   = { version = "0.3", optional = true }
 hashbrown      = { version = "0.14.2", optional = true, default-features = false, features = ["allocator-api2", "inline-more"] } # 0.14.2 introduces explicit hashing
 heapless       = { version = "0.8", optional = true }
 libc           = { version = "0.2.153", default-features = false, optional = true } # 0.2.79 is the first version that has IP_PMTUDISC_OMIT
+log            = { version = "0.4.22", optional = true }
 parking_lot    = { version = "0.12", optional = true }
 moka           = { version = "0.12.3", optional = true, features = ["future"] }
 openssl        = { version = "0.10.57", optional = true } # 0.10.57 upgrades to 'bitflags' 2.x
@@ -54,6 +55,7 @@ default     = ["std", "rand"]
 # Support for libraries
 bytes       = ["dep:bytes", "octseq/bytes"]
 heapless    = ["dep:heapless", "octseq/heapless"]
+log         = ["dep:log", "tracing/log"]
 serde       = ["dep:serde", "octseq/serde"]
 smallvec    = ["dep:smallvec", "octseq/smallvec"]
 std         = ["dep:hashbrown", "bytes?/std", "octseq/std", "time/std"]

--- a/src/net/server/connection.rs
+++ b/src/net/server/connection.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use futures_util::StreamExt;
+use log::{log_enabled, Level};
 use octseq::Octets;
 use tokio::io::{
     AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadHalf, WriteHalf,
@@ -17,8 +18,7 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, watch};
 use tokio::time::Instant;
 use tokio::time::{sleep_until, timeout};
-use tracing::Level;
-use tracing::{debug, enabled, error, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::base::message_builder::AdditionalBuilder;
 use crate::base::wire::Composer;
@@ -582,7 +582,7 @@ where
         &mut self,
         msg: StreamTarget<Svc::Target>,
     ) -> Result<(), ConnectionEvent> {
-        if enabled!(Level::TRACE) {
+        if log_enabled!(Level::Trace) {
             let bytes = msg.as_dgram_slice();
             let pcap_text = to_pcap_text(bytes, bytes.len());
             trace!(addr = %self.addr, pcap_text, "Sending response");
@@ -647,7 +647,7 @@ where
             Ok(buf) => {
                 let received_at = Instant::now();
 
-                if enabled!(Level::TRACE) {
+                if log_enabled!(Level::Trace) {
                     let pcap_text = to_pcap_text(&buf, buf.as_ref().len());
                     trace!(addr = %self.addr, pcap_text, "Received message");
                 }

--- a/src/net/server/dgram.rs
+++ b/src/net/server/dgram.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
 use futures_util::stream::StreamExt;
+use log::{log_enabled, Level};
 use octseq::Octets;
 use tokio::io::ReadBuf;
 use tokio::net::UdpSocket;
@@ -30,9 +31,7 @@ use tokio::time::interval;
 use tokio::time::timeout;
 use tokio::time::Instant;
 use tokio::time::MissedTickBehavior;
-use tracing::warn;
-use tracing::Level;
-use tracing::{enabled, error, trace};
+use tracing::{error, trace, warn};
 
 use crate::base::wire::Composer;
 use crate::base::Message;
@@ -496,7 +495,7 @@ where
                     let received_at = Instant::now();
                     self.metrics.inc_num_received_requests();
 
-                    if enabled!(Level::TRACE) {
+                    if log_enabled!(Level::Trace) {
                         let pcap_text = to_pcap_text(&buf, bytes_read);
                         trace!(%addr, pcap_text, "Received message");
                     }
@@ -553,7 +552,7 @@ where
                                         let bytes = target.as_dgram_slice();
 
                                         // Logging
-                                        if enabled!(Level::TRACE) {
+                                        if log_enabled!(Level::Trace) {
                                             let pcap_text = to_pcap_text(bytes, bytes.len());
                                             trace!(%addr, pcap_text, "Sending response");
                                         }

--- a/src/net/server/middleware/edns.rs
+++ b/src/net/server/middleware/edns.rs
@@ -4,8 +4,9 @@ use core::marker::PhantomData;
 use core::ops::ControlFlow;
 
 use futures_util::stream::{once, Once, Stream};
+use log::{log_enabled, Level};
 use octseq::Octets;
-use tracing::{debug, enabled, error, trace, warn, Level};
+use tracing::{debug, error, trace, warn};
 
 use crate::base::iana::OptRcode;
 use crate::base::message_builder::AdditionalBuilder;
@@ -141,7 +142,7 @@ where
                         //   "A DNS server that receives a query using UDP
                         //    transport that includes the edns-tcp-keepalive
                         //    option MUST ignore the option."
-                        if enabled!(Level::DEBUG)
+                        if log_enabled!(Level::Debug)
                             && opt_rec.opt().tcp_keepalive().is_some()
                         {
                             debug!("RFC 7828 3.2.1 violation: ignoring edns-tcp-keepalive option received via UDP");
@@ -161,7 +162,7 @@ where
                         let requestors_udp_payload_size =
                             opt_rec.udp_payload_size();
 
-                        if enabled!(Level::DEBUG)
+                        if log_enabled!(Level::Debug)
                             && requestors_udp_payload_size
                                 < MINIMUM_RESPONSE_BYTE_LEN
                         {
@@ -200,7 +201,7 @@ where
                             None => clamped_requestors_udp_payload_size,
                         };
 
-                        if enabled!(Level::TRACE) {
+                        if log_enabled!(Level::Trace) {
                             trace!("EDNS(0) response size negotation concluded: client requested={}, server requested={:?}, chosen value={}",
                                 opt_rec.udp_payload_size(), server_max_response_size_hint, negotiated_hint);
                         }


### PR DESCRIPTION
This PR does this by enabling Tokio Tracing to emit logs if no tracing subscriber is initialized (via the `tracing/log` feature).

Also fixes guards around costly logging to actually emits log events if no tracing subscriber is initialized by using the enabled check of the log crate instead of the enabled check of the tracing crate.

See: https://docs.rs/tracing/0.1.41/tracing/#emitting-log-records