### PR TITLE
Introduce a new `zonefile` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ required-features = ["net", "tokio-stream", "tracing-subscriber", "unstable-clie
 
 [[example]]
 name = "read-zone"
-required-features = ["zonefile"]
+required-features = ["zonefile", "unstable-new"]
 
 [[example]]
 name = "query-zone"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ net         = ["bytes", "futures-util", "rand", "std", "tokio"]
 resolv      = ["net", "smallvec", "unstable-client-transport"]
 resolv-sync = ["resolv", "tokio/rt"]
 tsig        = ["bytes", "constant_time_eq", "ring", "smallvec"]
-zonefile    = ["bytes", "serde", "std"]
+zonefile    = ["bytes", "serde", "std", "bumpalo"] # new: ["std", "bumpalo", "dep:time"]
 
 # Unstable features
 unstable-new = []

--- a/examples/read-zone.rs
+++ b/examples/read-zone.rs
@@ -1,12 +1,11 @@
 //! Reads a zone file.
 
-use std::env;
 use std::fs::File;
 use std::process::exit;
 use std::time::SystemTime;
+use std::{env, io::BufReader};
 
-use domain::zonefile::inplace::Entry;
-use domain::zonefile::inplace::Zonefile;
+use domain::new::zonefile::simple::ZonefileScanner;
 
 fn main() {
     let mut args = env::args();
@@ -23,44 +22,17 @@ fn main() {
     for zone_file in zone_files {
         print!("Processing {zone_file}: ");
         let start = SystemTime::now();
-        let mut reader =
-            Zonefile::load(&mut File::open(&zone_file).unwrap()).unwrap();
-        println!(
-            "Data loaded ({:.03}s).",
-            start.elapsed().unwrap().as_secs_f32()
-        );
+        let file = BufReader::new(File::open(&zone_file).unwrap());
+        let mut scanner = ZonefileScanner::new(file, None);
 
         let mut i = 0;
-        let mut last_entry = None;
-        loop {
-            match reader.next_entry() {
-                Ok(entry) if entry.is_some() => {
-                    last_entry = entry;
-                }
-                Ok(_) => break, // EOF
-                Err(err) => {
-                    eprintln!(
-                        "\nAn error occurred while reading {zone_file}:"
-                    );
-                    eprintln!("  Error: {err}");
-                    if let Some(entry) = &last_entry {
-                        if let Entry::Record(record) = &entry {
-                            eprintln!(
-                                "\nThe last record read was:\n{record}."
-                            );
-                        } else {
-                            eprintln!(
-                                "\nThe last record read was:\n{last_entry:#?}."
-                            );
-                        }
-                        eprintln!(
-                            "\nTry commenting out the line after that record with a leading ; (semi-colon) character."
-                        )
-                    }
-                    exit(1);
-                }
-            }
+        while let Some(entry) = scanner.scan().transpose() {
             i += 1;
+            if let Err(err) = entry {
+                eprintln!("Could not parse {zone_file}: {err}");
+                exit(1);
+            }
+
             if i % 100_000_000 == 0 {
                 println!(
                     "Processed {}M records ({:.03}s)",

--- a/src/new/base/charstr.rs
+++ b/src/new/base/charstr.rs
@@ -8,6 +8,9 @@ use core::str::FromStr;
 
 use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 use super::{
     build::{BuildInMessage, NameCompressor},
     parse::{ParseMessageBytes, SplitMessageBytes},
@@ -457,6 +460,42 @@ impl fmt::Display for CharStrParseError {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a CharStr {
+    /// Scan a character string.
+    ///
+    /// This parses the `d-word` syntax from [the specification].
+    ///
+    /// [the specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let start = buffer.len();
+        match scanner.scan_token(buffer)? {
+            Some(token) if token.len() > 255 => {
+                buffer.truncate(start);
+                Err(ScanError::Custom("overlong character string"))
+            }
+
+            Some(token) => {
+                let bytes = alloc.alloc_slice_copy(token);
+                buffer.truncate(start);
+                // SAFETY: 'token' consists of up to 255 bytes.
+                Ok(unsafe { core::mem::transmute::<&[u8], Self>(bytes) })
+            }
+
+            None => {
+                buffer.truncate(start);
+                Err(ScanError::Incomplete)
+            }
+        }
+    }
+}
+
 //============ Tests =========================================================
 
 #[cfg(test)]
@@ -483,5 +522,29 @@ mod test {
             Ok(&mut [] as &mut [u8])
         );
         assert_eq!(buffer, &bytes[..6]);
+    }
+
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        let cases = [
+            (b"hello" as &[u8], Ok(b"hello" as &[u8])),
+            (b"\"hi\"and\"bye\"" as &[u8], Ok(b"hiandbye")),
+            (b"\"\"" as &[u8], Ok(b"")),
+            (b"" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                <&CharStr>::scan(&mut scanner, &alloc, &mut buffer)
+                    .map(|c| &c.octets),
+                expected
+            );
+        }
     }
 }

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -21,6 +21,9 @@ use crate::{
     utils::dst::{UnsizedCopy, UnsizedCopyFrom},
 };
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 use super::{
     CanonicalName, Label, LabelBuf, LabelIter, LabelParseError,
     NameCompressor,
@@ -187,6 +190,26 @@ impl BuildInMessage for Name {
                 .copy_from_slice(self.as_bytes());
             Ok(end)
         }
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a Name {
+    /// Scan a domain name token.
+    ///
+    /// This parses a domain name, following the [specification].
+    ///
+    /// [specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let name = NameBuf::scan(scanner, alloc, buffer)?;
+        let bytes = alloc.alloc_slice_copy(name.as_bytes());
+        Ok(unsafe { Name::from_bytes_unchecked(bytes) })
     }
 }
 
@@ -575,6 +598,98 @@ impl NameBuf {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl Scan<'_> for NameBuf {
+    /// Scan a domain name token.
+    ///
+    /// This parses a domain name, following the [specification].
+    ///
+    /// [specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'_ bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        // Build up a 'Name'.
+        let mut this = Self::empty();
+
+        // Try parsing '@', indicating the origin name.
+        if let [b'@', b' ' | b'\t' | b'\r' | b'\n', ..] | [b'@'] =
+            scanner.remaining()
+        {
+            scanner.consume(1);
+            let origin = scanner
+                .origin()
+                .ok_or(ScanError::Custom("unknown origin name"))?;
+
+            origin
+                .build_bytes(&mut this.buffer)
+                .expect("Valid 'RevName's are at most 255 bytes");
+            this.size = origin.len() as u8;
+            return Ok(this);
+        }
+
+        loop {
+            // Parse a label and prepend it to the buffer.
+            let label = LabelBuf::scan(scanner, alloc, buffer)?;
+            if 255 - this.size < 1 + label.as_bytes().len() as u8 {
+                return Err(ScanError::Custom(
+                    "domain name exceeds 255 bytes",
+                ));
+            }
+            this.append_label(&label);
+
+            // Check if this is the end of the domain name.
+            match *scanner.remaining() {
+                [b' ' | b'\t' | b'\r' | b'\n', ..] | [] => {
+                    // This is a relative domain name.
+                    let origin = scanner
+                        .origin()
+                        .ok_or(ScanError::Custom("unknown origin name"))?;
+
+                    // Append the origin to this name.
+                    origin
+                        .build_bytes(&mut this.buffer[this.size as usize..])
+                        .map_err(|_| {
+                            ScanError::Custom(
+                                "relative domain name exceeds 255 bytes",
+                            )
+                        })?;
+                    // We exclude the root label, which gets added manually.
+                    this.size += origin.len() as u8 - 1;
+                    break;
+                }
+
+                [b'.', b' ' | b'\t' | b'\r' | b'\n', ..] | [b'.'] => {
+                    // This is an absolute domain name.
+                    scanner.consume(1);
+                    break;
+                }
+
+                [b'.', ..] => {
+                    scanner.consume(1);
+                }
+
+                _ => {
+                    return Err(ScanError::Custom(
+                        "irregular character in domain name",
+                    ));
+                }
+            }
+        }
+
+        if this.size == 0 {
+            return Err(ScanError::Incomplete);
+        }
+
+        // Add a root label and stop.
+        this.append_label(Label::ROOT);
+        Ok(this)
+    }
+}
+
 //--- Access to the underlying 'Name'
 
 impl Deref for NameBuf {
@@ -877,5 +992,63 @@ impl fmt::Display for NameParseError {
                 "a label contained an invalid escape"
             }
         })
+    }
+}
+
+//============ Unit tests ====================================================
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use std::vec::Vec;
+
+        use crate::{
+            new::base::name::RevNameBuf,
+            new::zonefile::scanner::{Scan, ScanError, Scanner},
+        };
+
+        use super::NameBuf;
+
+        let cases = [
+            (b"".as_slice(), Err(ScanError::Incomplete)),
+            (b" ".as_slice(), Err(ScanError::Incomplete)),
+            (b"a", Ok(&[b"a" as &[u8], b"org", b""] as &[&[u8]])),
+            (b"xn--hello.", Ok(&[b"xn--hello", b""])),
+            (
+                b"hello\\.world.sld",
+                Ok(&[b"hello.world", b"sld", b"org", b""]),
+            ),
+            (b"a\\046b.c.", Ok(&[b"a.b", b"c", b""])),
+            (b"a.b\\ c.d", Ok(&[b"a", b"b c", b"d", b"org", b""])),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = Vec::new();
+        for (input, expected) in cases {
+            let origin = "org".parse::<RevNameBuf>().unwrap();
+            let mut scanner = Scanner::new(input, Some(&origin));
+            let mut name_buf = None;
+            let actual = NameBuf::scan(&mut scanner, &alloc, &mut buffer)
+                .map(|name| name_buf.insert(name).labels());
+            match expected {
+                Ok(labels) => {
+                    assert!(
+                        actual.clone().is_ok_and(|actual| actual
+                            .map(|l| &l.as_bytes()[1..])
+                            .eq(labels.iter().copied())),
+                        "{actual:?} == Ok({labels:?})"
+                    );
+                }
+
+                Err(err) => {
+                    assert!(
+                        actual.clone().is_err_and(|e| e == err),
+                        "{actual:?} == Err({err:?})"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -17,6 +17,9 @@ use crate::new::base::wire::{
 };
 use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 //----------- Label ----------------------------------------------------------
 
 /// A label in a domain name.
@@ -149,6 +152,26 @@ impl BuildBytes for Label {
 
     fn built_bytes_size(&self) -> usize {
         self.0.len()
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a Label {
+    /// Scan a domain name label.
+    ///
+    /// This parses a domain name label, following the [specification].
+    ///
+    /// [specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let label = LabelBuf::scan(scanner, alloc, buffer)?;
+        let bytes = alloc.alloc_slice_copy(label.as_bytes());
+        Ok(unsafe { Label::from_bytes_unchecked(bytes) })
     }
 }
 
@@ -348,6 +371,89 @@ impl UnsizedCopyFrom for LabelBuf {
     }
 }
 
+//--- Interaction
+
+impl LabelBuf {
+    /// Append some bytes to the [`Label`].
+    ///
+    /// If the label would grow too large, [`TruncationError`] is returned.
+    #[cfg(feature = "zonefile")]
+    fn append(&mut self, bytes: &[u8]) -> Result<(), TruncationError> {
+        let len = self.data[0] as usize;
+        if len + bytes.len() > 63 {
+            return Err(TruncationError);
+        }
+
+        self.data[1 + len..][..bytes.len()].copy_from_slice(bytes);
+        self.data[0] += bytes.len() as u8;
+        Ok(())
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl Scan<'_> for LabelBuf {
+    /// Scan a domain name label.
+    ///
+    /// This parses a domain name label, following the [specification].
+    ///
+    /// [specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        _alloc: &'_ bumpalo::Bump,
+        _buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        // Try parsing a wildcard label.
+        if let [b'*', b' ' | b'\t' | b'\r' | b'\n' | b'.', ..] | [b'*'] =
+            scanner.remaining()
+        {
+            scanner.consume(1);
+            return Ok(Self::copy_from(Label::WILDCARD));
+        }
+
+        // The buffer we'll fill into.
+        let mut this = Self { data: [0u8; 64] };
+
+        // Loop through non-special chunks and special sequences.
+        loop {
+            let (chunk, first) = scanner.scan_unquoted_chunk(|&c| {
+                !c.is_ascii_alphanumeric() && !b"-_".contains(&c)
+            });
+
+            // Copy the non-special chunk into the buffer.
+            this.append(chunk).map_err(|_| {
+                ScanError::Custom("a domain label exceeded 63 bytes")
+            })?;
+
+            // Determine the nature of the special sequence.
+            match first {
+                Some(b'"') => {
+                    return Err(ScanError::Custom(
+                        "a domain label was quoted",
+                    ))
+                }
+
+                Some(b'\\') => {
+                    // An escape sequence.
+                    scanner.consume(1);
+                    this.append(&[scanner.scan_escape()?]).map_err(|_| {
+                        ScanError::Custom("a domain label exceeded 63 bytes")
+                    })?;
+                }
+
+                _ => break,
+            }
+        }
+
+        // Parse the result as a label.
+        if this.data[0] == 0 {
+            return Err(ScanError::Incomplete);
+        }
+        Ok(this)
+    }
+}
+
 //--- Parsing from DNS messages
 
 impl ParseMessageBytes<'_> for LabelBuf {
@@ -409,6 +515,22 @@ impl BuildBytes for LabelBuf {
 
     fn built_bytes_size(&self) -> usize {
         (**self).built_bytes_size()
+    }
+}
+
+//--- Formatting
+
+impl fmt::Display for LabelBuf {
+    /// Print a label.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl fmt::Debug for LabelBuf {
+    /// Print a label for debugging purposes.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
     }
 }
 
@@ -813,5 +935,45 @@ impl fmt::Display for LabelParseError {
             Self::PartialEscape => "the label contained an incomplete escape",
             Self::InvalidEscape => "the label contained an invalid escape",
         })
+    }
+}
+
+//============ Unit tests ====================================================
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::LabelBuf;
+
+        let cases = [
+            (b"" as &[u8], Err(ScanError::Incomplete)),
+            (b"a", Ok(b"a" as &[u8])),
+            (b"xn--hello", Ok(b"xn--hello")),
+            (b"a\\010b", Ok(b"a\nb")),
+            (b"a\\000", Ok(b"a\0")),
+            (b"a\\", Err(ScanError::IncompleteEscape)),
+            (b"a\\00", Err(ScanError::IncompleteEscape)),
+            (b"a\\256", Err(ScanError::InvalidDecimalEscape)),
+            (b"\\065", Ok(b"A")),
+            (b"a ", Ok(b"a")),
+            (
+                b"\"hello\"",
+                Err(ScanError::Custom("a domain label was quoted")),
+            ),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            let mut label_buf = None;
+            let actual = LabelBuf::scan(&mut scanner, &alloc, &mut buffer)
+                .map(|label| &label_buf.insert(label).as_bytes()[1..]);
+            assert_eq!(actual, expected, "input {:?}", input);
+        }
     }
 }

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -20,6 +20,11 @@ use crate::{
     utils::dst::{UnsizedCopy, UnsizedCopyFrom},
 };
 
+#[cfg(feature = "zonefile")]
+use crate::new::base::name::LabelBuf;
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 use super::{LabelIter, NameBuf, NameParseError};
 
 //----------- RevName --------------------------------------------------------
@@ -178,6 +183,26 @@ impl BuildBytes for RevName {
 
     fn built_bytes_size(&self) -> usize {
         self.len()
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a RevName {
+    /// Scan a domain name token.
+    ///
+    /// This parses a domain name, following the [specification].
+    ///
+    /// [specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let name = RevNameBuf::scan(scanner, alloc, buffer)?;
+        let bytes = alloc.alloc_slice_copy(name.as_bytes());
+        Ok(unsafe { RevName::from_bytes_unchecked(bytes) })
     }
 }
 
@@ -534,6 +559,91 @@ impl From<RevNameBuf> for NameBuf {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl Scan<'_> for RevNameBuf {
+    /// Scan a domain name token.
+    ///
+    /// This parses a domain name, following the [specification].
+    ///
+    /// [specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'_ bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        // Try parsing '@', indicating the origin name.
+        if let [b'@', b' ' | b'\t' | b'\r' | b'\n', ..] | [b'@'] =
+            scanner.remaining()
+        {
+            scanner.consume(1);
+            let origin = scanner
+                .origin()
+                .ok_or(ScanError::Custom("unknown origin name"))?;
+            return Ok(RevNameBuf::copy_from(origin));
+        }
+
+        // Build up a 'RevName'.
+        let mut this = Self::empty();
+
+        loop {
+            // Parse a label and prepend it to the buffer.
+            let label = LabelBuf::scan(scanner, alloc, buffer)?;
+            if this.offset < 1 + label.as_bytes().len() as u8 {
+                return Err(ScanError::Custom(
+                    "domain name exceeds 255 bytes",
+                ));
+            }
+            this.prepend_bytes(label.as_bytes());
+
+            // Check if this is the end of the domain name.
+            match *scanner.remaining() {
+                [b' ' | b'\t' | b'\r' | b'\n', ..] | [] => {
+                    // This is a relative domain name.
+                    let origin = scanner
+                        .origin()
+                        .ok_or(ScanError::Custom("unknown origin name"))?;
+                    if this.offset < origin.len() as u8 {
+                        return Err(ScanError::Custom(
+                            "relative domain name exceeds 255 bytes",
+                        ));
+                    }
+
+                    // Prepend the origin to this name.
+                    this.prepend_bytes(&origin.as_bytes()[1..]);
+                    break;
+                }
+
+                [b'.', b' ' | b'\t' | b'\r' | b'\n', ..] | [b'.'] => {
+                    // This is an absolute domain name.
+                    scanner.consume(1);
+                    break;
+                }
+
+                [b'.', ..] => {
+                    scanner.consume(1);
+                }
+
+                _ => {
+                    return Err(ScanError::Custom(
+                        "irregular character in domain name",
+                    ));
+                }
+            }
+        }
+
+        if this.offset == 255 {
+            return Err(ScanError::Incomplete);
+        }
+
+        // Add a root label and stop.
+        this.offset -= 1;
+        this.buffer[this.offset as usize] = 0;
+        Ok(this)
+    }
+}
+
 //--- Access to the underlying 'RevName'
 
 impl Deref for RevNameBuf {
@@ -664,5 +774,60 @@ impl<'a> serde::Deserialize<'a> for std::boxed::Box<RevName> {
     {
         RevNameBuf::deserialize(deserializer)
             .map(|this| this.unsized_copy_into())
+    }
+}
+
+//============ Unit tests ====================================================
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use std::vec::Vec;
+
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::RevNameBuf;
+
+        let cases = [
+            (b"".as_slice(), Err(ScanError::Incomplete)),
+            (b" ".as_slice(), Err(ScanError::Incomplete)),
+            (b"a", Ok(&[b"" as &[u8], b"org", b"a"] as &[&[u8]])),
+            (b"xn--hello.", Ok(&[b"", b"xn--hello"])),
+            (
+                b"hello\\.world.sld",
+                Ok(&[b"", b"org", b"sld", b"hello.world"]),
+            ),
+            (b"a\\046b.c.", Ok(&[b"", b"c", b"a.b"])),
+            (b"a.b\\ c.d", Ok(&[b"", b"org", b"d", b"b c", b"a"])),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = Vec::new();
+        for (input, expected) in cases {
+            let origin = "org".parse::<RevNameBuf>().unwrap();
+            let mut scanner = Scanner::new(input, Some(&origin));
+            let mut name_buf = None;
+            let actual = RevNameBuf::scan(&mut scanner, &alloc, &mut buffer)
+                .map(|name| name_buf.insert(name).labels());
+            match expected {
+                Ok(labels) => {
+                    assert!(
+                        actual.clone().is_ok_and(|actual| actual
+                            .map(|l| &l.as_bytes()[1..])
+                            .eq(labels.iter().copied())),
+                        "{actual:?} == Ok({labels:?})"
+                    );
+                }
+
+                Err(err) => {
+                    assert!(
+                        actual.clone().is_err_and(|e| e == err),
+                        "{actual:?} == Err({err:?})"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -314,6 +314,9 @@ impl RType {
     /// The type of an [`Aaaa`](crate::new::rdata::Aaaa) record.
     pub const AAAA: Self = Self::new(28);
 
+    /// The type of an `Srv` record.
+    pub const SRV: Self = Self::new(33);
+
     /// The type of a [`DName`](crate::new::rdata::DName) record.
     pub const DNAME: Self = Self::new(39);
 
@@ -379,7 +382,7 @@ impl RType {
     /// - `NXT` (obsolete)
     /// - `NAPTR`
     /// - `KX`
-    /// - `SRV`
+    /// - [`SRV`](RType::SRV)
     /// - [`DNAME`](RType::DNAME)
     /// - `A6` (obsolete)
     /// - [`RRSIG`](RType::RRSIG)
@@ -396,6 +399,7 @@ impl RType {
                 | Self::PTR
                 | Self::MX
                 | Self::RP
+                | Self::SRV
                 | Self::DNAME
                 | Self::RRSIG
         )
@@ -433,6 +437,7 @@ impl fmt::Debug for RType {
             Self::TXT => "RType::TXT",
             Self::RP => "RType::RP",
             Self::AAAA => "RType::AAAA",
+            Self::SRV => "RType::SRV",
             Self::DNAME => "RType::DNAME",
             Self::OPT => "RType::OPT",
             Self::DS => "RType::DS",
@@ -469,6 +474,7 @@ impl Scan<'_> for RType {
             "MX" => Ok(Self::MX),
             "TXT" => Ok(Self::TXT),
             "AAAA" => Ok(Self::AAAA),
+            "SRV" => Ok(Self::SRV),
             "DNAME" => Ok(Self::DNAME),
             "OPT" => Ok(Self::OPT),
             "DS" => Ok(Self::DS),
@@ -825,7 +831,7 @@ impl Clone for alloc::boxed::Box<UnparsedRecordData> {
 
 #[cfg(test)]
 mod test {
-    use super::{RClass, RType, Record, TTL, UnparsedRecordData};
+    use super::{RClass, RType, Record, UnparsedRecordData, TTL};
 
     use crate::new::base::{
         name::Name,

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -464,33 +464,46 @@ impl Scan<'_> for RType {
         _alloc: &'_ bumpalo::Bump,
         _buffer: &mut std::vec::Vec<u8>,
     ) -> Result<Self, ScanError> {
-        match scanner.scan_plain_token()? {
-            "A" => Ok(Self::A),
-            "NS" => Ok(Self::NS),
-            "CNAME" => Ok(Self::CNAME),
-            "SOA" => Ok(Self::SOA),
-            "PTR" => Ok(Self::PTR),
-            "HINFO" => Ok(Self::HINFO),
-            "MX" => Ok(Self::MX),
-            "TXT" => Ok(Self::TXT),
-            "AAAA" => Ok(Self::AAAA),
-            "SRV" => Ok(Self::SRV),
-            "DNAME" => Ok(Self::DNAME),
-            "OPT" => Ok(Self::OPT),
-            "DS" => Ok(Self::DS),
-            "RRSIG" => Ok(Self::RRSIG),
-            "NSEC" => Ok(Self::NSEC),
-            "DNSKEY" => Ok(Self::DNSKEY),
-            "NSEC3" => Ok(Self::NSEC3),
-            "NSEC3PARAM" => Ok(Self::NSEC3PARAM),
+        let types = [
+            ("A", Self::A),
+            ("NS", Self::NS),
+            ("CNAME", Self::CNAME),
+            ("SOA", Self::SOA),
+            ("PTR", Self::PTR),
+            ("HINFO", Self::HINFO),
+            ("MX", Self::MX),
+            ("TXT", Self::TXT),
+            ("AAAA", Self::AAAA),
+            ("SRV", Self::SRV),
+            ("DNAME", Self::DNAME),
+            ("OPT", Self::OPT),
+            ("DS", Self::DS),
+            ("RRSIG", Self::RRSIG),
+            ("NSEC", Self::NSEC),
+            ("DNSKEY", Self::DNSKEY),
+            ("NSEC3", Self::NSEC3),
+            ("NSEC3PARAM", Self::NSEC3PARAM),
+        ];
 
-            rtype if rtype.starts_with("TYPE") => rtype[4..]
+        let token = scanner.scan_plain_token()?;
+
+        for candidate in types {
+            if token.eq_ignore_ascii_case(candidate.0) {
+                return Ok(candidate.1);
+            }
+        }
+
+        if token
+            .get(..4)
+            .is_some_and(|t| t.eq_ignore_ascii_case("TYPE"))
+        {
+            return token[4..]
                 .parse::<u16>()
                 .map_err(|_| ScanError::Custom("invalid record type value"))
-                .map(Self::from),
-
-            _ => Err(ScanError::Custom("unrecognized record type")),
+                .map(Self::from);
         }
+
+        Err(ScanError::Custom("unrecognized record type"))
     }
 }
 
@@ -557,17 +570,27 @@ impl Scan<'_> for RClass {
         _alloc: &'_ bumpalo::Bump,
         _buffer: &mut std::vec::Vec<u8>,
     ) -> Result<Self, ScanError> {
-        match scanner.scan_plain_token()? {
-            "IN" => Ok(Self::IN),
-            "CH" => Ok(Self::CH),
+        let classes = [("IN", Self::IN), ("CH", Self::CH)];
 
-            class if class.starts_with("CLASS") => class[5..]
+        let token = scanner.scan_plain_token()?;
+
+        for candidate in classes {
+            if token.eq_ignore_ascii_case(candidate.0) {
+                return Ok(candidate.1);
+            }
+        }
+
+        if token
+            .get(..5)
+            .is_some_and(|t| t.eq_ignore_ascii_case("CLASS"))
+        {
+            return token[5..]
                 .parse::<u16>()
                 .map_err(|_| ScanError::Custom("invalid record class value"))
-                .map(Self::new),
-
-            _ => Err(ScanError::Custom("unrecognized record class")),
+                .map(Self::new);
         }
+
+        Err(ScanError::Custom("unrecognized record class"))
     }
 }
 

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -4,6 +4,9 @@ use core::{borrow::Borrow, cmp::Ordering, fmt, ops::Deref};
 
 use crate::utils::dst::UnsizedCopy;
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 use super::build::{BuildInMessage, NameCompressor};
 use super::parse::{ParseMessageBytes, SplitMessageBytes};
 use super::wire::{
@@ -447,6 +450,44 @@ impl fmt::Debug for RType {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl Scan<'_> for RType {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        _alloc: &'_ bumpalo::Bump,
+        _buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        match scanner.scan_plain_token()? {
+            "A" => Ok(Self::A),
+            "NS" => Ok(Self::NS),
+            "CNAME" => Ok(Self::CNAME),
+            "SOA" => Ok(Self::SOA),
+            "PTR" => Ok(Self::PTR),
+            "HINFO" => Ok(Self::HINFO),
+            "MX" => Ok(Self::MX),
+            "TXT" => Ok(Self::TXT),
+            "AAAA" => Ok(Self::AAAA),
+            "DNAME" => Ok(Self::DNAME),
+            "OPT" => Ok(Self::OPT),
+            "DS" => Ok(Self::DS),
+            "RRSIG" => Ok(Self::RRSIG),
+            "NSEC" => Ok(Self::NSEC),
+            "DNSKEY" => Ok(Self::DNSKEY),
+            "NSEC3" => Ok(Self::NSEC3),
+            "NSEC3PARAM" => Ok(Self::NSEC3PARAM),
+
+            rtype if rtype.starts_with("TYPE") => rtype[4..]
+                .parse::<u16>()
+                .map_err(|_| ScanError::Custom("invalid record type value"))
+                .map(Self::from),
+
+            _ => Err(ScanError::Custom("unrecognized record type")),
+        }
+    }
+}
+
 //----------- RClass ---------------------------------------------------------
 
 /// The class of a record.
@@ -501,6 +542,29 @@ impl fmt::Debug for RClass {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl Scan<'_> for RClass {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        _alloc: &'_ bumpalo::Bump,
+        _buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        match scanner.scan_plain_token()? {
+            "IN" => Ok(Self::IN),
+            "CH" => Ok(Self::CH),
+
+            class if class.starts_with("CLASS") => class[5..]
+                .parse::<u16>()
+                .map_err(|_| ScanError::Custom("invalid record class value"))
+                .map(Self::new),
+
+            _ => Err(ScanError::Custom("unrecognized record class")),
+        }
+    }
+}
+
 //----------- TTL ------------------------------------------------------------
 
 /// How long a record can be cached.
@@ -547,6 +611,37 @@ impl From<TTL> for u32 {
 impl fmt::Debug for TTL {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "TTL({})", self.value)
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl Scan<'_> for TTL {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        _alloc: &'_ bumpalo::Bump,
+        _buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        use core::num::IntErrorKind;
+
+        scanner
+            .scan_plain_token()?
+            .parse::<u32>()
+            .map_err(|err| {
+                ScanError::Custom(match err.kind() {
+                    IntErrorKind::PosOverflow => {
+                        "specified TTL will overflow"
+                    }
+                    IntErrorKind::InvalidDigit => {
+                        "TTLs can only contain digits"
+                    }
+                    IntErrorKind::NegOverflow => "TTLs must be non-negative",
+                    // We have already checked for other kinds of errors.
+                    _ => unreachable!(),
+                })
+            })
+            .map(Self::from)
     }
 }
 
@@ -757,5 +852,81 @@ mod test {
         let mut buffer = [0u8; 15];
         assert_eq!(record.build_bytes(&mut buffer), Ok(&mut [] as &mut [u8]));
         assert_eq!(buffer, &bytes[..15]);
+    }
+
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan_rtype() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        let cases = [
+            (b"A" as &[u8], Ok(RType::A)),
+            (b"TYPE1", Ok(RType::A)),
+            (b"TXT", Ok(RType::TXT)),
+            (
+                b"TYPE65536",
+                Err(ScanError::Custom("invalid record type value")),
+            ),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                RType::scan(&mut scanner, &alloc, &mut buffer),
+                expected
+            );
+        }
+    }
+
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan_rclass() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        let cases = [
+            (b"IN" as &[u8], Ok(RClass::IN)),
+            (b"CLASS1", Ok(RClass::IN)),
+            (
+                b"CLASS65536",
+                Err(ScanError::Custom("invalid record class value")),
+            ),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                RClass::scan(&mut scanner, &alloc, &mut buffer),
+                expected
+            );
+        }
+    }
+
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan_ttl() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        let cases = [
+            (b"0" as &[u8], Ok(TTL::from(0))),
+            (b"65536", Ok(TTL::from(65536))),
+            (
+                b"42W",
+                Err(ScanError::Custom("TTLs can only contain digits")),
+            ),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                TTL::scan(&mut scanner, &alloc, &mut buffer),
+                expected
+            );
+        }
     }
 }

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -64,3 +64,4 @@
 pub mod base;
 pub mod edns;
 pub mod rdata;
+pub mod zonefile;

--- a/src/new/rdata/basic/hinfo.rs
+++ b/src/new/rdata/basic/hinfo.rs
@@ -14,6 +14,9 @@ use crate::new::base::{
     RType,
 };
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 //----------- HInfo ----------------------------------------------------------
 
 /// Information about the host computer.
@@ -232,6 +235,66 @@ impl<'a> ParseRecordDataBytes<'a> for HInfo<'a> {
         match rtype {
             RType::HINFO => Self::parse_bytes(bytes),
             _ => Err(ParseError),
+        }
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for HInfo<'a> {
+    /// Scan the data for an HINFO record.
+    ///
+    /// This parses the following syntax:
+    ///
+    /// ```text
+    /// rdata-hinfo = char-str ws+ char-str ws*
+    /// ```
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let cpu = <&CharStr>::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let os = <&CharStr>::scan(scanner, alloc, buffer)?;
+
+        scanner.skip_ws();
+        if scanner.is_empty() {
+            Ok(Self { cpu, os })
+        } else {
+            Err(ScanError::Custom("unexpected data at end of HINFO record"))
+        }
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::HInfo;
+
+        let cases = [
+            (b"cpu os" as &[u8], Ok((b"cpu" as &[u8], b"os" as &[u8]))),
+            (b"cpu" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                <HInfo<'_>>::scan(&mut scanner, &alloc, &mut buffer)
+                    .map(|hinfo| (&hinfo.cpu.octets, &hinfo.os.octets)),
+                expected
+            );
         }
     }
 }

