### PR TITLE
Don't error with unexpected end of entry for RFC 3597 RDATA of length zero.

### DIFF
--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -543,10 +543,10 @@ impl Scanner for EntryScanner<'_> {
         let mut write = 0;
         let mut builder = None;
         loop {
-            self.convert_one_token(&mut convert, &mut write, &mut builder)?;
             if self.zonefile.buf.is_line_feed() {
                 break;
             }
+            self.convert_one_token(&mut convert, &mut write, &mut builder)?;
         }
         if let Some(data) = convert.process_tail()? {
             self.append_data(data, &mut write, &mut builder);
@@ -1662,6 +1662,13 @@ mod test {
     fn test_unknown_yaml() {
         TestCase::test(include_str!(
             "../../test-data/zonefiles/unknown.yaml"
+        ));
+    }
+
+    #[test]
+    fn test_unknown_zero_length_yaml() {
+        TestCase::test(include_str!(
+            "../../test-data/zonefiles/unknown-zero-length.yaml"
         ));
     }
 

--- a/test-data/zonefiles/unknown-zero-length.yaml
+++ b/test-data/zonefiles/unknown-zero-length.yaml
@@ -1,0 +1,10 @@
+origin: example.com.
+zonefile: |
+  example.com. 3600 IN TXT \# 0
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 3600
+    data: !Unknown
+      rtype: Txt
+      data: 


### PR DESCRIPTION
[RFC 3597 ](https://datatracker.ietf.org/doc/html/rfc3597#section-5) says:

>    If the RDATA is of zero length, the text representation contains only
>   the \# token and the single zero representing the length.

However, domain is currently unable to parse such input, e.g. the following produces an unexpected end of entry error:

```
example.org. 240 IN SOA  example.net. hostmaster.example.net. 1234567890 28800 7200 604800 240
b.example.org   IN          TYPE62347       \# 0

```

This PR alters the parsing of unknown RDATA so that the end of line check to be before the attempt to consume the next token.