### PR TITLE
Add a `static-openssl` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ tracing     = ["dep:log", "dep:tracing"]
 # Cryptographic backends
 ring    = ["dep:ring"]
 openssl = ["dep:openssl"]
+static-openssl = ["openssl/vendored"]
 
 # Crate features
 net         = ["bytes", "futures-util", "rand", "std", "tokio"]


### PR DESCRIPTION
(based on Krill) to enable building in environments that cannot compile OpenSSL for the `openssl` crate, e.g. `cargo cross` build containers as used by [Ploutos](https://github.com/NLnetLabs/ploutos/).

Using this feature cross-compilation with Ploutos of `dnst` was able to succeed. See:
  - Build success with this PR: https://github.com/NLnetLabs/dnst/actions/runs/15065147049/job/42348216181
  - Build failure prior to this PR: https://github.com/NLnetLabs/dnst/actions/runs/15063995658/job/42344647962#step:9:264