### PR TITLE
In-place zone parser yields incorrect TTLs. (fixes #537)

### DIFF
--- a/test-data/zonefiles/multiple_dollar_ttls_multiple_missing_ttls.yaml
+++ b/test-data/zonefiles/multiple_dollar_ttls_multiple_missing_ttls.yaml
@@ -1,0 +1,35 @@
+origin: example.com.
+zonefile: |
+  $TTL 5555
+  example.com.  1111  IN  SOA   ns.example.com. noc.dns.example.org. 2020080302 7200 3600 1209600 3600
+  example.com.        IN  NS    example.com.
+  $TTL 6666
+  example.com.  3333  IN  A     192.0.2.1
+  example.com.        IN  AAAA  2001:db8::3
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 1111
+    data: !Soa
+      mname: ns.example.com.
+      rname: noc.dns.example.org.
+      serial: 2020080302
+      refresh: 7200
+      retry: 3600
+      expire: 1209600
+      minimum: 3600
+  - owner: example.com.
+    class: IN
+    ttl: 5555
+    data: !Ns
+      nsdname: example.com.
+  - owner: example.com.
+    class: IN
+    ttl: 3333
+    data: !A
+      addr: 192.0.2.1
+  - owner: example.com.
+    class: IN
+    ttl: 6666
+    data: !Aaaa
+      addr: 2001:db8::3

--- a/test-data/zonefiles/multiple_dollar_ttls_no_missing_ttls.yaml
+++ b/test-data/zonefiles/multiple_dollar_ttls_no_missing_ttls.yaml
@@ -1,0 +1,35 @@
+origin: example.com.
+zonefile: |
+  $TTL 5555
+  example.com.  1111  IN  SOA   ns.example.com. noc.dns.example.org. 2020080302 7200 3600 1209600 3600
+  example.com.  2222  IN  NS    example.com.
+  $TTL 666
+  example.com.  3333  IN  A     192.0.2.1
+  example.com.  4444  IN  AAAA  2001:db8::3
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 1111
+    data: !Soa
+      mname: ns.example.com.
+      rname: noc.dns.example.org.
+      serial: 2020080302
+      refresh: 7200
+      retry: 3600
+      expire: 1209600
+      minimum: 3600
+  - owner: example.com.
+    class: IN
+    ttl: 2222
+    data: !Ns
+      nsdname: example.com.
+  - owner: example.com.
+    class: IN
+    ttl: 3333
+    data: !A
+      addr: 192.0.2.1
+  - owner: example.com.
+    class: IN
+    ttl: 4444
+    data: !Aaaa
+      addr: 2001:db8::3

--- a/test-data/zonefiles/no_dollar_ttl_no_missing_ttls.yaml
+++ b/test-data/zonefiles/no_dollar_ttl_no_missing_ttls.yaml
@@ -1,0 +1,33 @@
+origin: example.com.
+zonefile: |
+  example.com.  1111  IN  SOA   ns.example.com. noc.dns.example.org. 2020080302 7200 3600 1209600 3600
+  example.com.  2222  IN  NS    example.com.
+  example.com.  3333  IN  A     192.0.2.1
+  example.com.  4444  IN  AAAA  2001:db8::3
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 1111
+    data: !Soa
+      mname: ns.example.com.
+      rname: noc.dns.example.org.
+      serial: 2020080302
+      refresh: 7200
+      retry: 3600
+      expire: 1209600
+      minimum: 3600
+  - owner: example.com.
+    class: IN
+    ttl: 2222
+    data: !Ns
+      nsdname: example.com.
+  - owner: example.com.
+    class: IN
+    ttl: 3333
+    data: !A
+      addr: 192.0.2.1
+  - owner: example.com.
+    class: IN
+    ttl: 4444
+    data: !Aaaa
+      addr: 2001:db8::3

--- a/test-data/zonefiles/no_dollar_ttl_one_missing_ttl.yaml
+++ b/test-data/zonefiles/no_dollar_ttl_one_missing_ttl.yaml
@@ -1,0 +1,33 @@
+origin: example.com.
+zonefile: |
+  example.com.  1111  IN  SOA   ns.example.com. noc.dns.example.org. 2020080302 7200 3600 1209600 3600
+  example.com.  2222  IN  NS    example.com.
+  example.com.        IN  A     192.0.2.1
+  example.com.  4444  IN  AAAA  2001:db8::3
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 1111
+    data: !Soa
+      mname: ns.example.com.
+      rname: noc.dns.example.org.
+      serial: 2020080302
+      refresh: 7200
+      retry: 3600
+      expire: 1209600
+      minimum: 3600
+  - owner: example.com.
+    class: IN
+    ttl: 2222
+    data: !Ns
+      nsdname: example.com.
+  - owner: example.com.
+    class: IN
+    ttl: 2222
+    data: !A
+      addr: 192.0.2.1
+  - owner: example.com.
+    class: IN
+    ttl: 4444
+    data: !Aaaa
+      addr: 2001:db8::3

--- a/test-data/zonefiles/rfc_1035_class_ttl_type_rdata.yaml
+++ b/test-data/zonefiles/rfc_1035_class_ttl_type_rdata.yaml
@@ -1,0 +1,15 @@
+origin: example.com.
+zonefile: |
+  example.com.  IN  1111  SOA   ns.example.com. noc.dns.example.org. 2020080302 7200 3600 1209600 3600
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 1111
+    data: !Soa
+      mname: ns.example.com.
+      rname: noc.dns.example.org.
+      serial: 2020080302
+      refresh: 7200
+      retry: 3600
+      expire: 1209600
+      minimum: 3600

--- a/test-data/zonefiles/rfc_1035_ttl_class_type_rdata.yaml
+++ b/test-data/zonefiles/rfc_1035_ttl_class_type_rdata.yaml
@@ -1,0 +1,15 @@
+origin: example.com.
+zonefile: |
+  example.com.  1111  IN  SOA   ns.example.com. noc.dns.example.org. 2020080302 7200 3600 1209600 3600
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 1111
+    data: !Soa
+      mname: ns.example.com.
+      rname: noc.dns.example.org.
+      serial: 2020080302
+      refresh: 7200
+      retry: 3600
+      expire: 1209600
+      minimum: 3600

--- a/test-data/zonefiles/top_dollar_ttl_and_missing_ttl.yaml
+++ b/test-data/zonefiles/top_dollar_ttl_and_missing_ttl.yaml
@@ -1,0 +1,34 @@
+origin: example.com.
+zonefile: |
+  $TTL 5555
+  example.com.  1111  IN  SOA   ns.example.com. noc.dns.example.org. 2020080302 7200 3600 1209600 3600
+  example.com.  2222  IN  NS    example.com.
+  example.com.        IN  A     192.0.2.1
+  example.com.  4444  IN  AAAA  2001:db8::3
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 1111
+    data: !Soa
+      mname: ns.example.com.
+      rname: noc.dns.example.org.
+      serial: 2020080302
+      refresh: 7200
+      retry: 3600
+      expire: 1209600
+      minimum: 3600
+  - owner: example.com.
+    class: IN
+    ttl: 2222
+    data: !Ns
+      nsdname: example.com.
+  - owner: example.com.
+    class: IN
+    ttl: 5555
+    data: !A
+      addr: 192.0.2.1
+  - owner: example.com.
+    class: IN
+    ttl: 4444
+    data: !Aaaa
+      addr: 2001:db8::3

--- a/test-data/zonefiles/top_dollar_ttl_no_missing_ttls.yaml
+++ b/test-data/zonefiles/top_dollar_ttl_no_missing_ttls.yaml
@@ -1,0 +1,34 @@
+origin: example.com.
+zonefile: |
+  $TTL 5555
+  example.com.  1111  IN  SOA   ns.example.com. noc.dns.example.org. 2020080302 7200 3600 1209600 3600
+  example.com.  2222  IN  NS    example.com.
+  example.com.  3333  IN  A     192.0.2.1
+  example.com.  4444  IN  AAAA  2001:db8::3
+result:
+  - owner: example.com.
+    class: IN
+    ttl: 1111
+    data: !Soa
+      mname: ns.example.com.
+      rname: noc.dns.example.org.
+      serial: 2020080302
+      refresh: 7200
+      retry: 3600
+      expire: 1209600
+      minimum: 3600
+  - owner: example.com.
+    class: IN
+    ttl: 2222
+    data: !Ns
+      nsdname: example.com.
+  - owner: example.com.
+    class: IN
+    ttl: 3333
+    data: !A
+      addr: 192.0.2.1
+  - owner: example.com.
+    class: IN
+    ttl: 4444
+    data: !Aaaa
+      addr: 2001:db8::3


### PR DESCRIPTION
See #537.

Also includes tests for RFC 1035 5.1 Format zone file field order support, as https://github.com/NLnetLabs/ldns/issues/279 was found while performing tests for #43.