--- a/src/new/rdata/basic/ptr.rs
+++ b/src/new/rdata/basic/ptr.rs
@@ -10,6 +10,9 @@ use crate::new::base::{
     CanonicalRecordData, ParseRecordData, ParseRecordDataBytes, RType,
 };
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 //----------- Ptr ------------------------------------------------------------
 
 /// A pointer to another domain name.
@@ -188,6 +191,67 @@ impl<'a, N: ParseBytes<'a>> ParseRecordDataBytes<'a> for Ptr<N> {
         match rtype {
             RType::PTR => Self::parse_bytes(bytes),
             _ => Err(ParseError),
+        }
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a, N: Scan<'a>> Scan<'a> for Ptr<N> {
+    /// Scan the data for a PTR record.
+    ///
+    /// This parses the following syntax:
+    ///
+    /// ```text
+    /// rdata-ptr = name ws*
+    /// ```
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let name = N::scan(scanner, alloc, buffer)?;
+
+        scanner.skip_ws();
+        if scanner.is_empty() {
+            Ok(Self { name })
+        } else {
+            Err(ScanError::Custom("unexpected data at end of PTR record"))
+        }
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::base::name::RevNameBuf;
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::Ptr;
+
+        let cases = [
+            (
+                b"example.org." as &[u8],
+                Ok(b"\x00\x03org\x07example" as &[u8]),
+            ),
+            (b"", Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            let mut tmp = None;
+            assert_eq!(
+                <Ptr<RevNameBuf>>::scan(&mut scanner, &alloc, &mut buffer)
+                    .map(|s| tmp.insert(s.name).as_bytes()),
+                expected
+            );
         }
     }
 }

--- a/src/new/rdata/basic/soa.rs
+++ b/src/new/rdata/basic/soa.rs
@@ -10,6 +10,9 @@ use crate::new::base::{
     Serial, wire::*,
 };
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 //----------- Soa ------------------------------------------------------------
 
 /// The start of a zone of authority.
@@ -354,6 +357,117 @@ impl<'a, N: SplitBytes<'a>> ParseRecordDataBytes<'a> for Soa<N> {
         match rtype {
             RType::SOA => Self::parse_bytes(bytes),
             _ => Err(ParseError),
+        }
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a, N: Scan<'a>> Scan<'a> for Soa<N> {
+    /// Scan the data for a SOA record.
+    ///
+    /// This parses the following syntax:
+    ///
+    /// ```text
+    /// rdata-soa = name ws+ name ws+ u32 ws+ u32 ws+ u32 ws+ u32 ws+ u32 ws*
+    /// # An unsigned 32-bit integer.
+    /// u32 = [0-9]+
+    /// ```
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let mname = N::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let rname = N::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let serial = Serial::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let refresh = u32::scan(scanner, alloc, buffer)?.into();
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let retry = u32::scan(scanner, alloc, buffer)?.into();
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let expire = u32::scan(scanner, alloc, buffer)?.into();
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let minimum = u32::scan(scanner, alloc, buffer)?.into();
+
+        scanner.skip_ws();
+        if scanner.is_empty() {
+            Ok(Self {
+                rname,
+                mname,
+                serial,
+                refresh,
+                retry,
+                expire,
+                minimum,
+            })
+        } else {
+            Err(ScanError::Custom("unexpected data at end of SOA record"))
+        }
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::base::{name::RevNameBuf, wire::U32, Serial};
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::Soa;
+
+        let cases = [
+            (
+                b"VENERA Action.domains 20 7200 600 3600000 60" as &[u8],
+                Ok((
+                    "VENERA.com",
+                    "Action.domains.com",
+                    20,
+                    7200,
+                    600,
+                    3600000,
+                    60,
+                )),
+            ),
+            (b"VENERA" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let origin = "com".parse::<RevNameBuf>().unwrap();
+            let mut scanner = Scanner::new(input, Some(&origin));
+            let expected = expected.map(|expected| Soa::<RevNameBuf> {
+                mname: expected.0.parse().unwrap(),
+                rname: expected.1.parse().unwrap(),
+                serial: Serial::from(expected.2),
+                refresh: U32::new(expected.3),
+                retry: U32::new(expected.4),
+                expire: U32::new(expected.5),
+                minimum: U32::new(expected.6),
+            });
+            assert_eq!(
+                <Soa<RevNameBuf>>::scan(&mut scanner, &alloc, &mut buffer),
+                expected
+            );
         }
     }
 }

--- a/src/new/rdata/basic/txt.rs
+++ b/src/new/rdata/basic/txt.rs
@@ -11,6 +11,9 @@ use crate::new::base::{
 };
 use crate::utils::dst::UnsizedCopy;
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 //----------- Txt ------------------------------------------------------------
 
 /// Free-form text strings about this domain.
@@ -255,6 +258,107 @@ impl<'a> ParseRecordDataBytes<'a> for &'a Txt {
         match rtype {
             RType::TXT => Self::parse_bytes(bytes),
             _ => Err(ParseError),
+        }
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a Txt {
+    /// Scan the data for a TXT record.
+    ///
+    /// This parses the following syntax:
+    ///
+    /// ```text
+    /// rdata-txt = char-str (ws+ char-str)* ws*
+    /// ```
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let start = buffer.len();
+
+        loop {
+            if start < buffer.len() && !scanner.skip_ws() {
+                break;
+            }
+
+            let cur = buffer.len();
+            buffer.push(0u8);
+            match scanner.scan_token(buffer)? {
+                Some(token) if token.len() > 255 => {
+                    buffer.truncate(start);
+                    return Err(ScanError::Custom(
+                        "overlong character string",
+                    ));
+                }
+
+                Some(token) => {
+                    buffer[cur] = token.len() as u8;
+                    if buffer.len() - start >= 65536 {
+                        return Err(ScanError::Custom(
+                            "TXT record has overflowed 64K bytes",
+                        ));
+                    }
+                }
+
+                None => {
+                    buffer.truncate(cur);
+                    break;
+                }
+            }
+        }
+
+        if start < buffer.len() && scanner.is_empty() {
+            let bytes = alloc.alloc_slice_copy(&buffer[start..]);
+            buffer.truncate(start);
+            // SAFETY: 'buffer' contains a sequence of character strings.
+            Ok(unsafe { core::mem::transmute::<&[u8], Self>(bytes) })
+        } else if start == buffer.len() {
+            Err(ScanError::Incomplete)
+        } else {
+            Err(ScanError::Custom("unexpected data at end of TXT record"))
+        }
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::Txt;
+
+        let cases = [
+            (b"a b" as &[u8], Ok(&[b"a" as &[u8], b"b"] as &[_])),
+            (b"a \"b c\" d", Ok(&[b"a" as &[u8], b"b c", b"d"])),
+            (b"" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            let result = <&Txt>::scan(&mut scanner, &alloc, &mut buffer);
+            assert!(
+                result.as_ref().err() == expected.as_ref().err(),
+                "{result:?} == {expected:?}"
+            );
+            if let (Ok(result), Ok(expected)) = (result, expected) {
+                assert!(
+                    result
+                        .iter()
+                        .map(|s| &s.octets)
+                        .eq(expected.iter().copied()),
+                    "{result:?} == {expected:?}"
+                );
+            }
         }
     }
 }

--- a/src/new/rdata/dnssec/dnskey.rs
+++ b/src/new/rdata/dnssec/dnskey.rs
@@ -19,6 +19,12 @@ use crate::{
     utils::dst::UnsizedCopy,
 };
 
+#[cfg(feature = "zonefile")]
+use crate::utils::decoding::Base64Dec;
+
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 use super::SecAlg;
 
 //----------- DNSKey ---------------------------------------------------------
@@ -64,6 +70,57 @@ impl BuildInMessage for DNSKey {
             .ok_or(TruncationError)?
             .copy_from_slice(bytes);
         Ok(end)
+    }
+}
+
+//--- Scanning from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a DNSKey {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let flags = DNSKeyFlags::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let protocol = u8::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let algorithm = SecAlg::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+
+        let start = buffer.len();
+        buffer.extend_from_slice(flags.as_bytes());
+        buffer.extend_from_slice(protocol.as_bytes());
+        buffer.extend_from_slice(algorithm.as_bytes());
+
+        let mut decoder = Base64Dec::new();
+        while !scanner.is_empty() {
+            let token = scanner.scan_plain_token()?;
+            scanner.skip_ws();
+
+            decoder.decode_to_vec(token.as_bytes(), buffer).map_err(
+                |_| ScanError::Custom("invalid Base64 in DNSKEY material"),
+            )?;
+        }
+        decoder.finish(&mut [], false).map_err(|_| {
+            ScanError::Custom(
+                "partial block in Base64-encoded DNSKEY material",
+            )
+        })?;
+
+        let record = alloc.alloc_slice_copy(&buffer[start..]);
+        let record = DNSKey::parse_bytes_by_ref(record)
+            .expect("A valid 'DNSKey' has been built");
+        buffer.truncate(start);
+
+        Ok(record)
     }
 }
 
@@ -160,6 +217,22 @@ impl DNSKeyFlags {
     }
 }
 
+//--- Conversion to and from 'u16'
+
+impl From<u16> for DNSKeyFlags {
+    fn from(value: u16) -> Self {
+        Self {
+            inner: U16::new(value),
+        }
+    }
+}
+
+impl From<DNSKeyFlags> for u16 {
+    fn from(value: DNSKeyFlags) -> Self {
+        value.inner.get()
+    }
+}
+
 //--- Formatting
 
 impl fmt::Debug for DNSKeyFlags {
@@ -169,5 +242,76 @@ impl fmt::Debug for DNSKeyFlags {
             .field("secure_entry_point", &self.is_secure_entry_point())
             .field("bits", &self.bits())
             .finish()
+    }
+}
+
+//--- Scanning from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for DNSKeyFlags {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        _alloc: &'a bumpalo::Bump,
+        _buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        use core::num::IntErrorKind;
+
+        scanner
+            .scan_plain_token()?
+            .parse::<u16>()
+            .map_err(|err| {
+                ScanError::Custom(match err.kind() {
+                    IntErrorKind::PosOverflow | IntErrorKind::NegOverflow => {
+                        "invalid NSEC3 flags number"
+                    }
+                    IntErrorKind::InvalidDigit => {
+                        "NSEC3 flags must be a number"
+                    }
+                    // We have already checked for other kinds of errors.
+                    _ => unreachable!(),
+                })
+            })
+            .map(Self::from)
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::DNSKey;
+
+        let cases = [
+            (
+                b"256 3 5 AQPSKmynfzW4kyBv015MUG2DeIQ3" as &[u8],
+                Ok((
+                    256,
+                    3,
+                    5,
+                    b"\x01\x03\xD2\x2A\x6C\xA7\x7F\x35\xB8\x93\x20\x6F\xD3\x5E\x4C\x50\x6D\x83\x78\x84\x37" as &[u8],
+                )),
+            ),
+            (b"256" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                <&DNSKey>::scan(&mut scanner, &alloc, &mut buffer).map(|r| (
+                    r.flags.into(),
+                    r.protocol,
+                    r.algorithm.into(),
+                    &r.key,
+                )),
+                expected
+            );
+        }
     }
 }

--- a/src/new/rdata/dnssec/ds.rs
+++ b/src/new/rdata/dnssec/ds.rs
@@ -11,6 +11,12 @@ use crate::new::base::build::{
 };
 use crate::new::base::wire::{AsBytes, U16};
 
+#[cfg(feature = "zonefile")]
+use crate::{new::base::wire::ParseBytesZC, utils::decoding::Base16Dec};
+
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 use super::SecAlg;
 
 //----------- Ds -------------------------------------------------------------
@@ -78,6 +84,56 @@ impl Hash for Ds {
     }
 }
 
+//--- Scanning from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a Ds {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let keytag = u16::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let algorithm = SecAlg::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let digest_type = DigestType::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+
+        // Decode the digest from Base16 words.
+        let start = buffer.len();
+        let mut decoder = Base16Dec::new();
+        while !scanner.is_empty() {
+            let token = scanner.scan_plain_token()?;
+            scanner.skip_ws();
+
+            decoder
+                .decode_to_vec(token.as_bytes(), buffer)
+                .map_err(|_| ScanError::Custom("invalid Base16 in digest"))?;
+        }
+        decoder.finish().map_err(|_| {
+            ScanError::Custom("partial byte in Base16-encoded digest")
+        })?;
+
+        // Allocate the record.
+        let record =
+            alloc.alloc_slice_fill_copy(4 + buffer.len() - start, 0u8);
+        record[0..2].copy_from_slice(&keytag.to_be_bytes());
+        record[2] = algorithm.into();
+        record[3] = digest_type.into();
+        record[4..].copy_from_slice(&buffer[start..]);
+
+        buffer.truncate(start);
+        Ok(Ds::parse_bytes_by_ref(record).unwrap())
+    }
+}
+
 //----------- DigestType -----------------------------------------------------
 
 /// A cryptographic digest algorithm.
@@ -110,6 +166,20 @@ impl DigestType {
     pub const SHA1: Self = Self { code: 1 };
 }
 
+//--- Conversion to and from 'u8'
+
+impl From<u8> for DigestType {
+    fn from(value: u8) -> Self {
+        Self { code: value }
+    }
+}
+
+impl From<DigestType> for u8 {
+    fn from(value: DigestType) -> Self {
+        value.code
+    }
+}
+
 //--- Formatting
 
 impl fmt::Debug for DigestType {
@@ -118,5 +188,76 @@ impl fmt::Debug for DigestType {
             Self::SHA1 => "DigestType::SHA1",
             _ => return write!(f, "DigestType({})", self.code),
         })
+    }
+}
+
+//--- Scanning from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for DigestType {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        _alloc: &'a bumpalo::Bump,
+        _buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        use core::num::IntErrorKind;
+
+        scanner
+            .scan_plain_token()?
+            .parse::<u8>()
+            .map_err(|err| {
+                ScanError::Custom(match err.kind() {
+                    IntErrorKind::PosOverflow | IntErrorKind::NegOverflow => {
+                        "invalid digest algorithm number"
+                    }
+                    IntErrorKind::InvalidDigit => {
+                        "digest algorithm must be a number"
+                    }
+                    // We have already checked for other kinds of errors.
+                    _ => unreachable!(),
+                })
+            })
+            .map(Self::from)
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::Ds;
+
+        let cases = [
+            (
+                b"60485 5 1 2BB183AF5F22588179A53B0A 98631FAD1A292118" as &[u8],
+                Ok((
+                    60485,
+                    5,
+                    1,
+                    b"\x2B\xB1\x83\xAF\x5F\x22\x58\x81\x79\xA5\x3B\x0A\x98\x63\x1F\xAD\x1A\x29\x21\x18" as &[u8],
+                )),
+            ),
+            (b"60000" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                <&Ds>::scan(&mut scanner, &alloc, &mut buffer).map(|ds| (
+                    ds.keytag.get(),
+                    ds.algorithm.into(),
+                    ds.digest_type.into(),
+                    &ds.digest
+                )),
+                expected
+            );
+        }
     }
 }

--- a/src/new/rdata/dnssec/nsec.rs
+++ b/src/new/rdata/dnssec/nsec.rs
@@ -1,6 +1,8 @@
 //! The NSEC record data type.
 
 use core::hash::{Hash, Hasher};
+use core::iter::FusedIterator;
+use core::ops::Range;
 use core::{cmp::Ordering, fmt};
 
 use crate::new::base::build::BuildInMessage;
@@ -8,6 +10,9 @@ use crate::new::base::name::{CanonicalName, Name, NameCompressor};
 use crate::new::base::wire::*;
 use crate::new::base::{CanonicalRecordData, RType};
 use crate::utils::dst::UnsizedCopy;
+
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
 
 //----------- NSec -----------------------------------------------------------
 
@@ -75,6 +80,30 @@ impl<'a> ParseBytes<'a> for NSec<'a> {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for NSec<'a> {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let next = <&'a Name>::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let types = <&'a TypeBitmaps>::scan(scanner, alloc, buffer)?;
+
+        scanner.skip_ws();
+        if scanner.is_empty() {
+            Ok(Self { next, types })
+        } else {
+            Err(ScanError::Custom("unexpected data at end of SOA record"))
+        }
+    }
+}
+
 //----------- TypeBitmaps ----------------------------------------------------
 
 /// A bitmap of DNS record types.
