### PR TITLE
Introduce feature unstable-client-cache to make the client cache optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,12 +72,13 @@ tsig        = ["bytes", "ring", "smallvec"]
 zonefile    = ["bytes", "serde", "std"]
 
 # Unstable features
-unstable-client-transport = ["moka", "net", "tracing"]
+unstable-client-transport = ["net", "tracing"]
+unstable-client-cache = ["unstable-client-transport", "moka"]
 unstable-server-transport = ["arc-swap", "chrono/clock", "libc", "net", "siphasher", "tracing"]
 unstable-sign = ["std", "dep:secrecy", "unstable-validate", "time/formatting"]
 unstable-stelline = ["tokio/test-util", "tracing", "tracing-subscriber", "tsig", "unstable-client-transport", "unstable-server-transport", "zonefile"]
 unstable-validate = ["bytes", "std", "ring"]
-unstable-validator = ["unstable-validate", "zonefile", "unstable-client-transport"]
+unstable-validator = ["unstable-validate", "zonefile", "unstable-client-transport", "moka"]
 unstable-xfr = ["net"]
 unstable-zonetree = ["futures-util", "parking_lot", "rustversion", "serde", "std", "tokio", "tracing", "unstable-xfr", "zonefile"]
 

--- a/examples/client-transports.rs
+++ b/examples/client-transports.rs
@@ -5,9 +5,11 @@ use domain::net::client::request::{
     RequestMessage, RequestMessageMulti, SendRequest,
 };
 use domain::net::client::{
-    cache, dgram, dgram_stream, load_balancer, multi_stream, redundant,
+    dgram, dgram_stream, load_balancer, multi_stream, redundant,
     stream,
 };
+#[cfg(feature = "unstable-client-cache")]
+use domain::net::client::cache;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 #[cfg(feature = "unstable-validator")]
@@ -92,27 +94,8 @@ async fn main() {
     // when it is no longer needed.
     drop(request);
 
-    // Create a cached transport.
-    let mut cache_config = cache::Config::new();
-    cache_config.set_max_cache_entries(100); // Just an example.
-    let cache =
-        cache::Connection::with_config(udptcp_conn.clone(), cache_config);
-
-    // Send a request message.
-    let mut request = cache.send_request(req.clone());
-
-    // Get the reply
-    println!("Wating for cache reply");
-    let reply = request.get_response().await;
-    println!("Cache reply: {reply:?}");
-
-    // Send the request message again.
-    let mut request = cache.send_request(req.clone());
-
-    // Get the reply
-    println!("Wating for cached reply");
-    let reply = request.get_response().await;
-    println!("Cached reply: {reply:?}");
+    #[cfg(feature = "unstable-client-cache")]
+    do_client_cache(udptcp_conn.clone(), req.clone()).await;
 
     #[cfg(feature = "unstable-validator")]
     do_validator(udptcp_conn.clone(), req.clone()).await;
@@ -313,6 +296,46 @@ async fn main() {
         drop(tcp);
     }
 }
+
+#[cfg(feature = "unstable-client-cache")]
+async fn do_client_cache<Octs, SR>(conn: SR, req: RequestMessage<Octs>)
+where
+    Octs: AsRef<[u8]>
+        + Clone
+        + std::fmt::Debug
+        + domain::dep::octseq::Octets
+        + domain::dep::octseq::OctetsFrom<Vec<u8>>
+        + Send
+        + Sync
+        + 'static,
+    <Octs as domain::dep::octseq::OctetsFrom<Vec<u8>>>::Error:
+        std::fmt::Debug,
+    SR: Clone + SendRequest<RequestMessage<Octs>> + Send + Sync + 'static,
+{
+    // Create a cached transport.
+    let mut cache_config = cache::Config::new();
+    cache_config.set_max_cache_entries(100); // Just an example.
+    let cache =
+        cache::Connection::with_config(conn, cache_config);
+
+    // Send a request message.
+    let mut request = cache.send_request(req.clone());
+
+    // Get the reply
+    println!("Wating for cache reply");
+    let reply = request.get_response().await;
+    println!("Cache reply: {reply:?}");
+
+    // Send the request message again.
+    let mut request = cache.send_request(req.clone());
+
+    // Get the reply
+    println!("Wating for cached reply");
+    let reply = request.get_response().await;
+    println!("Cached reply: {reply:?}");
+
+}
+
 
 #[cfg(feature = "unstable-validator")]
 async fn do_validator<Octs, SR>(conn: SR, req: RequestMessage<Octs>)

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -25,7 +25,9 @@
 //!   transport connections. The [load_balancer] transport favors connections
 //!   with the shortest outstanding request queue. Any of the other transports
 //!   can be added as upstream transports.
-//! * [cache] This is a simple message cache provided as a pass through
+#![cfg_attr(feature = "unstable-client-cache", doc = "* [cache]:")]
+#![cfg_attr(not(feature = "unstable-client-cache",), doc = "* cache:")]
+//!   This is a simple message cache provided as a pass through
 //!   transport. The cache works with any of the other transports.
 #![cfg_attr(feature = "tsig", doc = "* [tsig]:")]
 #![cfg_attr(not(feature = "tsig",), doc = "* tsig:")]
@@ -203,7 +205,8 @@
 //! * The [multi_stream] transport does not support timeouts or other limits on
 //!   the number of attempts to open a connection. The caller has to
 //!   implement a timeout mechanism.
-//! * The [cache] transport does not support:
+#![cfg_attr(feature = "unstable-client-cache", doc = "* The [cache] transport does not support:")]
+#![cfg_attr(not(feature = "unstable-client-cache"), doc = "* The cache transport does not support:")]
 //!   * Prefetching. In this context, prefetching means updating a cache entry
 //!     before it expires.
 //!   * [RFC 8767](https://tools.ietf.org/html/rfc8767)
@@ -223,6 +226,7 @@
 #![warn(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
 
+#[cfg(feature = "unstable-client-cache")]
 pub mod cache;
 pub mod dgram;
 pub mod dgram_stream;


### PR DESCRIPTION
The feature resolv depends on unstable-client-transport and the client cache depends on moka. This in not ideal because currently the resolver does not use the cache.

Introduce the feature unstable-client-cache for the client cache and remove the client cache from unstable-client-transport.