### PR TITLE
Remove no longer needed `mut` on `GenerateNsec3Config` and `SigningConfig`.

### DIFF
--- a/src/dnssec/sign/mod.rs
+++ b/src/dnssec/sign/mod.rs
@@ -373,7 +373,7 @@ where
 /// [`Zone`]: crate::zonetree::Zone
 pub fn sign_zone<N, Octs, S, Inner, Sort, T>(
     mut in_out: SignableZoneInOut<N, Octs, S, T, Sort>,
-    signing_config: &mut SigningConfig<Octs, Sort>,
+    signing_config: &SigningConfig<Octs, Sort>,
     signing_keys: &[&SigningKey<Octs, Inner>],
 ) -> Result<(), SigningError>
 where
@@ -413,7 +413,7 @@ where
 
     let owner_rrs = RecordsIter::new(in_out.as_slice());
 
-    match &mut signing_config.denial {
+    match &signing_config.denial {
         DenialConfig::AlreadyPresent => {
             // Nothing to do.
         }
@@ -424,7 +424,7 @@ where
             in_out.sorted_extend(nsecs.into_iter().map(Record::from_record));
         }
 
-        DenialConfig::Nsec3(ref mut cfg) => {
+        DenialConfig::Nsec3(ref cfg) => {
             // RFC 5155 7.1 step 5: "Sort the set of NSEC3 RRs into hash
             // order." We store the NSEC3s as we create them and sort them
             // afterwards.

--- a/src/dnssec/sign/traits.rs
+++ b/src/dnssec/sign/traits.rs
@@ -149,13 +149,13 @@ where
 /// let keys = [&key];
 ///
 /// // Create a signing configuration.
-/// let mut signing_config = SigningConfig::new(Default::default(), 0.into(), 0.into());
+/// let signing_config = SigningConfig::new(Default::default(), 0.into(), 0.into());
 ///
 /// // Then generate the records which when added to the zone make it signed.
 /// let mut signer_generated_records = SortedRecords::default();
 ///
 /// records.sign_zone(
-///     &mut signing_config,
+///     &signing_config,
 ///     &keys,
 ///     &mut signer_generated_records).unwrap();
 /// ```
@@ -186,7 +186,7 @@ where
     /// [`SignableZoneInOut::SignInto`].
     fn sign_zone<Inner, T>(
         &self,
-        signing_config: &mut SigningConfig<Octs, Sort>,
+        signing_config: &SigningConfig<Octs, Sort>,
         signing_keys: &[&SigningKey<Octs, Inner>],
         out: &mut T,
     ) -> Result<(), SigningError>
@@ -295,7 +295,7 @@ where
 /// let keys = [&key];
 ///
 /// // Create a signing configuration.
-/// let mut signing_config: SigningConfig<Vec<u8>, DefaultSorter> =
+/// let signing_config: SigningConfig<Vec<u8>, DefaultSorter> =
 ///     SigningConfig::new(Default::default(), 0.into(), 0.into());
 ///
 /// // Then sign the zone in-place.
@@ -327,7 +327,7 @@ where
     /// [`SignableZoneInOut::SignInPlace`].
     fn sign_zone<Inner>(
         &mut self,
-        signing_config: &mut SigningConfig<Octs, Sort>,
+        signing_config: &SigningConfig<Octs, Sort>,
         signing_keys: &[&SigningKey<Octs, Inner>],
     ) -> Result<(), SigningError>
     where


### PR DESCRIPTION
As it was made redundant by recent changes to the signing API.