@@ -89,26 +118,80 @@ pub struct TypeBitmaps {
 
 impl TypeBitmaps {
     /// The types in this bitmap.
-    pub fn types(&self) -> impl Iterator<Item = RType> + '_ {
-        fn split_window(octets: &[u8]) -> Option<(u8, &[u8], &[u8])> {
-            let &[num, len, ref rest @ ..] = octets else {
-                return None;
-            };
+    pub fn iter(&self) -> impl Iterator<Item = RType> + Clone + '_ {
+        self.into_iter()
+    }
+}
 
-            let (bits, rest) = rest.split_at(len as usize);
-            Some((num, bits, rest))
+//--- Iteration
+
+impl<'a> IntoIterator for &'a TypeBitmaps {
+    type Item = RType;
+    type IntoIter = TypeBitmapsIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        TypeBitmapsIter {
+            source: self,
+            block: self.octets[0],
+            offset: 2,
+            bits: 0..(self.octets[1] as usize * 8),
+        }
+    }
+}
+
+/// An iterator over the types in a [`TypeBitmapsIter`].
+#[derive(Clone)]
+pub struct TypeBitmapsIter<'a> {
+    /// The original bitmaps.
+    source: &'a TypeBitmaps,
+
+    /// The high bits of the current block.
+    block: u8,
+
+    /// The offset of the current block.
+    offset: usize,
+
+    /// The bits being tested in this block.
+    bits: Range<usize>,
+}
+
+impl Iterator for TypeBitmapsIter<'_> {
+    type Item = RType;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Loop:
+        // - 0 times: if there are no blocks left.
+        // - 1 time:  if there is another bit set in the current block.
+        // - 1 time:  if the current block is empty and is the last one.
+        // - 2 times: if the current block is empty but another block exists.
+        while self.offset < self.source.octets.len() {
+            let octets = &self.source.octets[self.offset..];
+
+            // Look for another bit within the current block.
+            for pos in &mut self.bits {
+                if (octets[pos / 8] & (1u8 << (pos % 8))) != 0 {
+                    let value = u16::from_be_bytes([self.block, pos as u8]);
+                    return Some(value.into());
+                }
+            }
+
+            // Move to the next block, if any.
+            self.offset += self.bits.end / 8;
+            self.block = *self.source.octets.get(self.offset)?;
+            let size = self.source.octets[self.offset + 1];
+            self.bits = 0..(size as usize * 8);
+            self.offset += 2;
         }
 
-        core::iter::successors(split_window(&self.octets), |(_, _, rest)| {
-            split_window(rest)
-        })
-        .flat_map(move |(num, bits, _)| {
-            bits.iter().enumerate().flat_map(move |(i, &b)| {
-                (0..8).filter(move |&j| ((b >> j) & 1) != 0).map(move |j| {
-                    RType::from(u16::from_be_bytes([num, (i * 8 + j) as u8]))
-                })
-            })
-        })
+        None
+    }
+}
+
+impl FusedIterator for TypeBitmapsIter<'_> {}
+
+impl fmt::Debug for TypeBitmapsIter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.clone()).finish()
     }
 }
 
@@ -116,7 +199,7 @@ impl TypeBitmaps {
 
 impl fmt::Debug for TypeBitmaps {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_set().entries(self.types()).finish()
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 
@@ -179,6 +262,64 @@ unsafe impl ParseBytesZC for TypeBitmaps {
     }
 }
 
+//--- Scanning from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a TypeBitmaps {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        // TODO: Re-use 'buffer' here.
+        let mut rtypes = std::vec::Vec::<RType>::new();
+
+        loop {
+            rtypes.push(RType::scan(scanner, alloc, buffer)?);
+            if scanner.is_empty() {
+                break;
+            } else {
+                scanner.skip_ws();
+            }
+        }
+
+        // Sort the records.
+        rtypes.sort_unstable();
+
+        // Build the bitmap in 'buffer'.
+        let start = buffer.len();
+        let mut rtypes = rtypes.iter().copied().peekable();
+        while let Some(&first) = rtypes.peek() {
+            // This is the first type in a new block.
+            let block = first.code.get() >> 8;
+            buffer.push(block as u8);
+            buffer.push(0);
+            let offset = buffer.len();
+
+            // TODO: Check for duplicate items in the set?
+
+            // Loop over the types in this block.
+            while let Some(elem) =
+                rtypes.next_if(|t| t.code.get() >> 8 == block)
+            {
+                let pos = elem.code.get() as u8;
+                buffer.resize(offset + ((pos / 8) + 1) as usize, 0);
+                *buffer.last_mut().unwrap() |= 1u8 << (pos % 8);
+            }
+
+            // Set the size of the block.
+            debug_assert!(buffer.len() - offset <= 32);
+            buffer[offset - 1] = (buffer.len() - offset) as u8;
+        }
+
+        // Copy the bitmap over to the allocator and finish up.
+        let this = alloc.alloc_slice_copy(&buffer[start..]);
+        buffer.truncate(start);
+
+        Ok(TypeBitmaps::parse_bytes_by_ref(this).unwrap())
+    }
+}
+
 //--- Cloning
 
 #[cfg(feature = "alloc")]
@@ -193,5 +334,60 @@ impl Clone for alloc::boxed::Box<TypeBitmaps> {
 impl Hash for TypeBitmaps {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(&self.octets)
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::{
+            new::base::{name::NameBuf, wire::U16, RType},
+            new::zonefile::scanner::{Scan, ScanError, Scanner},
+            utils::CmpIter,
+        };
+
+        use super::NSec;
+
+        let cases = [
+            (
+                b"host.example.com. A MX RRSIG NSEC TYPE1234" as &[u8],
+                Ok((
+                    "host.example.com",
+                    &const {
+                        [
+                            RType::A,
+                            RType::MX,
+                            RType::RRSIG,
+                            RType::NSEC,
+                            RType {
+                                code: U16::new(1234),
+                            },
+                        ]
+                    } as &[RType],
+                )),
+            ),
+            (b"host.example.com." as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            let actual = NSec::scan(&mut scanner, &alloc, &mut buffer);
+
+            assert_eq!(expected.as_ref().err(), actual.as_ref().err());
+            if let (Ok(expected), Ok(actual)) = (expected, actual) {
+                let (next, types) = expected;
+                assert_eq!(&*next.parse::<NameBuf>().unwrap(), actual.next);
+                assert_eq!(
+                    CmpIter(types.iter().copied()),
+                    CmpIter(actual.types),
+                );
+            }
+        }
     }
 }

--- a/src/new/rdata/dnssec/nsec3.rs
+++ b/src/new/rdata/dnssec/nsec3.rs
@@ -18,6 +18,15 @@ use crate::{
     utils::dst::UnsizedCopy,
 };
 
+#[cfg(feature = "zonefile")]
+use crate::{
+    new::base::wire::ParseBytesZC,
+    utils::decoding::{Base16Dec, Base32HexDec},
+};
+
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 use super::TypeBitmaps;
 
 //----------- NSec3 ----------------------------------------------------------
@@ -106,6 +115,79 @@ impl BuildInMessage for NSec3<'_> {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for NSec3<'a> {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let algorithm = Scan::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let flags = Scan::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let iterations = Scan::scan(scanner, alloc, buffer).map(U16::new)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+
+        let start = buffer.len();
+        buffer.push(0);
+        let salt = scanner.scan_plain_token()?;
+        if salt != "-" {
+            let salt_len =
+                Base16Dec::decode_all_to_vec(salt.as_bytes(), buffer)
+                    .map_err(|_| {
+                        ScanError::Custom("invalid NSEC3 salt (base16)")
+                    })?
+                    .len();
+            buffer[start] = salt_len as u8;
+        }
+        let salt = alloc.alloc_slice_copy(&buffer[start..]);
+        let salt = SizePrefixed::parse_bytes_by_ref(salt)
+            .expect("A valid size-prefixed slice has been built");
+        buffer.truncate(start);
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+
+        let start = buffer.len();
+        buffer.push(0);
+        let next = scanner.scan_plain_token()?;
+        let next_len =
+            Base32HexDec::decode_all_to_vec(next.as_bytes(), buffer, false)
+                .map_err(|_| {
+                    ScanError::Custom("invalid next owner name (base32hex)")
+                })?
+                .len();
+        buffer[start] = next_len as u8;
+        let next = alloc.alloc_slice_copy(&buffer[start..]);
+        let next = SizePrefixed::parse_bytes_by_ref(next)
+            .expect("A valid size-prefixed slice has been built");
+        buffer.truncate(start);
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+
+        let types = <&'a TypeBitmaps>::scan(scanner, alloc, buffer)?;
+
+        Ok(Self {
+            algorithm,
+            flags,
+            iterations,
+            salt,
+            next,
+            types,
+        })
+    }
+}
+
 //----------- NSec3Param -----------------------------------------------------
 
 /// Parameters for computing [`NSec3`] records.
@@ -149,6 +231,55 @@ impl BuildInMessage for NSec3Param {
             .ok_or(TruncationError)?
             .copy_from_slice(bytes);
         Ok(end)
+    }
+}
+
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a NSec3Param {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let algorithm = NSec3HashAlg::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let flags = NSec3Flags::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let iterations = u16::scan(scanner, alloc, buffer).map(U16::new)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+
+        let start = buffer.len();
+        buffer.extend_from_slice(algorithm.as_bytes());
+        buffer.extend_from_slice(flags.as_bytes());
+        buffer.extend_from_slice(iterations.as_bytes());
+
+        let salt_start = buffer.len();
+        buffer.push(0);
+        let salt = scanner.scan_plain_token()?;
+        if salt != "-" {
+            let salt_len =
+                Base16Dec::decode_all_to_vec(salt.as_bytes(), buffer)
+                    .map_err(|_| {
+                        ScanError::Custom("invalid NSEC3 salt (base16)")
+                    })?
+                    .len();
+            buffer[salt_start] = salt_len as u8;
+        }
+
+        let record = alloc.alloc_slice_copy(&buffer[start..]);
+        let record = NSec3Param::parse_bytes_by_ref(record)
+            .expect("A valid 'NSec3Param' has been built");
+        buffer.truncate(start);
+
+        Ok(record)
     }
 }
 
@@ -212,6 +343,20 @@ impl NSec3HashAlg {
     pub const SHA1: Self = Self { code: 1 };
 }
 
+//--- Conversion to and from 'u8'
+
+impl From<u8> for NSec3HashAlg {
+    fn from(value: u8) -> Self {
+        Self { code: value }
+    }
+}
+
+impl From<NSec3HashAlg> for u8 {
+    fn from(value: NSec3HashAlg) -> Self {
+        value.code
+    }
+}
+
 //--- Formatting
 
 impl fmt::Debug for NSec3HashAlg {
@@ -220,6 +365,36 @@ impl fmt::Debug for NSec3HashAlg {
             Self::SHA1 => "NSec3HashAlg::SHA1",
             _ => return write!(f, "NSec3HashAlg({})", self.code),
         })
+    }
+}
+
+//--- Scanning from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for NSec3HashAlg {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        _alloc: &'a bumpalo::Bump,
+        _buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        use core::num::IntErrorKind;
+
+        scanner
+            .scan_plain_token()?
+            .parse::<u8>()
+            .map_err(|err| {
+                ScanError::Custom(match err.kind() {
+                    IntErrorKind::PosOverflow | IntErrorKind::NegOverflow => {
+                        "invalid NSEC3 hash algorithm number"
+                    }
+                    IntErrorKind::InvalidDigit => {
+                        "NSEC3 hash algorithm must be a number"
+                    }
+                    // We have already checked for other kinds of errors.
+                    _ => unreachable!(),
+                })
+            })
+            .map(Self::from)
     }
 }
 
@@ -278,6 +453,20 @@ impl NSec3Flags {
     }
 }
 
+//--- Conversion to and from 'u8'
+
+impl From<u8> for NSec3Flags {
+    fn from(value: u8) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl From<NSec3Flags> for u8 {
+    fn from(value: NSec3Flags) -> Self {
+        value.inner
+    }
+}
+
 //--- Formatting
 
 impl fmt::Debug for NSec3Flags {
@@ -286,5 +475,120 @@ impl fmt::Debug for NSec3Flags {
             .field("optout", &self.is_optout())
             .field("bits", &self.bits())
             .finish()
+    }
+}
+
+//--- Scanning from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for NSec3Flags {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        _alloc: &'a bumpalo::Bump,
+        _buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        use core::num::IntErrorKind;
+
+        scanner
+            .scan_plain_token()?
+            .parse::<u8>()
+            .map_err(|err| {
+                ScanError::Custom(match err.kind() {
+                    IntErrorKind::PosOverflow | IntErrorKind::NegOverflow => {
+                        "invalid NSEC3 flags number"
+                    }
+                    IntErrorKind::InvalidDigit => {
+                        "NSEC3 flags must be a number"
+                    }
+                    // We have already checked for other kinds of errors.
+                    _ => unreachable!(),
+                })
+            })
+            .map(Self::from)
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::{new::base::RType, utils::CmpIter};
+
+        use super::NSec3;
+
+        let cases = [
+            (
+                b"1 1 12 aabbccdd 2t7b4g4vsa5smi47k61mv5bv1a22bojr MX DNSKEY NS SOA NSEC3PARAM RRSIG" as &[u8],
+                Ok((
+                    1,
+                    1,
+                    12,
+                    b"\xAA\xBB\xCC\xDD" as &[u8],
+                    b"\x17\x4E\xB2\x40\x9F\xE2\x8B\xCB\x48\x87\xA1\x83\x6F\x95\x7F\x0A\x84\x25\xE2\x7B" as &[u8],
+                    &const {[RType::NS, RType::SOA, RType::MX, RType::RRSIG, RType::DNSKEY, RType::NSEC3PARAM]} as &[RType],
+                )),
+            ),
+            (b"1" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            let actual = NSec3::scan(&mut scanner, &alloc, &mut buffer);
+
+            assert_eq!(expected.as_ref().err(), actual.as_ref().err());
+            if let (Ok(expected), Ok(actual)) = (expected, actual) {
+                let (algorithm, flags, iterations, salt, next, types) =
+                    expected;
+                assert_eq!(algorithm, actual.algorithm.code);
+                assert_eq!(flags, u8::from(actual.flags));
+                assert_eq!(iterations, actual.iterations.get());
+                assert_eq!(salt, &**actual.salt);
+                assert_eq!(next, &**actual.next);
+                assert_eq!(
+                    CmpIter(types.iter().copied()),
+                    CmpIter(actual.types)
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan_param() {
+        use super::NSec3Param;
+
+        let cases = [
+            (
+                b"1 1 12 aabbccdd" as &[u8],
+                Ok((1, 1, 12, b"\xAA\xBB\xCC\xDD" as &[u8])),
+            ),
+            (b"1" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+
+            assert_eq!(
+                <&NSec3Param>::scan(&mut scanner, &alloc, &mut buffer).map(
+                    |p| (
+                        p.algorithm.code,
+                        p.flags.into(),
+                        p.iterations.get(),
+                        &*p.salt
+                    )
+                ),
+                expected
+            );
+        }
     }
 }

--- a/src/new/rdata/dnssec/rrsig.rs
+++ b/src/new/rdata/dnssec/rrsig.rs
@@ -9,6 +9,12 @@ use crate::new::base::name::{CanonicalName, Name, NameCompressor};
 use crate::new::base::wire::{AsBytes, BuildBytes, TruncationError, U16};
 use crate::new::base::{CanonicalRecordData, RType, Serial, TTL};
 
+#[cfg(feature = "zonefile")]
+use crate::{
+    new::zonefile::scanner::{Scan, ScanError, Scanner},
+    utils::decoding::Base64Dec,
+};
+
 use super::SecAlg;
 
 //----------- RRSig ----------------------------------------------------------
@@ -101,5 +107,166 @@ impl BuildInMessage for RRSig<'_> {
         let bytes = contents.get_mut(start..).ok_or(TruncationError)?;
         let rest = self.build_bytes(bytes)?.len();
         Ok(contents.len() - rest)
+    }
+}
+
+//--- Scanning from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for RRSig<'a> {
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        fn parse_timestamp(text: &str) -> Result<Serial, ScanError> {
+            use core::num::IntErrorKind;
+
+            if !text.chars().all(|c| c.is_ascii_digit()) {
+                return Err(ScanError::Custom(
+                    "invalid characters in RRSIG timestamp",
+                ));
+            }
+
+            if text.len() != 14 {
+                return text.parse::<u32>().map(Into::into).map_err(|err| {
+                    ScanError::Custom(match err.kind() {
+                        IntErrorKind::PosOverflow => {
+                            "overly large UNIX timestamp"
+                        }
+                        // We have already checked for other kinds of errors.
+                        _ => unreachable!(),
+                    })
+                });
+            }
+
+            // Format: YYYYMMDDHHmmSS
+            let time = jiff::fmt::strtime::parse("%Y%m%d%H%M%S", text)
+                .and_then(|mut time| {
+                    // The timestamp did not explicitly state a time zone, so
+                    // we have to manually mark it as UTC.
+                    time.set_offset(Some(jiff::tz::Offset::UTC));
+                    time.to_timestamp()
+                })
+                .map_err(|_| ScanError::Custom("illegal signature time"))?;
+
+            Ok(Serial::from(time.as_second() as u32))
+        }
+
+        let rtype = Scan::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let algorithm = Scan::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let labels = Scan::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let ttl = Scan::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let expiration = parse_timestamp(scanner.scan_plain_token()?)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let inception = parse_timestamp(scanner.scan_plain_token()?)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let keytag = Scan::scan(scanner, alloc, buffer).map(U16::new)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+        let signer = Scan::scan(scanner, alloc, buffer)?;
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+
+        let start = buffer.len();
+        let mut decoder = Base64Dec::new();
+        while !scanner.is_empty() {
+            let token = scanner.scan_plain_token()?;
+            scanner.skip_ws();
+
+            decoder.decode_to_vec(token.as_bytes(), buffer).map_err(
+                |_| ScanError::Custom("invalid Base64 in RRSIG signature"),
+            )?;
+        }
+        decoder.finish(&mut [], false).map_err(|_| {
+            ScanError::Custom(
+                "partial block in Base64-encoded RRSIG signature",
+            )
+        })?;
+        let signature = alloc.alloc_slice_copy(&buffer[start..]);
+        buffer.truncate(start);
+
+        Ok(Self {
+            rtype,
+            algorithm,
+            labels,
+            ttl,
+            expiration,
+            inception,
+            keytag,
+            signer,
+            signature,
+        })
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan() {
+        use crate::new::base::{name::NameBuf, RType};
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::RRSig;
+
+        let name = "example.com".parse::<NameBuf>().unwrap();
+        let cases = [
+            (
+                b"A 5 3 86400 20030322173103 20030220173103 2642 example.com. oJB1W6WNGv+ldvQ3WDG0MQkg5IEhjRip8WTr" as &[u8],
+                Ok((
+                    RType::A,
+                    5,
+                    3,
+                    86400,
+                    1048354263,
+                    1045762263,
+                    2642,
+                    &*name,
+                    b"\xA0\x90\x75\x5B\xA5\x8D\x1A\xFF\xA5\x76\xF4\x37\x58\x31\xB4\x31\x09\x20\xE4\x81\x21\x8D\x18\xA9\xF1\x64\xEB" as &[u8],
+                )),
+            ),
+            (b"A" as &[u8], Err(ScanError::Incomplete)),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                RRSig::scan(&mut scanner, &alloc, &mut buffer).map(|r| (
+                    r.rtype,
+                    r.algorithm.into(),
+                    r.labels,
+                    r.ttl.into(),
+                    r.expiration.into(),
+                    r.inception.into(),
+                    r.keytag.get(),
+                    r.signer,
+                    r.signature
+                )),
+                expected
+            );
+        }
     }
 }

--- a/src/new/rdata/mod.rs
+++ b/src/new/rdata/mod.rs
@@ -95,6 +95,9 @@ use crate::{
 #[cfg(feature = "alloc")]
 use crate::new::base::name::{Name, NameBuf};
 
+#[cfg(feature = "zonefile")]
+use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
 //----------- Concrete record data types -------------------------------------
 
 mod basic;
@@ -479,6 +482,118 @@ impl<'a, N: SplitMessageBytes<'a>> ParseRecordData<'a> for RecordData<'a, N> {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a, N> Scan<'a> for RecordData<'a, N>
+where
+    N: Scan<'a> + SplitBytes<'a> + SplitMessageBytes<'a>,
+{
+    /// Scan record data.
+    ///
+    /// Parses the `data` syntax from [the specification].
+    ///
+    /// [the specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        let rtype = RType::scan(scanner, alloc, buffer)?;
+
+        if !scanner.skip_ws() {
+            return Err(ScanError::Incomplete);
+        }
+
+        if scanner.remaining().starts_with(b"\\#") {
+            // Parse from the unknown record data format.
+            let data = <&'a UnknownRecordData>::scan(scanner, alloc, buffer)?;
+            return Self::parse_record_data_bytes(&data.octets, rtype)
+                .map_err(|_| ScanError::Custom("invalid unknown-data content for a known record data type"));
+        }
+
+        // Try all concrete parsers.
+        match rtype {
+            RType::A => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::A)
+            }
+
+            RType::NS => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::Ns)
+            }
+
+            RType::CNAME => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::CName)
+            }
+
+            RType::SOA => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::Soa)
+            }
+
+            RType::PTR => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::Ptr)
+            }
+
+            RType::HINFO => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::HInfo)
+            }
+
+            RType::MX => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::Mx)
+            }
+
+            RType::TXT => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::Txt)
+            }
+
+            RType::AAAA => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::Aaaa)
+            }
+
+            RType::DS => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::Ds)
+            }
+
+            RType::RRSIG => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::RRSig)
+            }
+
+            RType::NSEC => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::NSec)
+            }
+
+            RType::DNSKEY => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::DNSKey)
+            }
+
+            RType::NSEC3 => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::NSec3)
+            }
+
+            RType::NSEC3PARAM => {
+                Scan::scan(scanner, alloc, buffer)
+                    .map(Self::NSec3Param)
+            }
+
+            _ => Err(ScanError::Custom("the concrete format for this record type is currently unsupported")),
+        }
+    }
+}
+
 //----------- BoxedRecordData ------------------------------------------------
 
 /// A heap-allocated container for [`RecordData`].
@@ -812,11 +927,131 @@ impl BuildInMessage for UnknownRecordData {
     }
 }
 
+//--- Parsing from the zonefile format
+
+#[cfg(feature = "zonefile")]
+impl<'a> Scan<'a> for &'a UnknownRecordData {
+    /// Scan record data from the generic format.
+    ///
+    /// Parses the `unknown-data` syntax from [the specification].
+    ///
+    /// [the specification]: crate::new::zonefile#specification
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut std::vec::Vec<u8>,
+    ) -> Result<Self, ScanError> {
+        // Allow the buffer to have previous content.
+        let start = buffer.len();
+
+        // Parse the special unknown data marker.
+        if !scanner
+            .remaining()
+            .strip_prefix(b"\\#")
+            .is_some_and(|r| r.first().is_none_or(u8::is_ascii_whitespace))
+        {
+            return Err(ScanError::Custom(
+                "missing marker for the unknown record data format",
+            ));
+        }
+        scanner.consume(2);
+
+        if !scanner.skip_ws() {
+            return Err(ScanError::Custom("missing data size field"));
+        }
+
+        // Parse the record data size.
+        let size: usize = scanner
+            .scan_plain_token()?
+            .parse::<u16>()
+            .map_err(|_| ScanError::Custom("invalid data size field"))?
+            .into();
+
+        // NOTE: We explicitly choose not to preallocate the expected size of
+        // the record, in case it's wrong and we end up over-allocating.
+
+        // Fill the buffer with the record data in bytes.
+        while buffer.len() < start + size {
+            if !scanner.skip_ws() {
+                return Err(ScanError::Custom("missing record data bytes"));
+            }
+
+            let token = scanner.scan_plain_token()?;
+
+            if buffer.len() > start + size + token.len() / 2 {
+                return Err(ScanError::Custom(
+                    "overlong unknown record data bytes",
+                ));
+            }
+
+            for chunk in token.as_bytes().chunks(2) {
+                let &[hi, lo] = chunk else {
+                    return Err(ScanError::Custom(
+                        "partial byte in unknown record data",
+                    ));
+                };
+
+                fn decode_hex(c: u8) -> Result<u8, ScanError> {
+                    match c {
+                        b'0'..=b'9' => Ok(c - b'0'),
+                        b'A'..=b'F' => Ok(c - b'A' + 10),
+                        b'a'..=b'f' => Ok(c - b'a' + 10),
+                        _ => Err(ScanError::Custom("unknown record data contained a non-hexadecimal value")),
+                    }
+                }
+
+                buffer.push((decode_hex(hi)? << 4) | decode_hex(lo)?);
+            }
+        }
+
+        debug_assert_eq!(buffer.len(), start + size);
+        let bytes = alloc.alloc_slice_copy(&buffer[start..]);
+        Ok(Self::parse_bytes(bytes)
+            .expect("Up to 64K of arbitrary bytes is always valid 'UnknownRecordData'"))
+    }
+}
+
 //--- Cloning
 
 #[cfg(feature = "alloc")]
 impl Clone for alloc::boxed::Box<UnknownRecordData> {
     fn clone(&self) -> Self {
         (*self).unsized_copy_into()
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "zonefile")]
+    #[test]
+    fn scan_unknown() {
+        use crate::new::base::wire::AsBytes;
+        use crate::new::zonefile::scanner::{Scan, ScanError, Scanner};
+
+        use super::UnknownRecordData;
+
+        let cases = [
+            (b"\\# 0" as &[u8], Ok(&[] as &[u8])),
+            (b"\\# 1 5A", Ok(&[0x5A])),
+            (b"\\# 4 41 52 5a 4B", Ok(&[0x41, 0x52, 0x5a, 0x4B])),
+            (b"\\# 4 4152 5a4B", Ok(&[0x41, 0x52, 0x5a, 0x4B])),
+            (
+                b"\\# 4 415 25 a4B",
+                Err(ScanError::Custom("partial byte in unknown record data")),
+            ),
+        ];
+
+        let alloc = bumpalo::Bump::new();
+        let mut buffer = std::vec::Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input, None);
+            assert_eq!(
+                <&UnknownRecordData>::scan(&mut scanner, &alloc, &mut buffer)
+                    .map(|d| d.as_bytes()),
+                expected
+            );
+        }
     }
 }

