### PR TITLE
Remove the `static-openssl` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ tracing     = ["dep:log", "dep:tracing"]
 # Cryptographic backends
 ring    = ["dep:ring"]
 openssl = ["dep:openssl"]
-static-openssl = ["openssl/vendored"]
 
 # Crate features
 net         = ["bytes", "futures-util", "rand", "std", "tokio"]


### PR DESCRIPTION
- This significantly reduces the build times for '--all-features'.

- 'cargo build -F openssl/vendored' will still enable building OpenSSL from source, and can be used by dependent crates.

- This is not a breaking change as the previous published version does not include this flag.