### PR TITLE
FIX: Zone walking should walk below ENTs.

### DIFF
--- a/src/zonetree/in_memory/read.rs
+++ b/src/zonetree/in_memory/read.rs
@@ -479,9 +479,6 @@ mod tests {
                   rrset: &SharedRrset,
                   _at_zone_cut: bool| {
                 count_clone.fetch_add(1, Ordering::SeqCst);
-                eprintln!(
-                    "name: {owner:?}, rrset: {rrset:?}, bool: {_at_zone_cut}"
-                )
             },
         );
         read.walk(op);

--- a/src/zonetree/in_memory/read.rs
+++ b/src/zonetree/in_memory/read.rs
@@ -110,7 +110,18 @@ impl ReadZone {
                     )
                 }
             }
-            Some(Special::NxDomain) => NodeAnswer::nx_domain(),
+            Some(Special::NxDomain) => {
+                if walk.enabled() {
+                    self.query_children(
+                        node.children(),
+                        label,
+                        qname,
+                        qtype,
+                        walk,
+                    );
+                }
+                NodeAnswer::nx_domain()
+            }
             Some(Special::Cname(cname)) => {
                 if walk.enabled() {
                     let mut rrset = Rrset::new(Rtype::CNAME, cname.ttl());


### PR DESCRIPTION
E.g. given a.b.c where b is an empty non-terminal walking should not stop at b.