--- a/src/new/zonefile/entries.rs
+++ b/src/new/zonefile/entries.rs
@@ -1,0 +1,600 @@
+//! Scanning entries in a zonefile.
+//!
+//! Following the [specification] used by this implementation, a zone file is
+//! a sequence of entries.  This low-level module allows a zone file to be
+//! separated into individual entries, without actually parsing the contents
+//! of each entry.  Since entries are separated by newlines (except within
+//! parentheses), this module only focuses on finding the right newlines.
+//!
+//! [specification]: super#specification
+//!
+//! ## Usage
+//!
+//! Simply create an [`Entries`] scanner over some I/O source, and repeatedly
+//! call [`next_entry()`](Entries::next_entry()).  If an error occurs, [`Err`]
+//! is returned; when the zonefile finishes, `Ok(None)` is returned.  The
+//! returned [`Entry`] objects provide the raw content of each entry as well
+//! as the line numbers they spanned.
+//!
+//! ```
+//! # use domain::new::zonefile::entries::Entries;
+//! // Any type implementing 'std::io::BufRead' is appropriate.
+//! let zonefile = b"Hello World!; (hi!)\nThis (entry\nspans\nlines)\n".as_slice();
+//! let mut expected = [
+//!     b"Hello World!".as_slice(),
+//!     b"This entry\nspans\nlines".as_slice(),
+//! ].into_iter();
+//! let mut entries = Entries::new(zonefile);
+//! while let Some(entry) = entries.next_entry().unwrap() {
+//!     assert_eq!(entry.content, expected.next().unwrap());
+//! }
+//! ```
+
+use core::{fmt, ops::Range};
+use std::{io, vec::Vec};
+
+//----------- Entries --------------------------------------------------------
+
+/// The entries in a zonefile.
+///
+/// This is a streaming parser that loads one whole entry (which is a a record
+/// or a zonefile directive) from an I/O source.  It does the minimal amount
+/// of work to correctly distinguish entries from each other, and doesn't try
+/// to catch all possible syntax errors.  It is the user's responsibily to try
+/// parsing the contents of each entry and discover errors.
+///
+/// Note that this type does not implement [`Iterator`].  A single buffer is
+/// used to store every entry, and it is returned by reference (which is not
+/// compatible with the [`Iterator`] interface).  Users are expected to parse
+/// the entry in place instead of copying the data out, minimizing the number
+/// of memory allocations required.
+///
+/// See the [module-level documentation](self) for an example.
+#[derive(Clone, Debug)]
+pub struct Entries<R: io::BufRead> {
+    /// The zonefile source.
+    source: R,
+
+    /// The current entry.
+    entry: Vec<u8>,
+
+    /// The current line number.
+    line_number: usize,
+}
+
+//--- Construction
+
+impl<R: io::BufRead> Entries<R> {
+    /// Construct a new [`Entries`].
+    ///
+    /// The zonefile will be read from the given source.  It is assumed that
+    /// the reader is situated at the start of the first line (line 1).
+    pub fn new(source: R) -> Self {
+        Self::with_line_number(source, 1)
+    }
+
+    /// Construct a new [`Entries`] from a specific line number.
+    ///
+    /// The zonefile will be read from the given source.  It is assumed that
+    /// the reader is situated at the start of the specified line (where the
+    /// first line in a file should be line 1).
+    pub fn with_line_number(source: R, line_number: usize) -> Self {
+        Self {
+            source,
+            entry: Vec::new(),
+            line_number,
+        }
+    }
+}
+
+//--- Inspection
+
+impl<R: io::BufRead> Entries<R> {
+    /// The zonefile source.
+    ///
+    /// Some I/O readers can be modified through a shared reference (e.g.
+    /// [`File`](std::fs::File)).  This may cause the [`Entries`] to report
+    /// errors incorrectly, or to report incorrect line numbers for entries.
+    pub fn source(&self) -> &R {
+        &self.source
+    }
+
+    /// The current line number.
+    ///
+    /// This is the line number of the next character in the source.  This may
+    /// be different from the line number of the next returned entry (as the
+    /// source may contain a blank line).
+    pub fn line_number(&self) -> usize {
+        self.line_number
+    }
+
+    /// Deconstruct the [`Entries`].
+    ///
+    /// The original source and the current line number (the line number of
+    /// the next character in the source) are returned.  The original object
+    /// can be reconstructed using [`Entries::with_line_number()`].
+    pub fn into_parts(self) -> (R, usize) {
+        (self.source, self.line_number)
+    }
+}
+
+//--- Interaction
+
+impl<R: io::BufRead> Entries<R> {
+    // NOTE: Most functions here are essentially tail-recursive, but Rust
+    // doesn't give us a way to mandate that.  In debug builds, the stack
+    // could overflow.  To be careful, we just implement loops explicitly.
+
+    /// Retrieve the next entry from the zonefile.
+    pub fn next_entry(&mut self) -> Result<Option<Entry<'_>>, EntriesError> {
+        // Loop over entries and blank lines in the source.
+        loop {
+            // Clear the entry buffer from any previous (attempted) entry.
+            self.entry.clear();
+
+            // We try to avoid writing to the entry buffer unless we know that
+            // we are writing out an actual entry, and not a blank line.  This
+            // won't work if the zonefile source buffer is too small to find a
+            // non-whitespace character on the line.
+
+            let Some((pos, first)) = self.skip_leading_ws()? else {
+                return Ok(None);
+            };
+
+            // Determine the nature of this line based on the first character.
+            match first {
+                b'\n' => {
+                    // This was a blank line.  Skip past it and try again.
+                    self.source.consume(pos + 1);
+                    self.line_number += 1;
+                }
+
+                b';' => {
+                    // This was a blank line with a comment.  Skip past the
+                    // comment and try again.
+                    self.source.consume(pos + 1);
+                    let Some(()) = self.skip_comment()? else {
+                        return Ok(None);
+                    };
+                }
+
+                _ => {
+                    // This line has an actual entry.  Copy all the leading
+                    // whitespace and drop down to actual parsing.
+                    let buffer = self.source.fill_buf()?;
+                    self.entry.extend_from_slice(&buffer[..pos]);
+                    self.source.consume(pos);
+                    return self.scan_entry().map(Some);
+                }
+            }
+        }
+    }
+
+    /// Skip past leading whitespace.
+    ///
+    /// Every time the full source buffer is consumed (because it contained no
+    /// non-whitespace characters), it is appended to the entry buffer.  When
+    /// a buffer with a non-whitespace character is found, the data up to the
+    /// character is not appended to the buffer.  Instead, the position of the
+    /// character in the buffer is returned.
+    ///
+    /// If the zonefile is emptied, [`None`] is returned.
+    fn skip_leading_ws(&mut self) -> io::Result<Option<(usize, u8)>> {
+        // Loop through fills of the source buffer.
+        loop {
+            let buffer = self.source.fill_buf()?;
+            if buffer.is_empty() {
+                return Ok(None);
+            }
+
+            match buffer.iter().position(|b| !b" \t\r".contains(b)) {
+                Some(pos) => break Ok(Some((pos, buffer[pos]))),
+                None => {
+                    // Copy the leading whitespace to the entry and try again.
+                    self.entry.extend_from_slice(buffer);
+                }
+            }
+        }
+    }
+
+    /// Skip past a comment.
+    ///
+    /// The current line in the zonefile source is skipped (including the line
+    /// feed byte), and is not written to the entry.  If the source is emptied
+    /// [`None`] is returned.
+    fn skip_comment(&mut self) -> io::Result<Option<()>> {
+        // Loop through fills of the source buffer.
+        loop {
+            let buffer = self.source.fill_buf()?;
+            if buffer.is_empty() {
+                return Ok(None);
+            }
+
+            match buffer.iter().position(|&b| b == b'\n') {
+                Some(pos) => {
+                    // Consume the comment and finish up.
+                    self.source.consume(pos + 1);
+                    self.line_number += 1;
+                    return Ok(Some(()));
+                }
+
+                None => {
+                    // Empty the buffer and try again.
+                    let amount = buffer.len();
+                    self.source.consume(amount);
+                }
+            }
+        }
+    }
+
+    /// Scan an actual entry.
+    ///
+    /// The zonefile source should be located at the first non-whitespace
+    /// character in the entry.
+    fn scan_entry(&mut self) -> Result<Entry<'_>, EntriesError> {
+        // The line number this entry begins at.
+        let line_number = self.line_number;
+
+        // The line number where an opening parentheses began.
+        let mut paren_line_number = None;
+
+        // Loop through fills of the source buffer.
+        loop {
+            let buffer = self.source.fill_buf()?;
+            if buffer.is_empty() {
+                // Make sure we're outside parentheses.
+                if let Some(line_number) = paren_line_number {
+                    return Err(EntriesError::UnmatchedRightParen {
+                        line_number,
+                    });
+                }
+
+                return Ok(Entry {
+                    content: &self.entry,
+                    line_numbers: line_number..self.line_number + 1,
+                });
+            }
+
+            // Look for characters that affect the entry.
+            let Some(pos) =
+                buffer.iter().position(|b| b"\n;()\"".contains(b))
+            else {
+                // Nothing interesting here.
+                let amount = buffer.len();
+                self.entry.extend_from_slice(buffer);
+                self.source.consume(amount);
+                continue;
+            };
+
+            // Make sure the character isn't escaped.
+            let num_backslashes = self
+                .entry
+                .iter()
+                .chain(&buffer[..pos])
+                .rev()
+                .take_while(|&&b| b == b'\\')
+                .count();
+            if buffer[pos] != b'\n' && num_backslashes % 2 != 0 {
+                // Nothing interesting thus far.
+                self.entry.extend_from_slice(&buffer[..pos + 1]);
+                self.source.consume(pos + 1);
+                continue;
+            }
+
+            match buffer[pos] {
+                b'\n' if paren_line_number.is_some() => {
+                    // We hit a new line within parentheses.  Keep going.
+                    self.entry.extend_from_slice(&buffer[..pos + 1]);
+                    self.source.consume(pos + 1);
+                    self.line_number += 1;
+                }
+
+                b'\n' => {
+                    // The entry is over.
+                    self.entry.extend_from_slice(&buffer[..pos]);
+                    self.source.consume(pos + 1);
+                    self.line_number += 1;
+                    return Ok(Entry {
+                        content: &self.entry,
+                        line_numbers: line_number..self.line_number,
+                    });
+                }
+
+                b';' if paren_line_number.is_some() => {
+                    // We hit a comment within parentheses.  Keep going.
+                    self.entry.extend_from_slice(&buffer[..pos]);
+                    self.source.consume(pos + 1);
+                    self.skip_comment()?;
+                    self.entry.push(b'\n');
+                }
+
+                b';' => {
+                    // The entry is over, ending on a comment.
+                    self.entry.extend_from_slice(&buffer[..pos]);
+                    self.source.consume(pos + 1);
+                    self.skip_comment()?;
+                    return Ok(Entry {
+                        content: &self.entry,
+                        line_numbers: line_number..self.line_number,
+                    });
+                }
+
+                b'(' => {
+                    // Make sure we're already outside parentheses.
+                    if let Some(line_number) = paren_line_number {
+                        self.source.consume(pos);
+                        return Err(EntriesError::NestedOpeningParen {
+                            first_line_number: line_number,
+                            second_line_number: self.line_number,
+                        });
+                    }
+
+                    // Begin parentheses.
+                    self.entry.extend_from_slice(&buffer[..pos]);
+                    self.source.consume(pos + 1);
+                    paren_line_number = Some(self.line_number);
+                }
+
+                b')' => {
+                    // Make sure we're already inside parentheses.
+                    if paren_line_number.is_none() {
+                        self.source.consume(pos);
+                        return Err(EntriesError::UnmatchedRightParen {
+                            line_number: self.line_number,
+                        });
+                    }
+
+                    // End parentheses.
+                    self.entry.extend_from_slice(&buffer[..pos]);
+                    self.source.consume(pos + 1);
+                    paren_line_number = None;
+                }
+
+                b'"' => {
+                    self.entry.extend_from_slice(&buffer[..pos + 1]);
+                    self.source.consume(pos + 1);
+                    self.scan_quoted()?;
+                }
+
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// Skip past a quoted string.
+    fn scan_quoted(&mut self) -> Result<(), EntriesError> {
+        // The line number where the quoted string began.
+        let line_number = self.line_number;
+
+        // Loop through fills of the source buffer.
+        loop {
+            let buffer = self.source.fill_buf()?;
+            if buffer.is_empty() {
+                return Err(EntriesError::UnmatchedDoubleQuote {
+                    line_number,
+                });
+            }
+
+            // Look for characters that affect the entry.
+            let Some(pos) = buffer.iter().position(|&b| b == b'"') else {
+                // Nothing interesting here.
+                let amount = buffer.len();
+                self.entry.extend_from_slice(buffer);
+                self.source.consume(amount);
+                continue;
+            };
+
+            // Make sure the character isn't escaped.
+            let num_backslashes = self
+                .entry
+                .iter()
+                .chain(&buffer[..pos])
+                .rev()
+                .take_while(|&&b| b == b'\\')
+                .count();
+            if num_backslashes % 2 != 0 {
+                // Nothing interesting thus far.
+                self.entry.extend_from_slice(&buffer[..pos + 1]);
+                self.source.consume(pos + 1);
+                continue;
+            }
+
+            self.entry.extend_from_slice(&buffer[..pos + 1]);
+            self.source.consume(pos + 1);
+            return Ok(());
+        }
+    }
+}
+
+//----------- Entry ----------------------------------------------------------
+
+/// An entry in a zonefile.
+///
+/// An entry is typically a single line, although it may contain parenthesized
+/// content, which can span multiple lines.  It is usually a serialized DNS
+/// record, but it may also be a zonefile directive.
+///
+/// The entry is left completely unparsed.  It includes all whitespace up to
+/// the line terminator, comment marker, or end of the file.  For multi-line
+/// entries, line terminators are preserved (but all comments are removed).
+#[derive(Clone, Debug)]
+pub struct Entry<'a> {
+    /// The unparsed entry content.
+    pub content: &'a [u8],
+
+    /// The range of line numbers covered by the entry.
+    ///
+    /// Usually, line numbers start from 1.  However, if the [`Entries`] was
+    /// created in the middle of a file, a custom line number can be provided
+    /// to [`Entries::with_line_number()`].
+    pub line_numbers: Range<usize>,
+}
+
+//----------- EntryError -----------------------------------------------------
+
+/// An error in [`Entries::next_entry()`].
+#[derive(Debug)]
+pub enum EntriesError {
+    /// An unmatched double-quote was found.
+    UnmatchedDoubleQuote {
+        /// The line number of the opening double quote.
+        line_number: usize,
+    },
+
+    /// An unmatched closing parenthesis was found.
+    ///
+    /// Everything up to the parenthesis (except the parenthesis itself) is
+    /// consumed from the zonefile source.
+    UnmatchedRightParen {
+        /// The line number of the opening parenthesis.
+        line_number: usize,
+    },
+
+    /// A nested opening parenthesis was found.
+    ///
+    /// Everything up to the parenthesis (except the parenthesis itself) is
+    /// consumed from the zonefile source.
+    NestedOpeningParen {
+        /// The line number of the first opening parenthesis.
+        first_line_number: usize,
+
+        /// The line number of the second opening parenthesis.
+        second_line_number: usize,
+    },
+
+    /// The zonefile source could not be read from.
+    Source(io::Error),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for EntriesError {}
+
+//--- Conversions from sub-errors
+
+impl From<io::Error> for EntriesError {
+    fn from(error: io::Error) -> Self {
+        Self::Source(error)
+    }
+}
+
+//--- Formatting
+
+impl fmt::Display for EntriesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnmatchedDoubleQuote { line_number } => {
+                write!(f, "a double-quote on line {line_number} was never terminated")
+            }
+            Self::UnmatchedRightParen { line_number } => {
+                write!(f, "an opening parenthesis on line {line_number} was never terminated")
+            }
+            Self::NestedOpeningParen {
+                first_line_number,
+                second_line_number,
+            } => {
+                write!(f, "nested parentheses (on line {first_line_number} and {second_line_number}) were found")
+            }
+            Self::Source(error) => error.fmt(f),
+        }
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use core::ops::Range;
+
+    use super::Entries;
+
+    #[test]
+    fn rfc1035() {
+        let zonefile = b"\
+@   IN  SOA     VENERA      Action\\.domains (
+                                 20     ; SERIAL
+                                 7200   ; REFRESH
+                                 600    ; RETRY
+                                 3600000; EXPIRE
+                                 60)    ; MINIMUM
+
+        NS      A.ISI.EDU.
+        NS      VENERA
+        NS      VAXA
+        MX      10      VENERA
+        MX      20      VAXA
+
+A       A       26.3.0.103
+
+VENERA  A       10.1.0.52
+        A       128.9.0.32
+
+VAXA    A       10.2.0.27
+        A       128.9.0.33
+
+
+$INCLUDE <SUBSYS>ISI-MAILBOXES.TXT
+";
+
+        let expected: [(&str, Range<usize>); 12] = [
+            (
+                "\
+@   IN  SOA     VENERA      Action\\.domains 
+                                 20     
+                                 7200   
+                                 600    
+                                 3600000
+                                 60    ",
+                1..7,
+            ),
+            ("        NS      A.ISI.EDU.", 8..9),
+            ("        NS      VENERA", 9..10),
+            ("        NS      VAXA", 10..11),
+            ("        MX      10      VENERA", 11..12),
+            ("        MX      20      VAXA", 12..13),
+            ("A       A       26.3.0.103", 14..15),
+            ("VENERA  A       10.1.0.52", 16..17),
+            ("        A       128.9.0.32", 17..18),
+            ("VAXA    A       10.2.0.27", 19..20),
+            ("        A       128.9.0.33", 20..21),
+            ("$INCLUDE <SUBSYS>ISI-MAILBOXES.TXT", 23..24),
+        ];
+
+        let mut entries = Entries::new(zonefile.as_slice());
+        for (expected, line_numbers) in expected {
+            let entry = entries.next_entry().unwrap().unwrap();
+            let content = core::str::from_utf8(entry.content);
+            assert_eq!(content, Ok(expected));
+            assert_eq!(entry.line_numbers, line_numbers);
+        }
+        assert!(entries.next_entry().unwrap().is_none());
+
+        //---
+
+        let zonefile = b"\
+MOE     MB      A.ISI.EDU.
+LARRY   MB      A.ISI.EDU.
+CURLEY  MB      A.ISI.EDU.
+STOOGES MG      MOE
+        MG      LARRY
+        MG      CURLEY
+";
+
+        let expected: [(&str, Range<usize>); 6] = [
+            ("MOE     MB      A.ISI.EDU.", 1..2),
+            ("LARRY   MB      A.ISI.EDU.", 2..3),
+            ("CURLEY  MB      A.ISI.EDU.", 3..4),
+            ("STOOGES MG      MOE", 4..5),
+            ("        MG      LARRY", 5..6),
+            ("        MG      CURLEY", 6..7),
+        ];
+
+        let mut entries = Entries::new(zonefile.as_slice());
+        for (expected, line_numbers) in expected {
+            let entry = entries.next_entry().unwrap().unwrap();
+            let content = core::str::from_utf8(entry.content);
+            assert_eq!(content, Ok(expected));
+            assert_eq!(entry.line_numbers, line_numbers);
+        }
+        assert!(entries.next_entry().unwrap().is_none());
+    }
+}

--- a/src/new/zonefile/mod.rs
+++ b/src/new/zonefile/mod.rs
@@ -154,3 +154,4 @@
 
 pub mod entries;
 pub mod scanner;
+pub mod simple;

