### PR TITLE
Pass &N instead of N and also remove thereby an unnecessary clone().

### DIFF
--- a/src/dnssec/sign/records.rs
+++ b/src/dnssec/sign/records.rs
@@ -129,11 +129,7 @@ where
     {
         let mut found_one = false;
         loop {
-            if self.remove_first_by_name_class_rtype(
-                name,
-                class,
-                rtype,
-            ) {
+            if self.remove_first_by_name_class_rtype(name, class, rtype) {
                 found_one = true
             } else {
                 break;

--- a/src/dnssec/sign/records.rs
+++ b/src/dnssec/sign/records.rs
@@ -119,7 +119,7 @@ where
     ///   - false: if no matching record was found
     pub fn remove_all_by_name_class_rtype(
         &mut self,
-        name: N,
+        name: &N,
         class: Option<Class>,
         rtype: Option<Rtype>,
     ) -> bool
@@ -130,7 +130,7 @@ where
         let mut found_one = false;
         loop {
             if self.remove_first_by_name_class_rtype(
-                name.clone(),
+                name,
                 class,
                 rtype,
             ) {
@@ -151,7 +151,7 @@ where
     ///   - false: if no matching record was found
     pub fn remove_first_by_name_class_rtype(
         &mut self,
-        name: N,
+        name: &N,
         class: Option<Class>,
         rtype: Option<Rtype>,
     ) -> bool
@@ -169,7 +169,7 @@ where
                 }
             }
 
-            match stored.owner().name_cmp(&name) {
+            match stored.owner().name_cmp(name) {
                 Ordering::Equal => {}
                 res => return res,
             }


### PR DESCRIPTION
This modifies part of `SortedRecords` that was added since the last release to support `dnst signzone`. As `SortedRecords` already exists in released `domain` if we're going to add to it we should try and avoiding then changing it in a subsequent release, i.e. any fixes to the API like this  should be done before the next release.