### PR TITLE
Some `net::client::dgram` fixes

### DIFF
--- a/src/net/client/dgram.rs
+++ b/src/net/client/dgram.rs
@@ -25,6 +25,7 @@ use std::boxed::Box;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::vec::Vec;
 use std::{error, io};
 use tokio::sync::Semaphore;
 use tokio::time::{timeout_at, Duration, Instant};
@@ -236,8 +237,8 @@ where
             .await
             .expect("semaphore closed");
 
-        // A place to store the receive buffer for reuse.
-        let mut reuse_buf = None;
+        // The buffer we will reuse on subsequent requests
+        let mut buf = Vec::new();
 
         // Transmit loop.
         for _ in 0..1 + self.state.config.max_retries {
@@ -267,10 +268,10 @@ where
             // Receive loop. It may at most take read_timeout time.
             let deadline = Instant::now() + self.state.config.read_timeout;
             while deadline > Instant::now() {
-                let mut buf = reuse_buf.take().unwrap_or_else(|| {
-                    // XXX use uninit'ed mem here.
-                    vec![0; self.state.config.recv_size]
-                });
+                // The buffer might have been truncated in a previous
+                // iteration.
+                buf.resize(self.state.config.recv_size, 0);
+
                 let len =
                     match timeout_at(deadline, sock.recv(&mut buf)).await {
                         Ok(Ok(len)) => len,
@@ -292,10 +293,10 @@ where
                 // thing.
                 let answer = match Message::try_from_octets(buf) {
                     Ok(answer) => answer,
-                    Err(buf) => {
+                    Err(old_buf) => {
                         // Just go back to receiving.
                         trace!("Received bytes were garbage, reading more");
-                        reuse_buf = Some(buf);
+                        buf = old_buf;
                         continue;
                     }
                 };
@@ -303,7 +304,7 @@ where
                 if !request.is_answer(answer.for_slice()) {
                     // Wrong answer, go back to receiving
                     trace!("Received message is not the answer we were waiting for, reading more");
-                    reuse_buf = Some(answer.into_octets());
+                    buf = answer.into_octets();
                     continue;
                 }
 

--- a/src/net/client/dgram.rs
+++ b/src/net/client/dgram.rs
@@ -229,7 +229,7 @@ where
         mut request: Req,
     ) -> Result<Message<Bytes>, Error> {
         // Acquire the semaphore or wait for it.
-        let _ = self
+        let _permit = self
             .state
             .semaphore
             .acquire()


### PR DESCRIPTION
While working on `new-client`, I found some issues with the current dgram client that we might as well fix.

1. The semaphore permit was bound to `_`, which drops it immediately. This defeats the point of the semaphore.
2. The buffer that we read into was truncated to the response size, but also reused for the next retry. For the next request it then no longer has a size of `recv_size`. 