--- a/src/new/zonefile/mod.rs
+++ b/src/new/zonefile/mod.rs
@@ -1,0 +1,156 @@
+//! Reading and writing zone files.
+//!
+//! A "zone file" is a textual representation of a DNS zone.  The zone file
+//! specifies the records that make up the zone.  Each record is specified on
+//! its own line, and consists of several whitespace-separated fields.
+//!
+//! Here's a simple example of a zone file (from [RFC 1034, section 6.1]):
+//!
+//! ```text
+//! .       IN      SOA     SRI-NIC.ARPA. HOSTMASTER.SRI-NIC.ARPA. (
+//!                         870611          ;serial
+//!                         1800            ;refresh every 30 min
+//!                         300             ;retry every 5 min
+//!                         604800          ;expire after a week
+//!                         86400)          ;minimum of a day
+//!                 NS      A.ISI.EDU.
+//!                 NS      C.ISI.EDU.
+//!                 NS      SRI-NIC.ARPA.
+//!
+//! EDU.    86400   NS      SRI-NIC.ARPA.
+//!         86400   NS      C.ISI.EDU.
+//!
+//! ACC.ARPA.       A       26.6.0.65
+//!                 HINFO   PDP-11/70 UNIX
+//!                 MX      10 ACC.ARPA.
+//!
+//! USC-ISIC.ARPA.  CNAME   C.ISI.EDU.
+//!
+//! 65.0.6.26.IN-ADDR.ARPA.  PTR    ACC.ARPA.
+//! 52.0.0.10.IN-ADDR.ARPA.  PTR    C.ISI.EDU.
+//! 103.0.3.26.IN-ADDR.ARPA. PTR    A.ISI.EDU.
+//!
+//! A.ISI.EDU. 86400 A      26.3.0.103
+//! C.ISI.EDU. 86400 A      10.0.0.52
+//! ```
+//!
+//! [RFC 1034, section 6.1]: https://datatracker.ietf.org/doc/html/rfc1034#section-6.1
+//!
+//! The basic elements of the format become visible quickly.  Each line begins
+//! a new DNS record, with whitespace-separated fields specifying the owner
+//! name, record class, TTL, record type, and record data.  All fields except
+//! the record type and data are optional -- when omitted, the last explicitly
+//! specified values are used.  The format of the record data fields depends
+//! on the record data type.  Semicolons begin comments and parentheses allow
+//! record data to be continued across multiple lines.
+//!
+//! This module provides functionality for parsing records from a zone file,
+//! and for serializing records into the zone file format.  It is designed to
+//! maximize performance while maintaining a user-friendly API.  It minimizes
+//! heap allocations (e.g. by reusing buffers) and supports parallelization.
+//!
+//! ## Usage
+//!
+// TODO
+//!
+//! ## Compatibility
+//!
+//! Unfortunately, the zone file format is quite underspecified.  While most
+//! implementations are compatible enough with each other, users can only rely
+//! on syntax exactly like the examples in the RFCs.  Contradictions in those
+//! reference specifications have muddled the waters further.
+//!
+//! Zone files were designed to be written by hand.  The format offers various
+//! niceties to this end, e.g. by allowing duplicate information to be omitted
+//! in many places.  However, as the Internet has grown exponentially, zone
+//! files are almost always machine generated.  Most zone files today actually
+//! use a subset of the original syntax, and avoid the underspecified parts of
+//! the format.
+//!
+//! This module only supports the most commonly used subset of the format.  It
+//! does not allow for edge cases (i.e. situations where the RFCs are unclear)
+//! that are also rejected by other implementations.  The specific subset it
+//! employs is documented below.  These restrictions are not expected to cause
+//! problems for the vast majority of users.
+//!
+//! ## Specification
+//!
+//! This section details the subset of the zone file format supported by this
+//! module.  An official, concrete specification of the format has not been
+//! published yet, so other implementations may support more or less.
+//!
+//! ```text
+//! zone-file = ( entry? ws* comment? "\n" )*
+//! entry = record | directive
+//!
+//! # Includes "\n" when wrapped within parentheses.
+//! ws = [ \t\r]
+//! comment = ";" [^\n]*
+//!
+//! # If the name, TTL or class are omitted, use the respective field of the
+//! # closest preceding record where it was explicitly specified.  If no such
+//! # record exists (e.g. because this is the first record), the file is
+//! # malformed.
+//! record = name? (ws+ (ttl (ws+ class)? | class (ws+ ttl)?) )? ws+ data
+//!
+//! # If it does not end with a period, a period and the origin name are
+//! # appended.  The special name "@" means the origin name.  When the full
+//! # domain name is encoded in the wire format, it must fit within 255 bytes.
+//! # If an origin name is necessary but unknown, an error occurs.
+//! name = (label ".")* label "."? | "@"
+//!   # Must contain at most 63 bytes (after escapes are processed).
+//!   label = ([a-zA-Z0-9-] | "\\" ascii-printable)+
+//!
+//! # All printable / graphic ASCII characters.
+//! ascii-printable = '!'..='~'
+//!
+//! # An integer number of seconds.
+//! ttl = [0-9]+
+//!
+//! # "CS" and "HS" exist, but are long obsolete.
+//! # "CH" is obselete too, but some name servers abuse it for metadata.
+//! class = "IN" | "CH" | "CLASS" [0-9]+
+//!
+//! # If the format of the record type is unknown, 'unknown-data' is used.
+//! data = type ws+ (unknown-data | known-data)
+//!
+//! # Includes the identifiers for supported record types.
+//! type = (...) | "TYPE" [0-9]+
+//!
+//! unknown-data = "\\#" ws+ ud-size ws+ ud-data
+//!   # The size of the record data, in bytes.
+//!   ud-size = [0-9]+
+//!   ud-data = (ud-word (ws+ ud-word)*)?
+//!   ud-word = ([0-9a-fA-F] [0-9a-fA-F])+
+//!
+//! known-data = (d-word (ws+ d-word)*)?
+//!   d-word = ([^"\\\(\); \t\r\n] | "\\" ascii-printable | quoted-string)+
+//!
+//! quoted-string = "\"" ([^"\\\n] | "\\" (ascii-printable | ws))* "\""
+//!
+//! # A directive changes how the file is parsed.
+//! directive = include-dir | origin-dir | ttl-dir
+//!
+//! # Like '#include' in C, process the referenced file in place here.
+//! # 'name' (or this file's origin) is used as the origin for that file.
+//! include-dir = "$INCLUDE" ws+ file-path (ws+ name)?
+//! file-path = ([^ \\\t\r\n\(\)";] | "\\" ascii-printable | quoted-string)*
+//!
+//! # Set the origin name for all future entries in this file.
+//! origin-dir = "$ORIGIN" ws+ name
+//!
+//! # Explicitly set a TTL, for use in implicit TTLs for records in this file.
+//! ttl-dir = "$TTL" ws+ ttl
+//! ```
+//!
+//! Every DNS record type (that is allowed within a zone file) has a standard
+//! zone file format, which specifies how record data of that type should be
+//! formatted in zone files.  As new record types are added occasionally, they
+//! are the extensible part of the zone file format.  The format for a record
+//! data type is documented on its type in [`rdata`](super::rdata).
+
+#![cfg(feature = "zonefile")]
+#![cfg_attr(docsrs, doc(cfg(feature = "zonefile")))]
+
+pub mod entries;
+pub mod scanner;

--- a/src/new/zonefile/scanner.rs
+++ b/src/new/zonefile/scanner.rs
@@ -1,0 +1,518 @@
+//! Scanning the data in a zonefile entry.
+//!
+//! Following the [specification] used by this implementation, a zone file is
+//! a sequence of entries.  The syntax for a zonefile entry is fairly diverse,
+//! and can grow over time (as new record data types are added); rather than
+//! trying to parse every possible syntax, this low-level module provides the
+//! tools to parse a zonefile entry in any format.
+//!
+//! [specification]: super#specification
+//!
+//! ## Usage
+//!
+// TODO
+//!
+
+use core::{fmt, num::IntErrorKind};
+use std::vec::Vec;
+
+use bumpalo::Bump;
+
+use crate::new::base::name::RevName;
+
+//----------- Scanner --------------------------------------------------------
+
+/// A scanner for parsing a single zonefile entry.
+#[derive(Clone, Debug)]
+pub struct Scanner<'a> {
+    /// The remaining data in the entry.
+    remaining: &'a [u8],
+
+    /// The origin for relative domain names.
+    origin: Option<&'a RevName>,
+}
+
+//--- Construction
+
+impl<'a> Scanner<'a> {
+    /// Prepare to scan a zonefile entry.
+    ///
+    /// The input is a byte string representing the zonefile entry.  It should
+    /// primarily consist of ASCII text.  It may span multiple lines.  Any
+    /// comments (whose grammar is defined in the [specification]) should be
+    /// stripped out beforehand.
+    ///
+    /// [specification]: super#specification
+    ///
+    /// The provided origin name (if any) is used to resolve relative domain
+    /// names within the entry.  If the scanner requires an origin name (e.g.
+    /// because the entry contained a relative domain name) but one is not
+    /// provided, an error will occur.
+    pub fn new(entry: &'a [u8], origin: Option<&'a RevName>) -> Self {
+        Self {
+            remaining: entry,
+            origin,
+        }
+    }
+}
+
+//--- Inspection
+
+impl<'a> Scanner<'a> {
+    /// The remaining content in the entry.
+    pub fn remaining(&self) -> &'a [u8] {
+        self.remaining
+    }
+
+    /// Whether the scanner has been emptied.
+    pub fn is_empty(&self) -> bool {
+        self.remaining.is_empty()
+    }
+
+    /// The origin for relative domain names.
+    pub fn origin(&self) -> Option<&'a RevName> {
+        self.origin
+    }
+}
+
+//--- Interaction
+
+impl<'a> Scanner<'a> {
+    /// Parse a plain token, without quotes and escapes.
+    ///
+    /// The following grammar is parsed:
+    ///
+    /// ```text
+    /// plain-token = [^"\\\(\); \t\r\n]+
+    /// ```
+    pub fn scan_plain_token(&mut self) -> Result<&'a str, ScanError> {
+        let (chunk, first) = self.scan_unquoted_chunk(|_| false);
+
+        match first {
+            Some(b' ' | b'\t' | b'\r' | b'\n') | None => {}
+            Some(b'"') => return Err(ScanError::ProhibitedQuote),
+            Some(b'\\') => return Err(ScanError::ProhibitedEscape),
+            Some(_) => return Err(ScanError::InvalidCharacter),
+        }
+
+        if chunk.is_empty() {
+            return Err(ScanError::Incomplete);
+        }
+
+        // SAFETY: Only ASCII characters were allowed in the string.
+        Ok(unsafe { core::str::from_utf8_unchecked(chunk) })
+    }
+
+    /// Parse a conventional token into the given buffer.
+    ///
+    /// The following grammar is parsed:
+    ///
+    /// ```text
+    /// token = ([^"\\\(\); \t\r\n] | "\\" escape | quoted-string)+
+    /// escape = (ascii-printable & [^0-9]) | [0-9][0-9][0-9]
+    /// quoted-string = '"' ([^"\\] | "\\" escape)* '"'
+    /// ```
+    pub fn scan_token<'b>(
+        &mut self,
+        buffer: &'b mut Vec<u8>,
+    ) -> Result<Option<&'b [u8]>, ScanError> {
+        // Allow the buffer to have previous content.
+        let start = buffer.len();
+
+        // Whether the token exists (even if it has no content).
+        let mut exists = false;
+
+        // Loop through non-special chunks and special sequences.
+        loop {
+            let (chunk, first) = self.scan_unquoted_chunk(|_| false);
+
+            // Copy the non-special chunk into the buffer.
+            buffer.extend_from_slice(chunk);
+            exists |= !chunk.is_empty();
+
+            // Determine the nature of the special sequence.
+            match first {
+                Some(b' ' | b'\t' | b'\r' | b'\n') | None => {
+                    // This is the end of the token.
+                    return Ok(exists.then_some(&buffer[start..]));
+                }
+
+                Some(b'"') => {
+                    // A quoted string within the token.
+                    exists = true;
+                    self.consume(1);
+                    self.scan_quoted(buffer)?;
+                }
+
+                Some(b'\\') => {
+                    // An escape sequence.
+                    exists = true;
+                    self.consume(1);
+                    buffer.push(self.scan_escape()?);
+                }
+
+                Some(_) => {
+                    // This is some non-ASCII char or control code.
+                    return Err(ScanError::InvalidCharacter);
+                }
+            }
+        }
+    }
+
+    /// Parse a chunk of non-special content within a single unquoted token.
+    ///
+    /// All non-special characters in the input, up to a special character or
+    /// the end of the entry, are returned.
+    ///
+    /// By default, a non-special character is any printable ASCII character
+    /// except backslash, left/right parenthesis, double quote, and semicolon.
+    /// The caller can specify additional special characters via a predicate.
+    /// Note that unquoted left/right parentheses and semicolons should have
+    /// been stripped out before calling [`Scanner::new()`].
+    ///
+    /// The chunk will be returned as a reference to the original input.  No
+    /// additional characters will be consumed from the input.  If the scanner
+    /// did not reach the end of the input, the delimiting special character
+    /// is returned.
+    pub fn scan_unquoted_chunk(
+        &mut self,
+        special: impl Fn(&u8) -> bool,
+    ) -> (&'a [u8], Option<u8>) {
+        let pos = self
+            .remaining
+            .iter()
+            .position(|b| {
+                !b.is_ascii_graphic()
+                    || b"();\\\"".contains(b)
+                    || (special)(b)
+            })
+            .unwrap_or(self.remaining.len());
+
+        let (unescaped, rest) = self.remaining.split_at(pos);
+        self.remaining = rest;
+        (unescaped, self.remaining.first().copied())
+    }
+
+    /// Scan a quoted string.
+    ///
+    /// The scanner should be located immediately after the opening double
+    /// quote.  The rest of the quoted string (including the closing double
+    /// quote) will be consumed, unescaped, and appended to the given buffer.
+    pub fn scan_quoted<'b>(
+        &mut self,
+        buffer: &'b mut Vec<u8>,
+    ) -> Result<&'b [u8], ScanError> {
+        // Allow the buffer to have previous content.
+        let start = buffer.len();
+
+        // Loop through non-special chunks and special sequences.
+        loop {
+            // Scan for special sequences.
+            let pos = self
+                .remaining
+                .iter()
+                .position(|b| b"\\\"".contains(b))
+                .ok_or(ScanError::UnterminatedQuote)?;
+
+            // Copy the non-special chunk to the output.
+            buffer.extend_from_slice(&self.remaining[..pos]);
+
+            match self.remaining[pos] {
+                b'\\' => {
+                    // Parse an escape sequence.
+                    self.consume(pos + 1);
+                    buffer.push(self.scan_escape()?);
+                }
+
+                b'"' => {
+                    // The quoted string is complete.  Stop.
+                    self.consume(pos + 1);
+                    return Ok(&buffer[start..]);
+                }
+
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// Parse an escape.
+    ///
+    /// The scanner should be located immediately after the backslash
+    /// character.  It parses the regular expression `[0-9]{3}|[^0-9]`.  In
+    /// the first case, the three decimal digits are interpreted as the value
+    /// of the byte (which must be at most 255).  In the second case, the byte
+    /// is copied over verbatim.  The escape is consumed and the unescaped
+    /// byte value is returned.
+    pub fn scan_escape(&mut self) -> Result<u8, ScanError> {
+        let (&first, rest) = self
+            .remaining
+            .split_first()
+            .ok_or(ScanError::IncompleteEscape)?;
+
+        if first.is_ascii_digit() {
+            // This is a decimal escape.
+
+            if self.remaining.len() < 3 {
+                return Err(ScanError::IncompleteEscape);
+            }
+
+            let (num, rest) = self.remaining.split_at(3);
+            self.remaining = rest;
+            core::str::from_utf8(num)
+                .ok()
+                .and_then(|num| num.parse().ok())
+                .ok_or(ScanError::InvalidDecimalEscape)
+        } else {
+            // This is a regular escape.
+            self.remaining = rest;
+            Ok(first)
+        }
+    }
+
+    /// Skip whitespace.
+    ///
+    /// Any whitespace at the beginning of the scanner, including newlines,
+    /// will be skipped over.  The scanner will then start at a non-whitespace
+    /// token (or will have run out of input).  `true` is returned if at least
+    /// one whitespace character was consumed.
+    pub fn skip_ws(&mut self) -> bool {
+        let amount = self
+            .remaining
+            .iter()
+            .take_while(|&b| b.is_ascii_whitespace())
+            .count();
+        self.remaining = &self.remaining[amount..];
+        amount != 0
+    }
+
+    /// Consume the specified number of bytes.
+    ///
+    /// The caller can inspect the remaining bytes with [`Self::remaining()`],
+    /// parse them manually, and then mark them as consumed with this method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of bytes exceeds [`Self::remaining()`].
+    pub fn consume(&mut self, amount: usize) {
+        assert!(amount <= self.remaining.len());
+        self.remaining = &self.remaining[amount..];
+    }
+}
+
+//----------- Scan -----------------------------------------------------------
+
+/// A type that can be scanned from a zonefile entry.
+pub trait Scan<'a>: Sized {
+    /// Scan a value from a zonefile entry.
+    ///
+    /// Data to be stored indirectly can be allocated on the given [`Bump`].
+    /// Temporary allocations (e.g. when building byte strings) can be built
+    /// on the provided [`Vec`] (which may have existing content that should
+    /// not be removed).
+    fn scan(
+        scanner: &mut Scanner<'_>,
+        alloc: &'a Bump,
+        buffer: &mut Vec<u8>,
+    ) -> Result<Self, ScanError>;
+}
+
+macro_rules! impl_scan_int {
+    ($type:ty) => {
+        impl Scan<'_> for $type {
+            fn scan(
+                scanner: &mut Scanner<'_>,
+                _alloc: &'_ Bump,
+                _buffer: &mut Vec<u8>,
+            ) -> Result<Self, ScanError> {
+                scanner.scan_plain_token()?.parse::<$type>().map_err(|err| {
+                    ScanError::Custom(match err.kind() {
+                        IntErrorKind::PosOverflow => {
+                            "Integer value too large for field"
+                        }
+                        IntErrorKind::InvalidDigit => {
+                            "Invalid decimal integer"
+                        }
+                        IntErrorKind::NegOverflow => {
+                            "A non-negative integer was expected"
+                        }
+                        // We have already checked for other kinds of errors.
+                        _ => unreachable!(),
+                    })
+                })
+            }
+        }
+    };
+}
+
+impl_scan_int!(u8);
+impl_scan_int!(u16);
+impl_scan_int!(u32);
+impl_scan_int!(u64);
+impl_scan_int!(usize);
+
+impl_scan_int!(i8);
+impl_scan_int!(i16);
+impl_scan_int!(i32);
+impl_scan_int!(i64);
+impl_scan_int!(isize);
+
+//----------- ScanError ------------------------------------------------------
+
+/// An error in scanning a zonefile entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ScanError {
+    /// A quoted string was not terminated.
+    UnterminatedQuote,
+
+    /// This token is not allowed to contain a quoted string.
+    ProhibitedQuote,
+
+    /// This token is not allowed to contain escapes.
+    ProhibitedEscape,
+
+    /// An incomplete escape sequence was found.
+    IncompleteEscape,
+
+    /// An invalid decimal escape was found.
+    InvalidDecimalEscape,
+
+    /// An unescaped non-ASCII character or ASCII control code was found.
+    InvalidCharacter,
+
+    /// The input was incomplete.
+    Incomplete,
+
+    /// A custom record scanning error occurred.
+    Custom(&'static str),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ScanError {}
+
+//--- Formatting
+
+impl fmt::Display for ScanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::UnterminatedQuote => "a quoted string was not terminated",
+            Self::ProhibitedQuote => "a token incorrectly uses quotes",
+            Self::ProhibitedEscape => "a token incorrectly uses escapes",
+            Self::IncompleteEscape => "the entry ended on a partial escape",
+            Self::InvalidDecimalEscape => {
+                "an invalid decimal escape was found"
+            }
+            Self::InvalidCharacter => "an unprintable character was found",
+            Self::Incomplete => "the input was incomplete",
+            Self::Custom(s) => s,
+        })
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use std::vec::Vec;
+
+    use super::Scanner;
+
+    #[test]
+    fn rfc1035() {
+        let cases: [(&str, &[Option<&str>]); 18] = [
+            (
+                "\
+@   IN  SOA     VENERA      Action\\.domains 
+                                 20     
+                                 7200   
+                                 600    
+                                 3600000
+                                 60    ",
+                &[
+                    Some("@"),
+                    Some("IN"),
+                    Some("SOA"),
+                    Some("VENERA"),
+                    Some("Action.domains"),
+                    Some("20"),
+                    Some("7200"),
+                    Some("600"),
+                    Some("3600000"),
+                    Some("60"),
+                ],
+            ),
+            (
+                "        NS      A.ISI.EDU.",
+                &[None, Some("NS"), Some("A.ISI.EDU.")],
+            ),
+            (
+                "        NS      VENERA",
+                &[None, Some("NS"), Some("VENERA")],
+            ),
+            ("        NS      VAXA", &[None, Some("NS"), Some("VAXA")]),
+            (
+                "        MX      10      VENERA",
+                &[None, Some("MX"), Some("10"), Some("VENERA")],
+            ),
+            (
+                "        MX      20      VAXA",
+                &[None, Some("MX"), Some("20"), Some("VAXA")],
+            ),
+            (
+                "A       A       26.3.0.103",
+                &[Some("A"), Some("A"), Some("26.3.0.103")],
+            ),
+            (
+                "VENERA  A       10.1.0.52",
+                &[Some("VENERA"), Some("A"), Some("10.1.0.52")],
+            ),
+            (
+                "        A       128.9.0.32",
+                &[None, Some("A"), Some("128.9.0.32")],
+            ),
+            (
+                "VAXA    A       10.2.0.27",
+                &[Some("VAXA"), Some("A"), Some("10.2.0.27")],
+            ),
+            (
+                "        A       128.9.0.33",
+                &[None, Some("A"), Some("128.9.0.33")],
+            ),
+            (
+                "$INCLUDE <SUBSYS>ISI-MAILBOXES.TXT",
+                &[Some("$INCLUDE"), Some("<SUBSYS>ISI-MAILBOXES.TXT")],
+            ),
+            (
+                "MOE     MB      A.ISI.EDU.",
+                &[Some("MOE"), Some("MB"), Some("A.ISI.EDU.")],
+            ),
+            (
+                "LARRY   MB      A.ISI.EDU.",
+                &[Some("LARRY"), Some("MB"), Some("A.ISI.EDU.")],
+            ),
+            (
+                "CURLEY  MB      A.ISI.EDU.",
+                &[Some("CURLEY"), Some("MB"), Some("A.ISI.EDU.")],
+            ),
+            (
+                "STOOGES MG      MOE",
+                &[Some("STOOGES"), Some("MG"), Some("MOE")],
+            ),
+            ("        MG      LARRY", &[None, Some("MG"), Some("LARRY")]),
+            (
+                "        MG      CURLEY",
+                &[None, Some("MG"), Some("CURLEY")],
+            ),
+        ];
+
+        let mut buffer = Vec::new();
+        for (input, expected) in cases {
+            let mut scanner = Scanner::new(input.as_bytes(), None);
+            for &expected in expected {
+                let token = scanner.scan_token(&mut buffer).unwrap();
+                assert_eq!(token, expected.map(|s| s.as_bytes()));
+                scanner.skip_ws();
+            }
+            assert_eq!(scanner.scan_token(&mut buffer), Ok(None));
+        }
+    }
+}

