### PR TITLE
Handle quoted octets. (#468)

### DIFF
--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -564,11 +564,21 @@ impl Scanner for EntryScanner<'_> {
         // trim off everything to the left already.
         self.zonefile.buf.trim_to(self.zonefile.buf.start);
 
+        // Remember if we are inside a quoted value. If so the opening quote
+        // has already been skipped over, it is not part of the value.
+        let is_quoted = self.zonefile.buf.cat == ItemCat::Quoted;
+
         // Skip over symbols that don’t need converting at the beginning.
         while self.zonefile.buf.next_ascii_symbol()?.is_some() {}
 
         // If we aren’t done yet, we have escaped characters to replace.
         let mut write = self.zonefile.buf.start;
+
+        if is_quoted {
+            // Discard the closing quote, it shouldn't be part of the value.
+            write -= 1;
+        }
+
         while let Some(sym) = self.zonefile.buf.next_symbol()? {
             self.zonefile.buf.buf[write] = sym.into_octet()?;
             write += 1;
@@ -1384,7 +1394,7 @@ impl SourceBuf {
 //------------ ItemCat -------------------------------------------------------
 
 /// The category of the current item in a source buffer.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ItemCat {
     /// We don’t currently have an item.
     ///
@@ -1531,6 +1541,26 @@ mod test {
         let entry = EntryScanner::new(&mut zone).unwrap();
         entry.zonefile.buf.next_item().unwrap();
         op(entry)
+    }
+
+    #[test]
+    fn scan_octets() {
+        #[track_caller]
+        fn test(zone: &str, tok: impl AsRef<[u8]>) {
+            with_entry(zone, |mut entry| {
+                let res = entry.scan_octets().unwrap();
+                assert_eq!(&res[..], tok.as_ref());
+            });
+        }
+
+        test(" unquoted\r\n", b"unquoted");
+        test(" unquoted  ", b"unquoted");
+        test("unquoted ", b"unquoted");
+        test("unqu\\oted ", b"unquoted");
+        test("unqu\\111ted ", b"unquoted");
+        test(" \"quoted\"\n", b"quoted");
+        test(" \"quoted\" ", b"quoted");
+        test("\"quoted\" ", b"quoted");
     }
 
     #[test]


### PR DESCRIPTION
This seems to solve the issue I encountered in #468, but not being very familiar with the zone parsing code I am not at all sure that this is the correct fix. Review needed!