--- a/src/new/zonefile/simple.rs
+++ b/src/new/zonefile/simple.rs
@@ -1,0 +1,748 @@
+//! A simple zonefile scanner.
+//!
+//! [`ZonefileScanner`] can be used to parse a zonefile directly out of an I/O
+//! source.  It returns a sequence of zonefile entries, which are records or
+//! directives.  It aims to be reasonably efficient -- the scanner re-uses
+//! allocations between returned records, expecting callers to copy them out
+//! if they need to.
+//!
+//! # Usage
+//!
+//! ```
+//! # use domain::new::base::name::RevNameBuf;
+//! # use domain::new::zonefile::simple::{ZonefileScanner, Entry};
+//! let zonefile: &[u8] = br#"
+//! @   IN 42 SOA m r 20 7200 600 3600000 60
+//!           A 127.0.0.1
+//! foo       NS ns.foo.net.
+//! "#;
+//! let origin: RevNameBuf = "example.org".parse().unwrap();
+//! let mut scanner = ZonefileScanner::new(zonefile, Some(&origin));
+//! while let Some(entry) = scanner.scan().unwrap() {
+//!     println!("{:?}", entry);
+//! }
+//! ```
+
+use core::fmt;
+use std::{io, path::PathBuf, vec::Vec};
+
+use crate::new::{
+    base::{
+        name::{Name, NameBuf, RevName, RevNameBuf},
+        RClass, Record, TTL,
+    },
+    rdata::RecordData,
+};
+
+use super::{
+    entries::{Entries, EntriesError},
+    scanner::{Scan, ScanError, Scanner},
+};
+
+//----------- ZonefileScanner ------------------------------------------------
+
+/// A simple zonefile scanner.
+///
+/// The zonefile is read in a streaming fashion -- it can thus be arbitrarily
+/// large.  Each record is scanned into a local buffer and can be borrowed for
+/// inspection and copying.
+#[derive(Debug)]
+pub struct ZonefileScanner<R: io::BufRead> {
+    /// The entries in the zonefile.
+    entries: Entries<R>,
+
+    /// The current origin, if one is known.
+    origin: Option<RevNameBuf>,
+
+    /// The implicit owner for the next record.
+    next_owner: Option<RevNameBuf>,
+
+    /// The implicit TTL for the next record.
+    next_ttl: Option<TTL>,
+
+    /// The implicit class for the next record.
+    next_class: Option<RClass>,
+
+    /// A bump allocator for storing indirect data.
+    alloc: bumpalo::Bump,
+
+    /// A buffer for handling tokens.
+    buffer: Vec<u8>,
+}
+
+//--- Construction
+
+impl<R: io::BufRead> ZonefileScanner<R> {
+    /// Construct a new [`ZonefileScanner`].
+    ///
+    /// If the zonefile is relative to a certain origin, it can be specified
+    /// here.  Otherwise, the zonefile can specify its own origin internally,
+    /// or it cannot contain relative domain names.
+    ///
+    /// The given source is assumed to correspond to the beginning of the
+    /// zonefile, for the purpose of calculating line numbers.  If some lines
+    /// are stripped from the beginning of the actual zonefile, line numbers
+    /// reported by the zonefile scanner will be inaccurate.
+    pub fn new(source: R, origin: Option<&RevName>) -> Self {
+        Self {
+            entries: Entries::new(source),
+            origin: origin.map(RevNameBuf::copy_from),
+            next_owner: None,
+            next_ttl: None,
+            next_class: None,
+            alloc: bumpalo::Bump::new(),
+            buffer: Vec::new(),
+        }
+    }
+}
+
+//--- Clone
+
+impl<R: io::BufRead + Clone> Clone for ZonefileScanner<R> {
+    fn clone(&self) -> Self {
+        Self {
+            entries: self.entries.clone(),
+            origin: self.origin.clone(),
+            next_owner: self.next_owner.clone(),
+            next_ttl: self.next_ttl,
+            next_class: self.next_class,
+            alloc: bumpalo::Bump::new(),
+            buffer: Vec::new(),
+        }
+    }
+}
+
+//--- Interaction
+
+impl<R: io::BufRead> ZonefileScanner<R> {
+    /// Scan the next entry and return a reference to it.
+    pub fn scan(&mut self) -> Result<Option<Entry<'_>>, ZonefileError> {
+        // Reset buffers from previous records.
+        self.alloc.reset();
+        self.buffer.clear();
+
+        // Ignore directives for setting the origin and TTL.
+        let entry = loop {
+            let Some(entry) = self.entries.next_entry()? else {
+                return Ok(None);
+            };
+
+            // Parse directives.
+            if entry.content.starts_with(b"$") {
+                match Self::scan_directive(
+                    entry.content,
+                    &mut self.origin,
+                    &mut self.next_ttl,
+                    &self.alloc,
+                    &mut self.buffer,
+                ) {
+                    Ok(Some(entry)) => return Ok(Some(entry)),
+
+                    // If it's not an include directive, keep going.
+                    Ok(None) => continue,
+
+                    Err(error) => {
+                        return Err(ZonefileError::Directive {
+                            error,
+                            line_number: entry.line_numbers.start,
+                        });
+                    }
+                }
+            }
+
+            break entry;
+        };
+
+        match Self::scan_record(
+            entry.content,
+            &self.origin,
+            &mut self.next_owner,
+            &mut self.next_ttl,
+            &mut self.next_class,
+            &self.alloc,
+            &mut self.buffer,
+        ) {
+            Ok(record) => Ok(Some(Entry::Record(record))),
+            Err(error) => Err(ZonefileError::Record {
+                error,
+                line_number: entry.line_numbers.start,
+            }),
+        }
+    }
+
+    /// Scan a directive.
+    fn scan_directive<'a>(
+        entry: &[u8],
+        origin: &mut Option<RevNameBuf>,
+        last_ttl: &mut Option<TTL>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut Vec<u8>,
+    ) -> Result<Option<Entry<'a>>, DirectiveError> {
+        // Extract the directive.
+        let pos = entry
+            .iter()
+            .take_while(|&b| !b.is_ascii_whitespace())
+            .count();
+        let (directive, args) = entry.split_at(pos);
+
+        let mut scanner = Scanner::new(args, None);
+        scanner.skip_ws();
+
+        // Select the appropriate sub-directive.
+        if directive.eq_ignore_ascii_case(b"$INCLUDE") {
+            Ok(Some(Self::scan_include_directive(
+                scanner, origin, alloc, buffer,
+            )?))
+        } else if directive.eq_ignore_ascii_case(b"$ORIGIN") {
+            Self::scan_origin_directive(scanner, origin, alloc, buffer)?;
+            Ok(None)
+        } else if directive.eq_ignore_ascii_case(b"$TTL") {
+            Self::scan_ttl_directive(scanner, last_ttl, alloc, buffer)?;
+            Ok(None)
+        } else {
+            Err(DirectiveError::UnknownDirective)
+        }
+    }
+
+    /// Scan an include directive.
+    fn scan_include_directive<'a>(
+        mut scanner: Scanner<'_>,
+        origin: &Option<RevNameBuf>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut Vec<u8>,
+    ) -> Result<Entry<'a>, DirectiveError> {
+        let file_name: PathBuf = scanner
+            .scan_token(buffer)
+            .transpose()
+            .ok_or(DirectiveError::MissingFields)?
+            .ok()
+            .and_then(|token| core::str::from_utf8(token).ok())
+            .ok_or(DirectiveError::InvalidIncludePath)?
+            .into();
+
+        let mut origin = origin.clone();
+        if !scanner.remaining().is_empty() {
+            origin = Some(
+                RevNameBuf::scan(&mut scanner, alloc, buffer)
+                    .map_err(|_| DirectiveError::InvalidOrigin)?,
+            );
+        }
+        let origin = origin.map(|origin| {
+            let bytes = alloc.alloc_slice_copy(origin.as_bytes());
+            // SAFETY: 'RevName::as_bytes()' is always valid.
+            unsafe { RevName::from_bytes_unchecked(bytes) }
+        });
+
+        Ok(Entry::Include { file_name, origin })
+    }
+
+    /// Scan an origin directive.
+    fn scan_origin_directive(
+        mut scanner: Scanner<'_>,
+        origin: &mut Option<RevNameBuf>,
+        alloc: &bumpalo::Bump,
+        buffer: &mut Vec<u8>,
+    ) -> Result<(), DirectiveError> {
+        if scanner.remaining().is_empty() {
+            return Err(DirectiveError::MissingFields);
+        }
+
+        *origin = Some(
+            RevNameBuf::scan(&mut scanner, alloc, buffer)
+                .map_err(|_| DirectiveError::InvalidOrigin)?,
+        );
+        Ok(())
+    }
+
+    /// Scan a TTL directive.
+    fn scan_ttl_directive(
+        mut scanner: Scanner<'_>,
+        last_ttl: &mut Option<TTL>,
+        alloc: &bumpalo::Bump,
+        buffer: &mut Vec<u8>,
+    ) -> Result<(), DirectiveError> {
+        if scanner.remaining().is_empty() {
+            return Err(DirectiveError::MissingFields);
+        }
+
+        *last_ttl = Some(
+            TTL::scan(&mut scanner, alloc, buffer)
+                .map_err(|_| DirectiveError::InvalidTTL)?,
+        );
+        Ok(())
+    }
+
+    /// Scan a record.
+    fn scan_record<'a>(
+        entry: &[u8],
+        origin: &Option<RevNameBuf>,
+        last_owner: &mut Option<RevNameBuf>,
+        last_ttl: &mut Option<TTL>,
+        last_rclass: &mut Option<RClass>,
+        alloc: &'a bumpalo::Bump,
+        buffer: &mut Vec<u8>,
+    ) -> Result<ScannedRecord<'a>, RecordError> {
+        let mut scanner = Scanner::new(entry, origin.as_ref().map(|n| &**n));
+
+        // Try parsing the record name.
+        let owner = match *scanner.remaining() {
+            [] => unreachable!(
+                "'scan_record' is only called on non-empty entries"
+            ),
+            [c, ..] if c.is_ascii_whitespace() => {
+                // The domain name is implicit.  Use the last owner name.
+                let owner = last_owner
+                    .as_ref()
+                    .ok_or(RecordError::MissingFirstField)?;
+                let bytes = alloc.alloc_slice_copy(owner.as_bytes());
+                // SAFETY: 'RevName::as_bytes()' is guaranteed to be valid.
+                unsafe { RevName::from_bytes_unchecked(bytes) }
+            }
+            _ => {
+                // Parse the domain name explicitly.
+                let owner = <&'a RevName>::scan(&mut scanner, alloc, buffer)
+                    .map_err(RecordError::OwnerError)?;
+                *last_owner = Some(RevNameBuf::copy_from(owner));
+                owner
+            }
+        };
+
+        // Try parsing the TTL, class, and type.
+        let mut rclass = None;
+        let mut ttl = None;
+        loop {
+            // Skip to the next field.
+            if !scanner.skip_ws() {
+                return Err(RecordError::MissingFields);
+            }
+
+            let input = scanner.remaining();
+
+            // Try parsing a TTL.
+            let c = input.first().ok_or(RecordError::MissingFields)?;
+            if c.is_ascii_digit() {
+                if ttl.is_some() {
+                    return Err(RecordError::MultipleTTLs);
+                }
+
+                ttl = Some(
+                    TTL::scan(&mut scanner, alloc, buffer)
+                        .map_err(RecordError::TTLError)?,
+                );
+                continue;
+            }
+
+            // Try parsing a class.
+            let mut temp = scanner.clone();
+            if let Ok(parsed) = RClass::scan(&mut temp, alloc, buffer) {
+                if rclass.is_some() {
+                    return Err(RecordError::MultipleClasses);
+                }
+
+                rclass = Some(parsed);
+                scanner = temp;
+                continue;
+            }
+
+            // We will assume it's a valid record type.
+            break;
+        }
+
+        let rclass = rclass
+            .or(*last_rclass)
+            .ok_or(RecordError::MissingFirstField)?;
+        *last_rclass = Some(rclass);
+
+        let ttl = ttl.or(*last_ttl).ok_or(RecordError::MissingFirstField)?;
+        *last_ttl = Some(ttl);
+
+        // Parse the record data.
+        let data =
+            // NOTE: If the unknown record data format is used for a type we
+            // recognize, we will scan it as 'UnknownRecordData' and then
+            // parse the bytes to ensure validity.  Unfortunately, it is not
+            // possible to parse bytes into '&RevName' (it would need access
+            // to the bump allocator).  So we just parse as 'RevNameBuf' and
+            // push all names onto the bump allocator afterwards.  Hopefully,
+            // the compiler is able to inline this fairly large type away.
+            <RecordData<'a, NameBuf>>::scan(&mut scanner, alloc, buffer)
+                .map_err(RecordError::DataError)?
+                .map_names(|name| {
+                    let bytes = alloc.alloc_slice_copy(name.as_bytes());
+                    // SAFETY: 'Name::as_bytes()' is always valid.
+                    unsafe { Name::from_bytes_unchecked(bytes) }
+                });
+        Ok(Record {
+            rname: owner,
+            rtype: data.rtype(),
+            rclass,
+            ttl,
+            rdata: data,
+        })
+    }
+}
+
+//----------- Type Aliases ---------------------------------------------------
+
+/// A scanned record.
+pub type ScannedRecord<'a> = Record<&'a RevName, RecordData<'a, &'a Name>>;
+
+/// An entry in a zonefile.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Entry<'a> {
+    /// A zonefile record.
+    Record(ScannedRecord<'a>),
+
+    /// An include directive.
+    Include {
+        /// The file name to include.
+        file_name: PathBuf,
+
+        /// The origin domain name to use.
+        origin: Option<&'a RevName>,
+    },
+}
+
+//----------- ScanError ------------------------------------------------------
+
+/// An error in scanning a zonefile.
+#[derive(Debug)]
+pub enum ZonefileError {
+    /// An error in scanning a record.
+    Record {
+        /// The scanning error that occurred.
+        error: RecordError,
+
+        /// The line number of the entry.
+        line_number: usize,
+    },
+
+    /// An error in scanning a directive.
+    Directive {
+        /// The scanning error that occurred.
+        error: DirectiveError,
+
+        /// The line number of the entry.
+        line_number: usize,
+    },
+
+    /// An error in disambiguating entries.
+    Entries(EntriesError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ZonefileError {}
+
+//--- Conversion from error types
+
+impl From<EntriesError> for ZonefileError {
+    fn from(error: EntriesError) -> Self {
+        Self::Entries(error)
+    }
+}
+
+//--- Formatting
+
+impl fmt::Display for ZonefileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Record { error, line_number } => {
+                write!(f, "failed to parse the record on line {line_number}: {error}")
+            }
+            Self::Directive { error, line_number } => {
+                write!(f, "failed to parse the directive on line {line_number}: {error}")
+            }
+            Self::Entries(error) => error.fmt(f),
+        }
+    }
+}
+
+//----------- RecordError ----------------------------------------------------
+
+/// An error in scanning a zonefile record.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RecordError {
+    /// An unknown record data type was encountered.
+    UnknownRecordType,
+
+    /// The origin name was requested, but none was set.
+    MissingOrigin,
+
+    /// A field in the first record was left implicit.
+    MissingFirstField,
+
+    /// A record was missing some fields.
+    MissingFields,
+
+    /// A record specified multiple TTLs.
+    MultipleTTLs,
+
+    /// A record specified multiple classes.
+    MultipleClasses,
+
+    /// The record name could not be scanned.
+    OwnerError(ScanError),
+
+    /// The record class could not be scanned.
+    ClassError(ScanError),
+
+    /// The TTL could not be scanned.
+    TTLError(ScanError),
+
+    /// The record data could not be scanned.
+    DataError(ScanError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RecordError {}
+
+//--- Formatting
+
+impl fmt::Display for RecordError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::UnknownRecordType => "unknown record type",
+            Self::MissingOrigin => "the origin name is unknown",
+            Self::MissingFirstField => "could not infer an omitted field",
+            Self::MissingFields => "one or more required fields were missing",
+            Self::MultipleTTLs => "multiple TTLs were specified",
+            Self::MultipleClasses => "multiple record classes were specified",
+            Self::OwnerError(err) => {
+                return write!(f, "could not parse the owner name: {err}")
+            }
+            Self::ClassError(err) => {
+                return write!(f, "could not parse the record class: {err}")
+            }
+            Self::TTLError(err) => {
+                return write!(f, "could not parse the record TTL: {err}")
+            }
+            Self::DataError(err) => {
+                return write!(f, "could not parse the record data: {err}")
+            }
+        })
+    }
+}
+
+//----------- DirectiveError -------------------------------------------------
+
+/// An error in scanning a zonefile directive.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DirectiveError {
+    /// A directive was missing some fields.
+    MissingFields,
+
+    /// An include directive contained an invalid file name.
+    InvalidIncludePath,
+
+    /// An invalid origin name was specified.
+    InvalidOrigin,
+
+    /// An invalid TTL was specified.
+    InvalidTTL,
+
+    /// An unknown directive was used.
+    UnknownDirective,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DirectiveError {}
+
+//--- Formatting
+
+impl fmt::Display for DirectiveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::MissingFields => "one or more required fields were missing",
+            Self::InvalidIncludePath => "could not parse the include path",
+            Self::InvalidOrigin => "could not parse the origin name",
+            Self::InvalidTTL => "could not parse the TTL",
+            Self::UnknownDirective => "unrecognized directive",
+        })
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use core::net::Ipv4Addr;
+    use std::path::PathBuf;
+
+    use crate::new::{
+        base::{
+            name::{NameBuf, RevNameBuf},
+            wire::{U16, U32},
+            RClass, RType, Record, Serial, TTL,
+        },
+        rdata::{Mx, Ns, RecordData, Soa, A},
+    };
+
+    use super::{Entry, ZonefileScanner};
+
+    #[test]
+    fn rfc1035() {
+        let source: &[u8] = br#"
+$TTL 42
+@   IN  SOA     VENERA      Action-domains (
+                                 20     ; SERIAL
+                                 7200   ; REFRESH
+                                 600    ; RETRY
+                                 3600000; EXPIRE
+                                 60)    ; MINIMUM
+
+        NS      A.ISI.EDU.
+        NS      VENERA
+        NS      VAXA
+        MX      10      VENERA
+        MX      20      VAXA
+
+A       A       26.3.0.103
+
+VENERA  A       10.1.0.52
+        A       128.9.0.32
+
+VAXA    A       10.2.0.27
+        A       128.9.0.33
+
+
+$INCLUDE <SUBSYS>ISI-MAILBOXES.TXT
+"#;
+
+        let origin: RevNameBuf = "ISI.EDU".parse().unwrap();
+
+        let addrs = [
+            Ipv4Addr::new(26, 3, 0, 103),
+            Ipv4Addr::new(10, 1, 0, 52),
+            Ipv4Addr::new(128, 9, 0, 32),
+            Ipv4Addr::new(10, 2, 0, 27),
+            Ipv4Addr::new(128, 9, 0, 33),
+        ]
+        .map(A::from);
+
+        let records = [
+            Record::<RevNameBuf, RecordData<'_, NameBuf>> {
+                rname: origin.clone(),
+                rtype: RType::SOA,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::Soa(Soa {
+                    mname: "VENERA.ISI.EDU".parse().unwrap(),
+                    rname: "Action-domains.ISI.EDU".parse().unwrap(),
+                    serial: Serial::from(20),
+                    refresh: U32::new(7200),
+                    retry: U32::new(600),
+                    expire: U32::new(3_600_000),
+                    minimum: U32::new(60),
+                }),
+            },
+            Record {
+                rname: origin.clone(),
+                rtype: RType::NS,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::Ns(Ns {
+                    server: "A.ISI.EDU".parse().unwrap(),
+                }),
+            },
+            Record {
+                rname: origin.clone(),
+                rtype: RType::NS,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::Ns(Ns {
+                    server: "VENERA.ISI.EDU".parse().unwrap(),
+                }),
+            },
+            Record {
+                rname: origin.clone(),
+                rtype: RType::NS,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::Ns(Ns {
+                    server: "VAXA.ISI.EDU".parse().unwrap(),
+                }),
+            },
+            Record {
+                rname: origin.clone(),
+                rtype: RType::MX,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::Mx(Mx {
+                    preference: U16::new(10),
+                    exchange: "VENERA.ISI.EDU".parse().unwrap(),
+                }),
+            },
+            Record {
+                rname: origin.clone(),
+                rtype: RType::MX,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::Mx(Mx {
+                    preference: U16::new(20),
+                    exchange: "VAXA.ISI.EDU".parse().unwrap(),
+                }),
+            },
+            Record {
+                rname: "A.ISI.EDU".parse().unwrap(),
+                rtype: RType::A,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::A(addrs[0]),
+            },
+            Record {
+                rname: "VENERA.ISI.EDU".parse().unwrap(),
+                rtype: RType::A,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::A(addrs[1]),
+            },
+            Record {
+                rname: "VENERA.ISI.EDU".parse().unwrap(),
+                rtype: RType::A,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::A(addrs[2]),
+            },
+            Record {
+                rname: "VAXA.ISI.EDU".parse().unwrap(),
+                rtype: RType::A,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::A(addrs[3]),
+            },
+            Record {
+                rname: "VAXA.ISI.EDU".parse().unwrap(),
+                rtype: RType::A,
+                rclass: RClass::IN,
+                ttl: TTL::from(42),
+                rdata: RecordData::A(addrs[4]),
+            },
+        ];
+
+        let mut expected = records
+            .iter()
+            .map(|r| {
+                Entry::Record(Record {
+                    rname: &*r.rname,
+                    rtype: r.rtype,
+                    rclass: r.rclass,
+                    ttl: r.ttl,
+                    rdata: r.rdata.map_names_by_ref(|n| &**n),
+                })
+            })
+            .chain([Entry::Include {
+                file_name: PathBuf::from("<SUBSYS>ISI-MAILBOXES.TXT"),
+                origin: Some(&origin),
+            }]);
+
+        let mut scanner = ZonefileScanner::new(source, Some(&origin));
+        loop {
+            let expected = expected.next();
+            let actual = scanner.scan().unwrap();
+            assert_eq!(expected, actual);
+            if expected.is_none() {
+                break;
+            }
+        }
+    }
+}

--- a/src/utils/decoding.rs
+++ b/src/utils/decoding.rs
@@ -1,0 +1,877 @@
+//! Decoding for common binary-to-text formats.
+
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+//----------- Base16Dec ------------------------------------------------------
+
+/// A Base16 decoder.
+#[derive(Default)]
+pub struct Base16Dec {
+    /// Carry-over bytes.
+    carry: [u8; 2],
+}
+
+impl Base16Dec {
+    /// Prepare for Base16 decoding.
+    pub const fn new() -> Self {
+        Self { carry: [0; 2] }
+    }
+
+    /// The necessary buffer size for decoded Base16 content.
+    ///
+    /// This returns the minimum size of the destination buffer for a call to
+    /// [`decode()`], accounting for any carry-over data currently saved.
+    ///
+    /// [`decode()`]: Self::decode()
+    pub const fn decoded_len(&self, encoded_len: usize) -> usize {
+        (self.carry[1] as usize + encoded_len) / 2
+    }
+
+    /// Decode some bytes into Base16.
+    ///
+    /// A partial byte, if any, will be saved for a future call to
+    /// [`decode()`] -- or [`finish()`] if there is no more data left.
+    ///
+    /// [`decode()`]: Self::decode()
+    /// [`finish()`]: Self::finish()
+    ///
+    /// # Panics
+    ///
+    /// Panics if `decoded` is too small to fit the decoded data; call
+    /// [`decoded_len()`] to determine how big it should be.
+    ///
+    /// [`decoded_len()`]: Self::decoded_len()
+    pub fn decode<'e>(
+        &mut self,
+        mut encoded: &[u8],
+        decoded: &'e mut [u8],
+    ) -> Result<&'e [u8], DecodeError> {
+        assert!(decoded.len() >= self.decoded_len(encoded.len()));
+
+        if self.decoded_len(encoded.len()) == 0 {
+            // We're not expecting to write any bytes.
+            // Append any encoded bytes to the carry and stop.
+
+            let off = self.carry[1] as usize;
+            self.carry[off..][..encoded.len()].copy_from_slice(encoded);
+            self.carry[1] += encoded.len() as u8;
+            return Ok(&[]);
+        }
+
+        // The offset into 'decoded'.
+        let mut dec = 0;
+
+        // Empty the carry first.
+        if self.carry[1] != 0 {
+            let off = self.carry[1] as usize;
+            self.carry[off..].copy_from_slice(&encoded[..2 - off]);
+            decoded[dec] = Self::decode_block(self.carry)?;
+            self.carry.fill(0);
+            encoded = &encoded[2 - off..];
+            dec += 1;
+        }
+
+        // Process as many blocks from 'encoded' as possible.
+        // TODO (feature(array_chunks)): Use 'slice::array_chunks()'.
+        let mut chunks = encoded.chunks_exact(2);
+        for chunk in &mut chunks {
+            let chunk: [u8; 2] = chunk.try_into().unwrap();
+            decoded[dec] = Self::decode_block(chunk)?;
+            dec += 1;
+        }
+
+        // Save any leftover carry.
+        let leftover = chunks.remainder().len();
+        self.carry[..leftover].copy_from_slice(chunks.remainder());
+        self.carry[1] = leftover as u8;
+
+        Ok(&decoded[..dec])
+    }
+
+    /// Decode bytes into a [`Vec`].
+    #[cfg(feature = "std")]
+    pub fn decode_to_vec<'e>(
+        &mut self,
+        mut encoded: &[u8],
+        decoded: &'e mut Vec<u8>,
+    ) -> Result<&'e [u8], DecodeError> {
+        if self.decoded_len(encoded.len()) == 0 {
+            // We're not expecting to write any bytes.
+            // Append any encoded bytes to the carry and stop.
+
+            let off = self.carry[1] as usize;
+            self.carry[off..][..encoded.len()].copy_from_slice(encoded);
+            self.carry[1] += encoded.len() as u8;
+            return Ok(&[]);
+        }
+
+        // The start of the decoded data.
+        let start = decoded.len();
+
+        // Empty the carry first.
+        if self.carry[1] != 0 {
+            let off = self.carry[1] as usize;
+            self.carry[off..].copy_from_slice(&encoded[..2 - off]);
+            decoded.push(Self::decode_block(self.carry)?);
+            self.carry.fill(0);
+
+            encoded = &encoded[2 - off..];
+        }
+
+        // Process as many blocks from 'encoded' as possible.
+        // TODO (feature(array_chunks)): Use 'slice::array_chunks()'.
+        let mut chunks = encoded.chunks_exact(2);
+        for chunk in &mut chunks {
+            let chunk: [u8; 2] = chunk.try_into().unwrap();
+            decoded.push(Self::decode_block(chunk)?);
+        }
+
+        // Save any leftover carry.
+        let leftover = chunks.remainder().len();
+        self.carry[..leftover].copy_from_slice(chunks.remainder());
+        self.carry[1] = leftover as u8;
+
+        Ok(&decoded[start..])
+    }
+
+    /// Finish decoding any leftover data.
+    pub fn finish(&mut self) -> Result<(), DecodeError> {
+        if self.carry[1] == 0 {
+            Ok(())
+        } else {
+            Err(DecodeError)
+        }
+    }
+
+    /// Decode a single block of data.
+    fn decode_block(mut encoded: [u8; 2]) -> Result<u8, DecodeError> {
+        // Decode each character.
+        for c in &mut encoded {
+            *c = match *c {
+                b'0'..=b'9' => *c - b'0',
+                b'A'..=b'F' => *c - b'A' + 10,
+                b'a'..=b'f' => *c - b'a' + 10,
+                _ => return Err(DecodeError),
+            }
+        }
+
+        Ok((encoded[0] << 4) + encoded[1])
+    }
+}
+
+impl Base16Dec {
+    pub fn all_decoded_len(encoded_len: usize) -> usize {
+        encoded_len / 2
+    }
+
+    /// Decode all the given data statelessly.
+    pub fn decode_all<'e>(
+        encoded: &[u8],
+        decoded: &'e mut [u8],
+    ) -> Result<&'e [u8], DecodeError> {
+        assert!(decoded.len() >= Self::all_decoded_len(encoded.len()));
+
+        let mut this = Self::new();
+        let mut dec = 0;
+        dec += this.decode(encoded, decoded)?.len();
+        this.finish()?;
+
+        Ok(&decoded[..dec])
+    }
+
+    /// Decode all the given data statelessly into a [`Vec`].
+    #[cfg(feature = "std")]
+    pub fn decode_all_to_vec<'e>(
+        encoded: &[u8],
+        decoded: &'e mut Vec<u8>,
+    ) -> Result<&'e [u8], DecodeError> {
+        let mut this = Self::new();
+        let start = decoded.len();
+        this.decode_to_vec(encoded, decoded)?;
+        this.finish()?;
+
+        Ok(&decoded[start..])
+    }
+}
+
+//----------- impl_base_dec --------------------------------------------------
+
+/// Define a decoder for a Base32-like format.
+macro_rules! impl_base_dec {
+    (
+        $(#[$attr:meta])*
+        $vis:vis struct $name:ident;
+    ) => {
+        $(#[$attr])*
+        $vis struct $name {
+            /// Carry-over bytes.
+            carry: [u8; Self::ENCODED_BLOCK_SIZE],
+        }
+
+        impl $name {
+            /// Initialize a new encoder.
+            pub const fn new() -> Self {
+                Self { carry: [0; Self::ENCODED_BLOCK_SIZE] }
+            }
+        }
+
+        impl $name {
+            /// The amount of carry.
+            const fn carry(&self) -> usize {
+                self.carry[Self::ENCODED_BLOCK_SIZE - 1] as usize
+            }
+        }
+
+        impl $name {
+            /// The minimum buffer size for calling [`decode()`].
+            ///
+            /// [`decode()`] must be called with a destination buffer that is
+            /// at least as big as the returned size (in bytes).
+            ///
+            /// [`decode()`]: Self::decode()
+            pub const fn decoded_len(&self, encoded_len: usize) -> usize {
+                let encoded = self.carry() + encoded_len;
+                let blocks = encoded / Self::ENCODED_BLOCK_SIZE;
+                blocks * Self::DECODED_BLOCK_SIZE
+            }
+
+            /// Decode some bytes.
+            ///
+            /// A partial block of encoded bytes, if any, will be saved and
+            /// used for a later call to [`decode()`] or [`finish()`].
+            ///
+            /// # Panics
+            ///
+            /// Panics if `decoded` is too small to fit the decoded data; call
+            /// [`decoded_len()`] to determine how big it should be.
+            ///
+            /// [`decode()`]: Self::decode()
+            /// [`finish()`]: Self::finish()
+            /// [`decoded_len()`]: Self::decoded_len()
+            pub fn decode<'e>(
+                &mut self,
+                mut encoded: &[u8],
+                decoded: &'e mut [u8],
+            ) -> Result<&'e [u8], DecodeError> {
+                let output_len = self.decoded_len(encoded.len());
+                assert!(decoded.len() >= output_len);
+
+                if output_len == 0 {
+                    // We're not expecting to write any bytes.
+                    // Append any encoded bytes to the carry and stop.
+
+                    let off = self.carry();
+                    let carry = &mut self.carry[off..];
+                    carry[..encoded.len()].copy_from_slice(encoded);
+                    carry[Self::ENCODED_BLOCK_SIZE - 1]
+                        += encoded.len() as u8;
+                    return Ok(&[]);
+                }
+
+                // The offset to write in `decoded` at.
+                let mut dec = 0;
+
+                // Empty the carry first.
+                if self.carry() != 0 {
+                    let off = self.carry();
+                    let carry = &mut self.carry[off..];
+                    let remaining = carry.len();
+
+                    carry.copy_from_slice(&encoded[..remaining]);
+                    dec += decoded[dec..]
+                        .iter_mut()
+                        .zip(Self::decode_block(self.carry)?)
+                        .map(|(d, b)| *d = b)
+                        .count();
+
+                    self.carry.fill(0);
+                    encoded = &encoded[remaining..];
+                }
+
+                // Process as many blocks from 'encoded' as possible.
+                // TODO (feature(array_chunks)): Use 'slice::array_chunks()'.
+                let mut input = encoded
+                    .chunks_exact(Self::ENCODED_BLOCK_SIZE);
+                for block in &mut input {
+                    let block = block.try_into().unwrap();
+                    dec += decoded[dec..]
+                        .iter_mut()
+                        .zip(Self::decode_block(block)?)
+                        .map(|(d, b)| *d = b)
+                        .count();
+                }
+
+                // Save any leftover carry.
+                let leftover = input.remainder().len();
+                self.carry[..leftover].copy_from_slice(input.remainder());
+                self.carry[Self::ENCODED_BLOCK_SIZE - 1] = leftover as u8;
+
+                Ok(&decoded[..dec])
+            }
+
+            /// Decode bytes into a [`Vec`].
+            ///
+            /// The bytes will be decoded and appended to the [`Vec`].  The
+            /// appended bytes will be returned as a string.  A partial block
+            /// of encoded bytes, if any, will be saved and used for a later
+            /// call to [`decode()`] or [`finish()`].
+            ///
+            /// [`decode()`]: Self::decode()
+            /// [`finish()`]: Self::finish()
+            #[cfg(feature = "std")]
+            pub fn decode_to_vec<'e>(
+                &mut self,
+                mut encoded: &[u8],
+                decoded: &'e mut Vec<u8>,
+            ) -> Result<&'e [u8], DecodeError> {
+                if self.decoded_len(encoded.len()) == 0 {
+                    // We're not expecting to write any bytes.
+                    // Append any encoded bytes to the carry and stop.
+
+                    let off = self.carry();
+                    let carry = &mut self.carry[off..];
+                    carry[..encoded.len()].copy_from_slice(encoded);
+                    carry[Self::ENCODED_BLOCK_SIZE - 1]
+                        += encoded.len() as u8;
+                    return Ok(&[]);
+                }
+
+                // The start of the decoded data.
+                let start = decoded.len();
+
+                // Empty the carry first.
+                if self.carry() != 0 {
+                    let off = self.carry();
+                    let carry = &mut self.carry[off..];
+                    let remaining = carry.len();
+
+                    carry.copy_from_slice(&encoded[..remaining]);
+                    decoded.extend(Self::decode_block(self.carry)?);
+
+                    self.carry.fill(0);
+                    encoded = &encoded[remaining..];
+                }
+
+                // Process as many blocks from 'encoded' as possible.
+                // TODO (feature(array_chunks)): Use 'slice::array_chunks()'.
+                let mut input = encoded
+                    .chunks_exact(Self::ENCODED_BLOCK_SIZE);
+                for chunk in &mut input {
+                    let chunk = chunk.try_into().unwrap();
+                    decoded.extend(Self::decode_block(chunk)?);
+                }
+
+                // Save any leftover carry.
+                let leftover = input.remainder().len();
+                self.carry[..leftover].copy_from_slice(input.remainder());
+                self.carry[Self::ENCODED_BLOCK_SIZE - 1] = leftover as u8;
+
+                Ok(&decoded[start..])
+            }
+
+            /// The minimum buffer size for calling [`finish()`].
+            ///
+            /// [`finish()`] must be called with a destination buffer that is
+            /// at least as big as the returned size (in bytes).
+            ///
+            /// [`finish()`]: Self::finish()
+            pub fn finished_len(&self, partial: bool) -> usize {
+                if partial {
+                    (self.carry() * Self::DECODED_BLOCK_SIZE)
+                        / Self::ENCODED_BLOCK_SIZE
+                } else {
+                    0
+                }
+            }
+
+            /// Finish decoding.
+            ///
+            /// If some encoded bytes were left over from previous calls to
+            /// [`decode()`], and partial decoding is allowed, they will be
+            /// decoded and written to the given slice.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `decoded` is too small to fit the decoded data; call
+            /// [`finished_len()`] to determine how big it should be.
+            ///
+            /// [`decode()`]: Self::decode()
+            /// [`finished_len()`]: Self::finished_len()
+            pub fn finish<'e>(
+                &mut self,
+                decoded: &'e mut [u8],
+                partial: bool,
+            ) -> Result<&'e [u8], DecodeError> {
+                let output_len = self.finished_len(partial);
+                assert!(decoded.len() >= output_len);
+                let decoded = &mut decoded[..output_len];
+
+                if self.carry() == 0 {
+                    return Ok(&[]);
+                } else if !partial {
+                    return Err(DecodeError);
+                }
+
+                let len = self.carry();
+                self.carry[len..].fill(Self::PADDING);
+                decoded.iter_mut()
+                    .zip(Self::decode_block(self.carry)?)
+                    .for_each(|(d, b)| *d = b);
+                self.carry.fill(0);
+
+                Ok(decoded)
+            }
+
+            /// Finish decoding.
+            ///
+            /// If some encoded bytes were left over from previous calls to
+            /// [`decode()`], they will be decoded (and possibly padded) and
+            /// appended to the given [`Vec`].
+            ///
+            /// [`decode()`]: Self::decode()
+            #[cfg(feature = "std")]
+            pub fn finish_to_vec<'e>(
+                &mut self,
+                decoded: &'e mut Vec<u8>,
+                partial: bool,
+            ) -> Result<&'e [u8], DecodeError> {
+                let start = decoded.len();
+
+                if self.carry() == 0 {
+                    return Ok(&[]);
+                } else if !partial {
+                    return Err(DecodeError);
+                }
+
+                let len = self.carry();
+                self.carry[len..].fill(Self::PADDING);
+                decoded.extend(Self::decode_block(self.carry)?);
+                self.carry.fill(0);
+
+                // Write padding if necessary.
+                Ok(&decoded[start..])
+            }
+        }
+
+        impl $name {
+            /// The minimum buffer size for calling [`decode_all()`].
+            ///
+            /// [`decode_all()`] must be called with a destination buffer that
+            /// is at least as big as the returned size (in bytes).
+            ///
+            /// [`decode_all()`]: Self::decode_all()
+            pub fn all_decoded_len(
+                encoded_len: usize,
+                partial: bool,
+            ) -> usize {
+                if partial {
+                    (encoded_len * Self::DECODED_BLOCK_SIZE)
+                        .div_ceil(Self::ENCODED_BLOCK_SIZE)
+                } else {
+                    (encoded_len / Self::ENCODED_BLOCK_SIZE)
+                        * Self::DECODED_BLOCK_SIZE
+                }
+            }
+
+            /// Decode bytes statelessly.
+            ///
+            /// This is a convenidece function for calling [`decode()`] and
+            /// [`finish()`] with a single slice of input.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `decoded` is too small to fit the decoded data; call
+            /// [`all_decoded_len()`] to determine how big it should be.
+            ///
+            /// [`decode()`]: Self::decode()
+            /// [`finish()`]: Self::finish()
+            /// [`all_decoded_len()`]: Self::all_decoded_len()
+            pub fn decode_all<'e>(
+                encoded: &[u8],
+                decoded: &'e mut [u8],
+                partial: bool,
+            ) -> Result<&'e [u8], DecodeError> {
+                let len = Self::all_decoded_len(encoded.len(), partial);
+                assert!(decoded.len() >= len);
+
+                let mut this = Self::new();
+                let mut dec = 0;
+                dec += this.decode(encoded, decoded)?.len();
+                dec += this.finish(&mut decoded[dec..], partial)?.len();
+
+                Ok(&decoded[..dec])
+            }
+
+            /// Decode bytes into a [`Vec`] statelessly.
+            ///
+            /// This is a convenidece function for calling [`decode_to_vec()`]
+            /// and [`finish_to_vec()`] with a single slice of input.
+            ///
+            /// [`decode_to_vec()`]: Self::decode_to_vec()
+            /// [`finish_to_vec()`]: Self::finish_to_vec()
+            #[cfg(feature = "std")]
+            pub fn decode_all_to_vec<'e>(
+                encoded: &[u8],
+                decoded: &'e mut Vec<u8>,
+                partial: bool,
+            ) -> Result<&'e [u8], DecodeError> {
+                let start = decoded.len();
+
+                let mut this = Self::new();
+                this.decode_to_vec(encoded, decoded)?;
+                this.finish_to_vec(decoded, partial)?;
+
+                Ok(&decoded[start..])
+            }
+        }
+    };
+}
+
+//----------- Base32Dec ------------------------------------------------------
+
+impl_base_dec! {
+    /// A Base32 decoder.
+    #[derive(Default)]
+    pub struct Base32Dec;
+}
+
+impl Base32Dec {
+    /// The size of a decoded block.
+    const DECODED_BLOCK_SIZE: usize = 5;
+
+    /// The size of an encoded block.
+    const ENCODED_BLOCK_SIZE: usize = 8;
+
+    /// An encoded padding character.
+    const PADDING: u8 = b'=';
+
+    /// Decode a single block of data.
+    fn decode_block(
+        mut encoded: [u8; 8],
+    ) -> Result<impl ExactSizeIterator<Item = u8>, DecodeError> {
+        // Check for padding.
+        let non_padding = encoded
+            .iter()
+            .position(|&c| c == b'=')
+            .unwrap_or(encoded.len());
+        let len = match non_padding {
+            8 => 5,
+            7 => 4,
+            5 => 3,
+            4 => 2,
+            2 => 1,
+            _ => return Err(DecodeError),
+        };
+
+        // Check for mixed padding and non-padding characters.
+        if encoded[non_padding..].iter().any(|&c| c != b'=') {
+            return Err(DecodeError);
+        }
+
+        // Overwrite the padding characters to encoded zeros.
+        encoded[non_padding..].fill(b'A');
+
+        // Decode each character.
+        for c in &mut encoded {
+            *c = match *c {
+                b'A'..=b'Z' => *c - b'A',
+                b'a'..=b'z' => *c - b'a',
+                b'2'..=b'7' => *c - b'2' + 26,
+                _ => return Err(DecodeError),
+            }
+        }
+
+        // Use 64-bit arithmetic to rearrange the bits efficiently.
+        let mut block = u64::from_be_bytes(encoded);
+        // 000X XXXX 000X XXXX 000X XXXX 000X XXXX
+        // 000X XXXX 000X XXXX 000X XXXX 000X XXXX
+        block = ((block & 0x1F00_1F00_1F00_1F00) >> 3)
+            | (block & 0x001F_001F_001F_001F);
+        // 0000 00XX XXXX XXXX 0000 00XX XXXX XXXX
+        // 0000 00XX XXXX XXXX 0000 00XX XXXX XXXX
+        block = ((block & 0x03FF0000_03FF0000) >> 6)
+            | (block & 0x000003FF_000003FF);
+        // 0000 0000 0000 XXXX XXXX XXXX XXXX XXXX
+        // 0000 0000 0000 XXXX XXXX XXXX XXXX XXXX
+        block = ((block & 0x000FFFFF00000000) >> 12)
+            | (block & 0x00000000000FFFFF);
+        // 0000 0000 0000 0000 0000 0000 XXXX XXXX
+        // XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX
+        let block = (block << 24).to_be_bytes();
+        Ok(block.into_iter().take(len))
+    }
+}
+
+//----------- Base32Dec ------------------------------------------------------
+
+impl_base_dec! {
+    /// A Base32 decoder using the `base32hex` alphabet.
+    #[derive(Default)]
+    pub struct Base32HexDec;
+}
+
+impl Base32HexDec {
+    /// The size of a decoded block.
+    const DECODED_BLOCK_SIZE: usize = 5;
+
+    /// The size of an encoded block.
+    const ENCODED_BLOCK_SIZE: usize = 8;
+
+    /// An encoded padding character.
+    const PADDING: u8 = b'=';
+
+    /// Decode a single block of data.
+    fn decode_block(
+        mut encoded: [u8; 8],
+    ) -> Result<impl ExactSizeIterator<Item = u8>, DecodeError> {
+        // Check for padding.
+        let non_padding = encoded
+            .iter()
+            .position(|&c| c == b'=')
+            .unwrap_or(encoded.len());
+        let len = match non_padding {
+            8 => 5,
+            7 => 4,
+            5 => 3,
+            4 => 2,
+            2 => 1,
+            _ => return Err(DecodeError),
+        };
+
+        // Check for mixed padding and non-padding characters.
+        if encoded[non_padding..].iter().any(|&c| c != b'=') {
+            return Err(DecodeError);
+        }
+
+        // Overwrite the padding characters to encoded zeros.
+        encoded[non_padding..].fill(b'0');
+
+        // Decode each character.
+        for c in &mut encoded {
+            *c = match *c {
+                b'0'..=b'9' => *c - b'0',
+                b'A'..=b'V' => *c - b'A' + 10,
+                b'a'..=b'v' => *c - b'a' + 10,
+                _ => return Err(DecodeError),
+            }
+        }
+
+        // Use 64-bit arithmetic to rearrange the bits efficiently.
+        let mut block = u64::from_be_bytes(encoded);
+        // 000X XXXX 000X XXXX 000X XXXX 000X XXXX
+        // 000X XXXX 000X XXXX 000X XXXX 000X XXXX
+        block = ((block & 0x1F00_1F00_1F00_1F00) >> 3)
+            | (block & 0x001F_001F_001F_001F);
+        // 0000 00XX XXXX XXXX 0000 00XX XXXX XXXX
+        // 0000 00XX XXXX XXXX 0000 00XX XXXX XXXX
+        block = ((block & 0x03FF0000_03FF0000) >> 6)
+            | (block & 0x000003FF_000003FF);
+        // 0000 0000 0000 XXXX XXXX XXXX XXXX XXXX
+        // 0000 0000 0000 XXXX XXXX XXXX XXXX XXXX
+        block = ((block & 0x000FFFFF00000000) >> 12)
+            | (block & 0x00000000000FFFFF);
+        // 0000 0000 0000 0000 0000 0000 XXXX XXXX
+        // XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX
+        let block = (block << 24).to_be_bytes();
+        Ok(block.into_iter().take(len))
+    }
+}
+
+//----------- Base64Dec ------------------------------------------------------
+
+impl_base_dec! {
+    /// A Base64 decoder.
+    #[derive(Default)]
+    pub struct Base64Dec;
+}
+
+impl Base64Dec {
+    /// The size of a decoded block.
+    const DECODED_BLOCK_SIZE: usize = 3;
+
+    /// The size of an encoded block.
+    const ENCODED_BLOCK_SIZE: usize = 4;
+
+    /// An encoded padding character.
+    const PADDING: u8 = b'=';
+
+    /// Decode a single block of data.
+    fn decode_block(
+        mut encoded: [u8; 4],
+    ) -> Result<impl ExactSizeIterator<Item = u8>, DecodeError> {
+        // Check for padding.
+        let len = match encoded {
+            [_, _, b'=', b'='] => {
+                encoded[2..].fill(b'A');
+                1
+            }
+            [_, _, _, b'='] => {
+                encoded[3..].fill(b'A');
+                2
+            }
+            _ => 3,
+        };
+
+        // Decode each character.
+        for c in &mut encoded {
+            *c = match *c {
+                b'A'..=b'Z' => *c - b'A',
+                b'a'..=b'z' => *c - b'a' + 26,
+                b'0'..=b'9' => *c - b'0' + 52,
+                b'+' => 62,
+                b'/' => 63,
+                _ => return Err(DecodeError),
+            }
+        }
+
+        // Use 32-bit arithmetic to rearrange the bits efficiently.
+        let mut block = u32::from_be_bytes(encoded);
+        // 00XX XXXX 00XX XXXX 00XX XXXX 00XX XXXX
+        block = ((block & 0x3F003F00) >> 2) | (block & 0x003F003F);
+        // 0000 XXXX XXXX XXXX 0000 XXXX XXXX XXXX
+        block = ((block & 0x0FFF0000) >> 4) | (block & 0x00000FFF);
+        // 0000 0000 XXXX XXXX XXXX XXXX XXXX XXXX
+        let block = (block << 8).to_be_bytes();
+        Ok(block.into_iter().take(len))
+    }
+}
+
+//----------- DecodeError ----------------------------------------------------
+
+/// An error when decoding Base32/Base64/etc.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DecodeError;
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use super::{Base16Dec, Base32Dec, Base32HexDec, Base64Dec};
+
+    #[test]
+    fn base16() {
+        const CASES: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "66"),
+            (b"fo", "666F"),
+            (b"foo", "666F6F"),
+            (b"foob", "666F6F62"),
+            (b"fooba", "666F6F6261"),
+            (b"foobar", "666F6F626172"),
+        ];
+
+        for &(output, input) in CASES {
+            let mut buffer = [0u8; 12];
+            assert_eq!(
+                Base16Dec::decode_all(input.as_bytes(), &mut buffer),
+                Ok(output)
+            );
+        }
+    }
+
+    #[test]
+    fn base32() {
+        const CASES: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "MY======"),
+            (b"fo", "MZXQ===="),
+            (b"foo", "MZXW6==="),
+            (b"foo\n", "MZXW6CQ="),
+            (b"foo\nb", "MZXW6CTC"),
+            (b"foo\nba", "MZXW6CTCME======"),
+            (b"foo\nbar", "MZXW6CTCMFZA===="),
+        ];
+
+        for &(output, input) in CASES {
+            let mut buffer = [0u8; 16];
+            assert_eq!(
+                Base32Dec::decode_all(input.as_bytes(), &mut buffer, false),
+                Ok(output)
+            );
+            assert_eq!(
+                Base32Dec::decode_all(input.as_bytes(), &mut buffer, true),
+                Ok(output)
+            );
+            assert_eq!(
+                Base32Dec::decode_all(
+                    input.trim_end_matches('=').as_bytes(),
+                    &mut buffer,
+                    true
+                ),
+                Ok(output)
+            );
+        }
+    }
+
+    #[test]
+    fn base32hex() {
+        const CASES: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "CO======"),
+            (b"fo", "CPNG===="),
+            (b"foo", "CPNMU==="),
+            (b"foo\n", "CPNMU2G="),
+            (b"foo\nb", "CPNMU2J2"),
+            (b"foo\nba", "CPNMU2J2C4======"),
+            (b"foo\nbar", "CPNMU2J2C5P0===="),
+        ];
+
+        for &(output, input) in CASES {
+            let mut buffer = [0u8; 16];
+            assert_eq!(
+                Base32HexDec::decode_all(
+                    input.as_bytes(),
+                    &mut buffer,
+                    false
+                ),
+                Ok(output)
+            );
+            assert_eq!(
+                Base32HexDec::decode_all(input.as_bytes(), &mut buffer, true),
+                Ok(output)
+            );
+            assert_eq!(
+                Base32HexDec::decode_all(
+                    input.trim_end_matches('=').as_bytes(),
+                    &mut buffer,
+                    true
+                ),
+                Ok(output)
+            );
+        }
+    }
+
+    #[test]
+    fn base64() {
+        const CASES: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "Zg=="),
+            (b"fo", "Zm8="),
+            (b"fo~", "Zm9+"),
+            (b"fo~b", "Zm9+Yg=="),
+            (b"fo~ba", "Zm9+YmE="),
+            (b"fo~ba\xFF", "Zm9+YmH/"),
+        ];
+
+        for &(output, input) in CASES {
+            let mut buffer = [0u8; 12];
+            assert_eq!(
+                Base64Dec::decode_all(input.as_bytes(), &mut buffer, false),
+                Ok(output)
+            );
+            assert_eq!(
+                Base64Dec::decode_all(input.as_bytes(), &mut buffer, true),
+                Ok(output)
+            );
+            assert_eq!(
+                Base64Dec::decode_all(
+                    input.trim_end_matches('=').as_bytes(),
+                    &mut buffer,
+                    true
+                ),
+                Ok(output)
+            );
+        }
+    }
+}

--- a/src/utils/encoding.rs
+++ b/src/utils/encoding.rs
@@ -1,0 +1,662 @@
+//! Encoding for common binary-to-text formats.
+
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+//----------- Base16Enc ------------------------------------------------------
+
+/// A Base16 encoder.
+#[derive(Default)]
+pub struct Base16Enc;
+
+impl Base16Enc {
+    /// Prepare for Base16 encoding.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// The necessary buffer size for encoded Base16 content.
+    ///
+    /// This returns the minimum size of the destination buffer for a call to
+    /// [`encode()`], accounting for any carry-over data currently saved.
+    ///
+    /// [`encode()`]: Self::encode()
+    pub const fn encoded_len(&self, decoded_len: usize) -> usize {
+        decoded_len * 2
+    }
+
+    /// Encode some bytes into Base16.
+    ///
+    /// Only whole blocks (groups of 2 characters) will be output.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `encoded` is too small to fit the encoded data; call
+    /// [`encoded_len()`] to determine how big it should be.
+    ///
+    /// [`encoded_len()`]: Self::encoded_len()
+    pub fn encode<'e>(
+        &mut self,
+        decoded: &[u8],
+        encoded: &'e mut [u8],
+    ) -> &'e str {
+        assert!(encoded.len() >= self.encoded_len(decoded.len()));
+
+        // The offset into 'encoded'.
+        let mut enc = 0;
+
+        // Process as many blocks from 'decoded' as possible.
+        for &byte in decoded {
+            encoded[enc..][..2].copy_from_slice(&Self::encode_block(byte));
+            enc += 2;
+        }
+
+        // SAFETY: 'encode_block()' only outputs ASCII characters, and the
+        // first 'enc' bytes of 'encoded' have been written with them.
+        unsafe { core::str::from_utf8_unchecked(&encoded[..enc]) }
+    }
+
+    /// Encode bytes into a [`Vec`].
+    #[cfg(feature = "std")]
+    pub fn encode_to_vec<'e>(
+        &mut self,
+        decoded: &[u8],
+        encoded: &'e mut Vec<u8>,
+    ) -> &'e str {
+        // The start of the encoded data.
+        let start = encoded.len();
+
+        // Process as many blocks from 'decoded' as possible.
+        for &byte in decoded {
+            encoded.extend_from_slice(&Self::encode_block(byte));
+        }
+
+        // SAFETY: 'encode_block()' only outputs ASCII characters, and the
+        // first 'enc' bytes of 'encoded' have been written with them.
+        unsafe { core::str::from_utf8_unchecked(&encoded[start..]) }
+    }
+
+    /// Encode a single block of data.
+    fn encode_block(decoded: u8) -> [u8; 2] {
+        let block = [decoded >> 4, decoded & 15];
+        block.map(|c| match c {
+            0..=9 => b'0' + c,
+            10..=15 => b'A' + c - 10,
+            _ => unreachable!(),
+        })
+    }
+}
+
+//----------- impl_base_enc --------------------------------------------------
+
+/// Define an encoder for a Base32-like format.
+macro_rules! impl_base_enc {
+    (
+        $(#[$attr:meta])*
+        $vis:vis struct $name:ident;
+    ) => {
+        $(#[$attr])*
+        $vis struct $name {
+            /// Carry-over bytes.
+            carry: [u8; Self::DECODED_BLOCK_SIZE],
+        }
+
+        impl $name {
+            /// Initialize a new encoder.
+            pub const fn new() -> Self {
+                Self { carry: [0; Self::DECODED_BLOCK_SIZE] }
+            }
+        }
+
+        impl $name {
+            /// The amount of carry.
+            const fn carry(&self) -> usize {
+                self.carry[Self::DECODED_BLOCK_SIZE - 1] as usize
+            }
+        }
+
+        impl $name {
+            /// The minimum buffer size for calling [`encode()`].
+            ///
+            /// [`encode()`] must be called with a destination buffer that is
+            /// at least as big as the returned size (in bytes).
+            ///
+            /// [`encode()`]: Self::encode()
+            pub const fn encoded_len(&self, decoded_len: usize) -> usize {
+                let decoded = self.carry() + decoded_len;
+                let blocks = decoded / Self::DECODED_BLOCK_SIZE;
+                blocks * Self::ENCODED_BLOCK_SIZE
+            }
+
+            /// Encode some bytes.
+            ///
+            /// A partial block of decoded bytes, if any, will be saved and
+            /// used for a later call to [`encode()`] or [`finish()`].
+            ///
+            /// # Panics
+            ///
+            /// Panics if `encoded` is too small to fit the encoded data; call
+            /// [`encoded_len()`] to determine how big it should be.
+            ///
+            /// [`encode()`]: Self::encode()
+            /// [`finish()`]: Self::finish()
+            /// [`encoded_len()`]: Self::encoded_len()
+            pub fn encode<'e>(
+                &mut self,
+                mut decoded: &[u8],
+                encoded: &'e mut [u8],
+            ) -> &'e str {
+                let output_len = self.encoded_len(decoded.len());
+                assert!(encoded.len() >= output_len);
+
+                if output_len == 0 {
+                    // We're not expecting to write any bytes.
+                    // Append any decoded bytes to the carry and stop.
+
+                    let off = self.carry();
+                    let carry = &mut self.carry[off..];
+                    carry[..decoded.len()].copy_from_slice(decoded);
+                    carry[Self::DECODED_BLOCK_SIZE - 1]
+                        += decoded.len() as u8;
+                    return "";
+                }
+
+                // The chunks of output to be written.
+                let encoded = &mut encoded[..output_len];
+                let mut output = encoded
+                    .chunks_exact_mut(Self::ENCODED_BLOCK_SIZE);
+
+                // Empty the carry first.
+                if self.carry() != 0 {
+                    let off = self.carry();
+                    let carry = &mut self.carry[off..];
+                    let remaining = carry.len();
+
+                    carry.copy_from_slice(&decoded[..remaining]);
+                    let block = Self::encode_block(self.carry);
+                    self.carry.fill(0);
+
+                    output.next().unwrap().copy_from_slice(&block);
+                    decoded = &decoded[remaining..];
+                }
+
+                // Process as many blocks from 'decoded' as possible.
+                // TODO (feature(array_chunks)): Use 'slice::array_chunks()'.
+                let mut input = decoded.chunks_exact(Self::DECODED_BLOCK_SIZE);
+                for (dst, src) in output.zip(&mut input) {
+                    let block = src.try_into().unwrap();
+                    let block = Self::encode_block(block);
+                    dst.copy_from_slice(&block);
+                }
+
+                // Save any leftover carry.
+                let leftover = input.remainder().len();
+                self.carry[..leftover].copy_from_slice(input.remainder());
+                self.carry[Self::DECODED_BLOCK_SIZE - 1] = leftover as u8;
+
+                // SAFETY: 'encode_block()' only outputs ASCII characters, and
+                // 'encoded' has been completely overwritten with it.
+                unsafe { core::str::from_utf8_unchecked(encoded) }
+            }
+
+            /// Encode bytes into a [`Vec`].
+            ///
+            /// The bytes will be encoded and appended to the [`Vec`].  The
+            /// appended bytes will be returned as a string.  A partial block
+            /// of decoded bytes, if any, will be saved and used for a later
+            /// call to [`encode()`] or [`finish()`].
+            ///
+            /// [`encode()`]: Self::encode()
+            /// [`finish()`]: Self::finish()
+            #[cfg(feature = "std")]
+            pub fn encode_to_vec<'e>(
+                &mut self,
+                mut decoded: &[u8],
+                encoded: &'e mut Vec<u8>,
+            ) -> &'e str {
+                if self.encoded_len(decoded.len()) == 0 {
+                    // We're not expecting to write any bytes.
+                    // Append any decoded bytes to the carry and stop.
+
+                    let off = self.carry();
+                    let carry = &mut self.carry[off..];
+                    carry[..decoded.len()].copy_from_slice(decoded);
+                    carry[Self::DECODED_BLOCK_SIZE - 1]
+                        += decoded.len() as u8;
+                    return "";
+                }
+
+                // The start of the encoded data.
+                let start = encoded.len();
+
+                // Empty the carry first.
+                if self.carry() != 0 {
+                    let off = self.carry();
+                    let carry = &mut self.carry[off..];
+                    let remaining = carry.len();
+
+                    carry.copy_from_slice(&decoded[..remaining]);
+                    let block = Self::encode_block(self.carry);
+                    self.carry.fill(0);
+
+                    encoded.extend_from_slice(&block);
+                    decoded = &decoded[remaining..];
+                }
+
+                // Process as many blocks from 'decoded' as possible.
+                // TODO (feature(array_chunks)): Use 'slice::array_chunks()'.
+                let mut input = decoded
+                    .chunks_exact(Self::DECODED_BLOCK_SIZE);
+                for chunk in &mut input {
+                    let chunk = chunk.try_into().unwrap();
+                    encoded.extend_from_slice(&Self::encode_block(chunk));
+                }
+
+                // Save any leftover carry.
+                let leftover = input.remainder().len();
+                self.carry[..leftover].copy_from_slice(input.remainder());
+                self.carry[Self::DECODED_BLOCK_SIZE - 1] = leftover as u8;
+
+                // SAFETY: 'encode_block()' only outputs ASCII characters, and
+                // 'encoded[start..]' was written with them.
+                unsafe { core::str::from_utf8_unchecked(&encoded[start..]) }
+            }
+
+            /// The minimum buffer size for calling [`finish()`].
+            ///
+            /// [`finish()`] must be called with a destination buffer that is
+            /// at least as big as the returned size (in bytes).
+            ///
+            /// [`finish()`]: Self::finish()
+            pub fn finished_len(&self, padded: bool) -> usize {
+                match (self.carry(), padded) {
+                    (0, _) => 0,
+                    (_, true) => Self::ENCODED_BLOCK_SIZE,
+                    (n, false) => {
+                        (n * Self::ENCODED_BLOCK_SIZE)
+                            .div_ceil(Self::DECODED_BLOCK_SIZE)
+                    }
+                }
+            }
+
+            /// Finish encoding.
+            ///
+            /// If some decoded bytes were left over from previous calls to
+            /// [`encode()`], they will be encoded (and possibly padded) and
+            /// written to the given slice.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `encoded` is too small to fit the encoded data; call
+            /// [`finished_len()`] to determine how big it should be.
+            ///
+            /// [`encode()`]: Self::encode()
+            /// [`finished_len()`]: Self::finished_len()
+            pub fn finish<'e>(
+                &mut self,
+                encoded: &'e mut [u8],
+                padded: bool,
+            ) -> &'e str {
+                let output_len = self.finished_len(padded);
+                let unpadded_len = self.finished_len(false);
+                assert!(encoded.len() >= output_len);
+                let encoded = &mut encoded[..output_len];
+
+                let len = self.carry();
+                self.carry[len..].fill(0);
+                let mut block = Self::encode_block(self.carry);
+                self.carry.fill(0);
+
+                // Write padding if necessary.
+                match (len, padded) {
+                    (0, _) => return "",
+                    (_, true) => {
+                        block[unpadded_len..].fill(b'=');
+                    }
+                    _ => {}
+                };
+
+                // SAFETY: 'encode_block()' only outputs ASCII characters.
+                encoded.copy_from_slice(&block[..output_len]);
+                unsafe { core::str::from_utf8_unchecked(encoded) }
+            }
+
+            /// Finish encoding.
+            ///
+            /// If some decoded bytes were left over from previous calls to
+            /// [`encode()`], they will be encoded (and possibly padded) and
+            /// appended to the given [`Vec`].
+            ///
+            /// [`encode()`]: Self::encode()
+            #[cfg(feature = "std")]
+            pub fn finish_to_vec<'e>(
+                &mut self,
+                encoded: &'e mut Vec<u8>,
+                padded: bool,
+            ) -> &'e str {
+                let output_len = self.finished_len(padded);
+                let unpadded_len = self.finished_len(false);
+                let start = encoded.len();
+
+                let len = self.carry();
+                self.carry[len..].fill(0);
+                let mut block = Self::encode_block(self.carry);
+                self.carry.fill(0);
+
+                // Write padding if necessary.
+                match (len, padded) {
+                    (0, _) => return "",
+                    (_, true) => {
+                        block[unpadded_len..].fill(b'=');
+                    }
+                    _ => {}
+                };
+
+                // SAFETY: 'encode_block()' only outputs ASCII characters.
+                encoded.extend_from_slice(&block[..output_len]);
+                unsafe { core::str::from_utf8_unchecked(&encoded[start..]) }
+            }
+        }
+
+        impl $name {
+            /// The minimum buffer size for calling [`encode_all()`].
+            ///
+            /// [`encode_all()`] must be called with a destination buffer that
+            /// is at least as big as the returned size (in bytes).
+            ///
+            /// [`encode_all()`]: Self::encode_all()
+            pub fn all_encoded_len(
+                decoded_len: usize,
+                padded: bool
+            ) -> usize {
+                if padded {
+                    decoded_len.div_ceil(Self::DECODED_BLOCK_SIZE)
+                        * Self::ENCODED_BLOCK_SIZE
+                } else {
+                    (decoded_len * Self::ENCODED_BLOCK_SIZE)
+                        .div_ceil(Self::DECODED_BLOCK_SIZE)
+                }
+            }
+
+            /// Encode bytes statelessly.
+            ///
+            /// This is a convenience function for calling [`encode()`] and
+            /// [`finish()`] with a single slice of input.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `encoded` is too small to fit the encoded data; call
+            /// [`all_encoded_len()`] to determine how big it should be.
+            ///
+            /// [`encode()`]: Self::encode()
+            /// [`finish()`]: Self::finish()
+            /// [`all_encoded_len()`]: Self::all_encoded_len()
+            pub fn encode_all<'e>(
+                decoded: &[u8],
+                encoded: &'e mut [u8],
+                padded: bool,
+            ) -> &'e str {
+                let len = Self::all_encoded_len(decoded.len(), padded);
+                assert!(encoded.len() >= len);
+
+                let mut this = Self::new();
+                let enc = this.encode(decoded, encoded).len();
+                let _ = this.finish(&mut encoded[enc..], padded);
+
+                // SAFETY: 'Self' only outputs ASCII characters.
+                unsafe { core::str::from_utf8_unchecked(&encoded[..len]) }
+            }
+
+            /// Encode bytes into a [`Vec`] statelessly.
+            ///
+            /// This is a convenience function for calling [`encode_to_vec()`]
+            /// and [`finish_to_vec()`] with a single slice of input.
+            ///
+            /// [`encode_to_vec()`]: Self::encode_to_vec()
+            /// [`finish_to_vec()`]: Self::finish_to_vec()
+            #[cfg(feature = "std")]
+            pub fn encode_all_to_vec<'e>(
+                decoded: &[u8],
+                encoded: &'e mut Vec<u8>,
+                padded: bool,
+            ) -> &'e str {
+                let start = encoded.len();
+
+                let mut this = Self::new();
+                let _ = this.encode_to_vec(decoded, encoded);
+                let _ = this.finish_to_vec(encoded, padded);
+
+                // SAFETY: 'Self' only outputs ASCII characters.
+                unsafe { core::str::from_utf8_unchecked(&encoded[start..]) }
+            }
+        }
+    };
+}
+
+//----------- Base32Enc ------------------------------------------------------
+
+impl_base_enc! {
+    /// A Base32 encoder.
+    #[derive(Default)]
+    pub struct Base32Enc;
+}
+
+impl Base32Enc {
+    /// The size of a decoded block.
+    const DECODED_BLOCK_SIZE: usize = 5;
+
+    /// The size of an encoded block.
+    const ENCODED_BLOCK_SIZE: usize = 8;
+
+    /// Encode a single block of data.
+    fn encode_block(decoded: [u8; 5]) -> [u8; 8] {
+        let mut block = [0u8; 8];
+        block[3..8].copy_from_slice(&decoded);
+        // Use 64-bit arithmetic to rearrange the bits efficiently.
+        let mut block = u64::from_be_bytes(block);
+        // 0000 0000 0000 0000 0000 0000 XXXX XXXX
+        // XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX
+        block = ((block & 0x000000FFFFF00000) << 12)
+            | (block & 0x00000000000FFFFF);
+        // 0000 0000 0000 XXXX XXXX XXXX XXXX XXXX
+        // 0000 0000 0000 XXXX XXXX XXXX XXXX XXXX
+        block = ((block & 0x000FFC00_000FFC00) << 6)
+            | (block & 0x000003FF_000003FF);
+        // 0000 00XX XXXX XXXX 0000 00XX XXXX XXXX
+        // 0000 00XX XXXX XXXX 0000 00XX XXXX XXXX
+        block = ((block & 0x03E0_03E0_03E0_03E0) << 3)
+            | (block & 0x001F_001F_001F_001F);
+        // 000X XXXX 000X XXXX 000X XXXX 000X XXXX
+        // 000X XXXX 000X XXXX 000X XXXX 000X XXXX
+        let block = block.to_be_bytes();
+        block.map(|c| match c {
+            0..=25 => b'A' + c,
+            26..=31 => b'2' + c - 26,
+            _ => unreachable!(),
+        })
+    }
+}
+
+//----------- Base32HexEnc ---------------------------------------------------
+
+impl_base_enc! {
+    /// A Base32 encoder using the `base32hex` alphabet.
+    #[derive(Default)]
+    pub struct Base32HexEnc;
+}
+
+impl Base32HexEnc {
+    /// The size of a decoded block.
+    const DECODED_BLOCK_SIZE: usize = 5;
+
+    /// The size of an encoded block.
+    const ENCODED_BLOCK_SIZE: usize = 8;
+
+    /// Encode a single block of data.
+    fn encode_block(decoded: [u8; 5]) -> [u8; 8] {
+        let mut block = [0u8; 8];
+        block[3..8].copy_from_slice(&decoded);
+        // Use 64-bit arithmetic to rearrange the bits efficiently.
+        let mut block = u64::from_be_bytes(block);
+        // 0000 0000 0000 0000 0000 0000 XXXX XXXX
+        // XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX
+        block = ((block & 0x000000FFFFF00000) << 12)
+            | (block & 0x00000000000FFFFF);
+        // 0000 0000 0000 XXXX XXXX XXXX XXXX XXXX
+        // 0000 0000 0000 XXXX XXXX XXXX XXXX XXXX
+        block = ((block & 0x000FFC00_000FFC00) << 6)
+            | (block & 0x000003FF_000003FF);
+        // 0000 00XX XXXX XXXX 0000 00XX XXXX XXXX
+        // 0000 00XX XXXX XXXX 0000 00XX XXXX XXXX
+        block = ((block & 0x03E0_03E0_03E0_03E0) << 3)
+            | (block & 0x001F_001F_001F_001F);
+        // 000X XXXX 000X XXXX 000X XXXX 000X XXXX
+        // 000X XXXX 000X XXXX 000X XXXX 000X XXXX
+        let block = block.to_be_bytes();
+        block.map(|c| match c {
+            0..=9 => b'0' + c,
+            10..=31 => b'A' + c - 10,
+            _ => unreachable!(),
+        })
+    }
+}
+
+//----------- Base64Enc ------------------------------------------------------
+
+impl_base_enc! {
+    /// A Base64 encoder.
+    #[derive(Default)]
+    pub struct Base64Enc;
+}
+
+impl Base64Enc {
+    /// The size of a decoded block.
+    const DECODED_BLOCK_SIZE: usize = 3;
+
+    /// The size of an encoded block.
+    const ENCODED_BLOCK_SIZE: usize = 4;
+
+    /// Encode a single block of data.
+    fn encode_block(decoded: [u8; 3]) -> [u8; 4] {
+        let mut block = [0u8; 4];
+        block[1..4].copy_from_slice(&decoded);
+        // Use 32-bit arithmetic to rearrange the bits efficiently.
+        let mut block = u32::from_be_bytes(block);
+        // 0000 0000 XXXX XXXX XXXX XXXX XXXX XXXX
+        block = ((block & 0x00FFF000) << 4) | (block & 0x00000FFF);
+        // 0000 XXXX XXXX XXXX 0000 XXXX XXXX XXXX
+        block = ((block & 0x0FC00FC0) << 2) | (block & 0x003F003F);
+        // 00XX XXXX 00XX XXXX 00XX XXXX 00XX XXXX
+        let block = block.to_be_bytes();
+        block.map(|c| match c {
+            0..=25 => b'A' + c,
+            26..=51 => b'a' + c - 26,
+            52..=61 => b'0' + c - 52,
+            62 => b'+',
+            63 => b'/',
+            _ => unreachable!(),
+        })
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use super::{Base16Enc, Base32Enc, Base32HexEnc, Base64Enc};
+
+    #[test]
+    fn base16() {
+        const CASES: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "66"),
+            (b"fo", "666F"),
+            (b"foo", "666F6F"),
+            (b"foob", "666F6F62"),
+            (b"fooba", "666F6F6261"),
+            (b"foobar", "666F6F626172"),
+        ];
+
+        for &(input, output) in CASES {
+            let mut buffer = [0u8; 12];
+            assert_eq!(Base16Enc.encode(input, &mut buffer), output);
+        }
+    }
+
+    #[test]
+    fn base32() {
+        const CASES: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "MY======"),
+            (b"fo", "MZXQ===="),
+            (b"foo", "MZXW6==="),
+            (b"foo\n", "MZXW6CQ="),
+            (b"foo\nb", "MZXW6CTC"),
+            (b"foo\nba", "MZXW6CTCME======"),
+            (b"foo\nbar", "MZXW6CTCMFZA===="),
+        ];
+
+        for &(input, output) in CASES {
+            let mut buffer = [0u8; 16];
+            assert_eq!(
+                Base32Enc::encode_all(input, &mut buffer, false),
+                output.trim_end_matches('='),
+            );
+            assert_eq!(
+                Base32Enc::encode_all(input, &mut buffer, true),
+                output
+            );
+        }
+    }
+
+    #[test]
+    fn base32hex() {
+        const CASES: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "CO======"),
+            (b"fo", "CPNG===="),
+            (b"foo", "CPNMU==="),
+            (b"foo\n", "CPNMU2G="),
+            (b"foo\nb", "CPNMU2J2"),
+            (b"foo\nba", "CPNMU2J2C4======"),
+            (b"foo\nbar", "CPNMU2J2C5P0===="),
+        ];
+
+        for &(input, output) in CASES {
+            let mut buffer = [0u8; 16];
+            assert_eq!(
+                Base32HexEnc::encode_all(input, &mut buffer, false),
+                output.trim_end_matches('='),
+            );
+            assert_eq!(
+                Base32HexEnc::encode_all(input, &mut buffer, true),
+                output
+            );
+        }
+    }
+
+    #[test]
+    fn base64() {
+        const CASES: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "Zg=="),
+            (b"fo", "Zm8="),
+            (b"fo~", "Zm9+"),
+            (b"fo~b", "Zm9+Yg=="),
+            (b"fo~ba", "Zm9+YmE="),
+            (b"fo~ba\xFF", "Zm9+YmH/"),
+        ];
+
+        for &(input, output) in CASES {
+            let mut buffer = [0u8; 12];
+            assert_eq!(
+                Base64Enc::encode_all(input, &mut buffer, false),
+                output.trim_end_matches('='),
+            );
+            assert_eq!(
+                Base64Enc::encode_all(input, &mut buffer, true),
+                output,
+            );
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,10 +1,63 @@
 //! Various utility modules.
 
+use core::cmp::Ordering;
+
 pub mod base16;
 pub mod base32;
 pub mod base64;
 
+pub mod decoding;
 pub mod dst;
+pub mod encoding;
 
 #[cfg(feature = "net")]
 pub(crate) mod config;
+
+//----------- CmpIter --------------------------------------------------------
+
+/// A wrapper for comparing iterators.
+#[derive(Copy, Clone, Debug)]
+pub struct CmpIter<T>(pub T);
+
+//--- Equality
+
+impl<T, U> PartialEq<CmpIter<U>> for CmpIter<T>
+where
+    T: IntoIterator + Clone,
+    U: IntoIterator + Clone,
+    T::Item: PartialEq<U::Item>,
+{
+    fn eq(&self, other: &CmpIter<U>) -> bool {
+        self.0.clone().into_iter().eq(other.0.clone())
+    }
+}
+
+impl<T> Eq for CmpIter<T>
+where
+    T: IntoIterator + Clone,
+    T::Item: Eq,
+{
+}
+
+//--- Ordering
+
+impl<T, U> PartialOrd<CmpIter<U>> for CmpIter<T>
+where
+    T: IntoIterator + Clone,
+    U: IntoIterator + Clone,
+    T::Item: PartialOrd<U::Item>,
+{
+    fn partial_cmp(&self, other: &CmpIter<U>) -> Option<Ordering> {
+        self.0.clone().into_iter().partial_cmp(other.0.clone())
+    }
+}
+
+impl<T> Ord for CmpIter<T>
+where
+    T: IntoIterator + Clone,
+    T::Item: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.clone().into_iter().cmp(other.0.clone())
+    }
+}


### PR DESCRIPTION
This is a work-in-progress PR for overhauling `domain::zonefile` with a brand-new, out-of-place zonefile parser.  It integrates a decent number of unit tests, but is currently lacking many record types (because `new-base` doesn't have them yet).

- [x] Add an example program which uses `new_zonefile` for parsing.
- [x] Test the implementation against large sample zonefiles.
- [x] Benchmark this against the old implementation.
- [x] Add support for more record data types (in this PR or `new-base`).

The new zonefile parser has a few basic differences from the existing implementation:
- Records borrow from the parser object to avoid unnecessary allocations.
- The actual parsing logic operates on strings instead of symbols.
- Entry-parsing code is separated from per-entry parsing code.

The new zonefile parser has been designed to support parallelized zonefile parsing in the future.  I am leaving this to a later PR.