### PR TITLE
Disallow elided lifetimes in paths

### DIFF
--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -347,7 +347,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> CharStr<Octs> {
     }
 
     /// Returns an iterator over the octets of the character string.
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             octets: self.as_slice(),
         }
@@ -357,7 +357,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> CharStr<Octs> {
 impl CharStr<[u8]> {
     /// Skips over a character string at the beginning of a parser.
     pub fn skip<Src: Octets + ?Sized>(
-        parser: &mut Parser<Src>,
+        parser: &mut Parser<'_, Src>,
     ) -> Result<(), ParseError> {
         let len = parser.parse_u8()?;
         parser.advance(len.into()).map_err(Into::into)
@@ -397,7 +397,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> CharStr<Octs> {
     /// The returned object will display the content surrounded by double
     /// quotes. It will escape double quotes, backslashes, and non-printable
     /// octets only.
-    pub fn display_quoted(&self) -> DisplayQuoted {
+    pub fn display_quoted(&self) -> DisplayQuoted<'_> {
         DisplayQuoted(self.for_slice())
     }
 
@@ -406,7 +406,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> CharStr<Octs> {
     /// The returned object will display the content without explicit
     /// delimiters and escapes space, double quotes, semicolons, backslashes,
     /// and non-printable octets.
-    pub fn display_unquoted(&self) -> DisplayUnquoted {
+    pub fn display_unquoted(&self) -> DisplayUnquoted<'_> {
         DisplayUnquoted(self.for_slice())
     }
 }
@@ -535,7 +535,7 @@ impl<T: AsRef<[u8]> + ?Sized> hash::Hash for CharStr<T> {
 //--- Display and Debug
 
 impl<T: AsRef<[u8]> + ?Sized> fmt::Display for CharStr<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for &ch in self.0.as_ref() {
             fmt::Display::fmt(&Symbol::display_from_octet(ch), f)?;
         }
@@ -544,7 +544,7 @@ impl<T: AsRef<[u8]> + ?Sized> fmt::Display for CharStr<T> {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> fmt::LowerHex for CharStr<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for ch in self.0.as_ref() {
             write!(f, "{:02x}", ch)?;
         }
@@ -553,7 +553,7 @@ impl<T: AsRef<[u8]> + ?Sized> fmt::LowerHex for CharStr<T> {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> fmt::UpperHex for CharStr<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for ch in self.0.as_ref() {
             write!(f, "{:02X}", ch)?;
         }
@@ -562,7 +562,7 @@ impl<T: AsRef<[u8]> + ?Sized> fmt::UpperHex for CharStr<T> {
 }
 
 impl<T: AsRef<[u8]> + ?Sized> fmt::Debug for CharStr<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("CharStr")
             .field(&format_args!("{}", self))
             .finish()
@@ -641,7 +641,7 @@ where
         {
             type Value = CharStr<Octets>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a character string")
             }
 
@@ -684,7 +684,7 @@ where
         {
             type Value = CharStr<Octets>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a character string")
             }
 
@@ -930,7 +930,7 @@ impl Iterator for Iter<'_> {
 pub struct DisplayQuoted<'a>(&'a CharStr<[u8]>);
 
 impl fmt::Display for DisplayQuoted<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("\"")?;
         for &ch in self.0.as_ref() {
             fmt::Display::fmt(&Symbol::quoted_from_octet(ch), f)?;
@@ -948,7 +948,7 @@ impl fmt::Display for DisplayQuoted<'_> {
 pub struct DisplayUnquoted<'a>(&'a CharStr<[u8]>);
 
 impl fmt::Display for DisplayUnquoted<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for &ch in self.0.as_ref() {
             fmt::Display::fmt(&Symbol::from_octet(ch), f)?;
         }
@@ -1006,7 +1006,7 @@ where
         {
             type Value = ();
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a character string")
             }
 
@@ -1033,7 +1033,7 @@ where
         {
             type Value = ();
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a character string")
             }
 
@@ -1070,7 +1070,7 @@ where
         {
             type Value = ();
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a character string")
             }
 
@@ -1101,7 +1101,7 @@ where
 pub struct CharStrError(());
 
 impl fmt::Display for CharStrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("long character string")
     }
 }
@@ -1138,7 +1138,7 @@ impl From<ShortBuf> for FromStrError {
 //--- Display and Error
 
 impl fmt::Display for FromStrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             FromStrError::Presentation(ref err) => err.fmt(f),
             FromStrError::ShortBuf => ShortBuf.fmt(f),
@@ -1191,7 +1191,7 @@ impl From<PresentationErrorEnum> for PresentationError {
 //--- Display and Error
 
 impl fmt::Display for PresentationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             PresentationErrorEnum::LongString => {
                 f.write_str("character string with more than 255 octets")

--- a/src/base/dig_printer.rs
+++ b/src/base/dig_printer.rs
@@ -156,7 +156,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for DigPrinter<'_, Octs> {
 
 fn write_record_item(
     f: &mut impl fmt::Write,
-    item: &ParsedRecord<&[u8]>,
+    item: &ParsedRecord<'_, &[u8]>,
 ) -> Result<(), fmt::Error> {
     let parsed = item.to_any_record::<AllRecordData<_, _>>();
 

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -400,7 +400,7 @@ impl Flags {
 //--- Display & FromStr
 
 impl fmt::Display for Flags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut sep = "";
         if self.qr {
             write!(f, "QR")?;
@@ -883,7 +883,7 @@ impl HeaderSection {
 ///
 impl HeaderSection {
     pub fn parse<Octs: AsRef<[u8]>>(
-        parser: &mut Parser<Octs>,
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         let mut res = Self::default();
         parser.parse_buf(&mut res.inner)?;

--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -114,7 +114,7 @@ macro_rules! int_enum {
         //--- Debug
 
         impl core::fmt::Debug for $ianatype {
-            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self.to_mnemonic().and_then(|bytes| {
                     core::str::from_utf8(bytes).ok()
                 }) {
@@ -209,7 +209,10 @@ macro_rules! int_enum_str_decimal {
         scan_impl!($ianatype);
 
         impl core::fmt::Display for $ianatype {
-            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn fmt(
+                &self,
+                f: &mut core::fmt::Formatter<'_>,
+            ) -> core::fmt::Result {
                 write!(f, "{}", self.to_int())
             }
         }
@@ -281,7 +284,10 @@ macro_rules! int_enum_str_with_decimal {
         }
 
         impl core::fmt::Display for $ianatype {
-            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn fmt(
+                &self,
+                f: &mut core::fmt::Formatter<'_>,
+            ) -> core::fmt::Result {
                 match self.to_mnemonic_str() {
                     Some(m) => {
                         write!(f, "{m}({})", self.to_int())
@@ -392,7 +398,10 @@ macro_rules! int_enum_str_with_prefix {
         }
 
         impl core::fmt::Display for $ianatype {
-            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn fmt(
+                &self,
+                f: &mut core::fmt::Formatter<'_>,
+            ) -> core::fmt::Result {
                 match self.to_mnemonic_str() {
                     Some(m) => f.write_str(m),
                     None => {
@@ -519,7 +528,10 @@ macro_rules! from_str_error {
         }
 
         impl core::fmt::Display for FromStrError {
-            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn fmt(
+                &self,
+                f: &mut core::fmt::Formatter<'_>,
+            ) -> core::fmt::Result {
                 $description.fmt(f)
             }
         }

--- a/src/base/iana/rcode.rs
+++ b/src/base/iana/rcode.rs
@@ -254,7 +254,7 @@ impl From<Rcode> for u8 {
 //--- Display and Debug
 
 impl fmt::Display for Rcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self
             .to_mnemonic()
             .and_then(|bytes| core::str::from_utf8(bytes).ok())
@@ -266,7 +266,7 @@ impl fmt::Display for Rcode {
 }
 
 impl fmt::Debug for Rcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self
             .to_mnemonic()
             .and_then(|bytes| core::str::from_utf8(bytes).ok())
@@ -644,7 +644,7 @@ impl From<Rcode> for OptRcode {
 //--- Display and Debug
 
 impl fmt::Display for OptRcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self
             .to_mnemonic()
             .and_then(|bytes| core::str::from_utf8(bytes).ok())
@@ -656,7 +656,7 @@ impl fmt::Display for OptRcode {
 }
 
 impl fmt::Debug for OptRcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self
             .to_mnemonic()
             .and_then(|bytes| core::str::from_utf8(bytes).ok())
@@ -906,7 +906,7 @@ int_enum_zonefile_fmt_with_decimal!(TsigRcode);
 pub struct InvalidRcode(());
 
 impl fmt::Display for InvalidRcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("invalid rcode value")
     }
 }

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -732,7 +732,7 @@ impl<'a, Octs: Octets + ?Sized> IntoIterator for &'a Message<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Message<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Message")
             .field("id", &self.header().id())
             .field("qr", &self.header().qr())
@@ -1306,7 +1306,7 @@ where
 pub struct ShortMessage(());
 
 impl fmt::Display for ShortMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("short message")
     }
 }
@@ -1343,7 +1343,7 @@ impl From<PushError> for CopyRecordsError {
 //--- Display and Error
 
 impl fmt::Display for CopyRecordsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             CopyRecordsError::Parse(ref err) => err.fmt(f),
             CopyRecordsError::Push(ref err) => err.fmt(f),

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -1417,7 +1417,9 @@ impl<Target: Composer> AdditionalBuilder<Target> {
     /// [`OptBuilder`]: struct.OptBuilder.html
     pub fn opt<F>(&mut self, op: F) -> Result<(), PushError>
     where
-        F: FnOnce(&mut OptBuilder<Target>) -> Result<(), Target::AppendError>,
+        F: FnOnce(
+            &mut OptBuilder<'_, Target>,
+        ) -> Result<(), Target::AppendError>,
     {
         self.authority.answer.builder.push(
             |target| OptBuilder::new(target)?.build(op),
@@ -2652,7 +2654,7 @@ impl<T: Into<ShortBuf>> From<T> for PushError {
 }
 
 impl fmt::Display for PushError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             PushError::CountOverflow => f.write_str("counter overflow"),
             PushError::ShortBuf => ShortBuf.fmt(f),

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -403,7 +403,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> Name<Octs> {
 ///
 impl<Octs: AsRef<[u8]> + ?Sized> Name<Octs> {
     /// Returns an iterator over the labels of the domain name.
-    pub fn iter(&self) -> NameIter {
+    pub fn iter(&self) -> NameIter<'_> {
         NameIter::new(self.0.as_ref())
     }
 
@@ -715,7 +715,7 @@ impl<Octs> Name<Octs> {
 
     /// Peeks at a parser and returns the length of a name at its beginning.
     fn parse_name_len<Source: AsRef<[u8]> + ?Sized>(
-        parser: &Parser<Source>,
+        parser: &Parser<'_, Source>,
     ) -> Result<usize, ParseError> {
         let len = {
             let mut tmp = parser.peek_all();
@@ -922,7 +922,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Name<Octs> {
     /// This will produce the domain name in ‘common display format’ without
     /// the trailing dot with the exception of a root name which will be just
     /// a dot.
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_root() {
             return f.write_str(".");
         }
@@ -941,7 +941,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Name<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Name<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Name({})", self.fmt_with_dot())
     }
 }
@@ -1028,7 +1028,7 @@ where
         {
             type Value = Name<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an absolute domain name")
             }
 
@@ -1071,7 +1071,7 @@ where
         {
             type Value = Name<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an absolute domain name")
             }
 
@@ -1203,7 +1203,7 @@ impl From<NameError> for ParseError {
 //--- Display and Error
 
 impl fmt::Display for NameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             DnameErrorEnum::BadLabel(ref err) => err.fmt(f),
             DnameErrorEnum::CompressedName => {

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -553,7 +553,7 @@ impl From<ShortBuf> for PushError {
 //--- Display and Error
 
 impl fmt::Display for PushError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             PushError::LongLabel => f.write_str("long label"),
             PushError::LongName => f.write_str("long domain name"),
@@ -588,7 +588,7 @@ impl From<ShortBuf> for PushNameError {
 //--- Display and Error
 
 impl fmt::Display for PushNameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             PushNameError::LongName => f.write_str("long domain name"),
             PushNameError::ShortBuf => ShortBuf.fmt(f),
@@ -641,7 +641,7 @@ impl From<BadSymbol> for LabelFromStrError {
 //--- Display and Error
 
 impl fmt::Display for LabelFromStrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             LabelFromStrErrorEnum::SymbolChars(err) => err.fmt(f),
             LabelFromStrErrorEnum::BadSymbol(err) => err.fmt(f),
@@ -705,7 +705,7 @@ impl<T: Into<PresentationError>> From<T> for FromStrError {
 //--- Display and Error
 
 impl fmt::Display for FromStrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             FromStrError::Presentation(err) => err.fmt(f),
             FromStrError::ShortBuf => ShortBuf.fmt(f),
@@ -750,7 +750,7 @@ impl<T: Into<LabelFromStrError>> From<T> for PresentationError {
 //--- Display and Error
 
 impl fmt::Display for PresentationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             PresentationErrorEnum::BadLabel(ref err) => err.fmt(f),
             PresentationErrorEnum::EmptyLabel => f.write_str("empty label"),

--- a/src/base/name/chain.rs
+++ b/src/base/name/chain.rs
@@ -220,7 +220,7 @@ impl<L, R> fmt::Display for Chain<L, R>
 where
     Self: ToLabelIter,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut empty = true;
         for label in self.iter_labels() {
             if label.is_root() {
@@ -339,7 +339,7 @@ impl<L, R> fmt::Display for DisplayWithDot<'_, L, R>
 where
     Chain<L, R>: ToLabelIter,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut empty = true;
         for label in self.0.iter_labels() {
             if label.is_root() {
@@ -368,7 +368,7 @@ pub struct LongChainError(());
 //--- Display and Error
 
 impl fmt::Display for LongChainError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("long domain name")
     }
 }

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -190,7 +190,7 @@ impl Label {
     }
 
     /// Iterator over the octets of the label.
-    pub fn iter(&self) -> iter::Copied<slice::Iter<u8>> {
+    pub fn iter(&self) -> iter::Copied<slice::Iter<'_, u8>> {
         self.as_slice().iter().copied()
     }
 
@@ -205,7 +205,7 @@ impl Label {
     ///
     /// Panics if `start` is beyond the end of `slice`.
     #[must_use]
-    pub fn iter_slice(slice: &[u8], start: usize) -> SliceLabelsIter {
+    pub fn iter_slice(slice: &[u8], start: usize) -> SliceLabelsIter<'_> {
         SliceLabelsIter { slice, start }
     }
 
@@ -434,7 +434,7 @@ impl<'a> IntoIterator for &'a Label {
 //--- Display and Debug
 
 impl fmt::Display for Label {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for ch in self.iter() {
             if ch == b' ' || ch == b'.' || ch == b'\\' {
                 write!(f, "\\{}", ch as char)?;
@@ -449,7 +449,7 @@ impl fmt::Display for Label {
 }
 
 impl fmt::Debug for Label {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Label(")?;
         fmt::Display::fmt(self, f)?;
         f.write_str(")")
@@ -633,13 +633,13 @@ impl hash::Hash for OwnedLabel {
 //--- Display and Debug
 
 impl fmt::Display for OwnedLabel {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_label().fmt(f)
     }
 }
 
 impl fmt::Debug for OwnedLabel {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("OwnedLabel").field(&self.as_label()).finish()
     }
 }
@@ -680,7 +680,7 @@ impl<'de> serde::Deserialize<'de> for OwnedLabel {
         impl<'de> serde::de::Visitor<'de> for InnerVisitor {
             type Value = OwnedLabel;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an domain name label")
             }
 
@@ -703,7 +703,7 @@ impl<'de> serde::Deserialize<'de> for OwnedLabel {
         impl<'de> serde::de::Visitor<'de> for NewtypeVisitor {
             type Value = OwnedLabel;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an domain name label")
             }
 
@@ -798,7 +798,7 @@ pub enum LabelTypeError {
 //--- Display and Error
 
 impl fmt::Display for LabelTypeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             LabelTypeError::Undefined => f.write_str("undefined label type"),
             LabelTypeError::Extended(value) => {
@@ -820,7 +820,7 @@ pub struct LongLabelError(());
 //--- Display and Error
 
 impl fmt::Display for LongLabelError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("long label")
     }
 }
@@ -868,7 +868,7 @@ impl From<SplitLabelError> for ParseError {
 //--- Display and Error
 
 impl fmt::Display for SplitLabelError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             SplitLabelError::Pointer(_) => {
                 f.write_str("compressed domain name")

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -352,7 +352,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> RelativeName<Octs> {
 ///
 impl<Octs: AsRef<[u8]> + ?Sized> RelativeName<Octs> {
     /// Returns an iterator over the labels of the domain name.
-    pub fn iter(&self) -> NameIter {
+    pub fn iter(&self) -> NameIter<'_> {
         NameIter::new(self.0.as_ref())
     }
 
@@ -720,7 +720,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> hash::Hash for RelativeName<Octs> {
 //--- Display and Debug
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for RelativeName<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut iter = self.iter();
         match iter.next() {
             Some(label) => label.fmt(f)?,
@@ -735,7 +735,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for RelativeName<Octs> {
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for RelativeName<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "RelativeName({})", self)
     }
 }
@@ -830,7 +830,7 @@ where
         {
             type Value = RelativeName<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a relative domain name")
             }
 
@@ -875,7 +875,7 @@ where
         {
             type Value = RelativeName<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a relative domain name")
             }
 
@@ -1003,7 +1003,7 @@ impl From<RelativeNameErrorEnum> for RelativeNameError {
 //--- Display and Error
 
 impl fmt::Display for RelativeNameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             RelativeNameErrorEnum::BadLabel(err) => err.fmt(f),
             RelativeNameErrorEnum::CompressedName => {
@@ -1048,7 +1048,7 @@ impl From<FromStrError> for RelativeFromStrError {
 //--- Display and Error
 
 impl fmt::Display for RelativeFromStrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RelativeFromStrError::FromStr(err) => err.fmt(f),
             RelativeFromStrError::AbsoluteName => {
@@ -1070,7 +1070,7 @@ pub struct StripSuffixError(());
 //--- Display and Error
 
 impl fmt::Display for StripSuffixError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("suffix not found")
     }
 }

--- a/src/base/name/traits.rs
+++ b/src/base/name/traits.rs
@@ -216,7 +216,7 @@ pub trait ToName: ToLabelIter {
     /// [`as_flat_slice`]: ToName::as_flat_slice
     /// [`to_name`]: ToName::to_name
     #[cfg(feature = "std")]
-    fn to_cow(&self) -> Name<std::borrow::Cow<[u8]>> {
+    fn to_cow(&self) -> Name<std::borrow::Cow<'_, [u8]>> {
         let octets = self
             .as_flat_slice()
             .map(Cow::Borrowed)
@@ -359,7 +359,7 @@ impl<T> fmt::Display for DisplayWithDot<'_, T>
 where
     T: ToLabelIter + ?Sized,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut labels = self.0.iter_labels();
         let first = match labels.next() {
             Some(first) => first,
@@ -502,7 +502,7 @@ pub trait ToRelativeName: ToLabelIter {
     /// [`as_flat_slice`]: ToRelativeName::as_flat_slice
     /// [`to_relative_name`]: ToRelativeName::to_relative_name
     #[cfg(feature = "std")]
-    fn to_cow(&self) -> RelativeName<std::borrow::Cow<[u8]>> {
+    fn to_cow(&self) -> RelativeName<std::borrow::Cow<'_, [u8]>> {
         let octets = self
             .as_flat_slice()
             .map(Cow::Borrowed)

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -413,7 +413,7 @@ impl<'a, Octets: AsRef<[u8]>> IntoIterator for &'a UncertainName<Octets> {
 //--- Display and Debug
 
 impl<Octets: AsRef<[u8]>> fmt::Display for UncertainName<Octets> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             UncertainName::Absolute(ref name) => {
                 write!(f, "{}.", name)
@@ -424,7 +424,7 @@ impl<Octets: AsRef<[u8]>> fmt::Display for UncertainName<Octets> {
 }
 
 impl<Octets: AsRef<[u8]>> fmt::Debug for UncertainName<Octets> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             UncertainName::Absolute(ref name) => {
                 write!(f, "UncertainName::Absolute({})", name)
@@ -487,7 +487,7 @@ where
         {
             type Value = UncertainName<Octets>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a domain name")
             }
 
@@ -532,7 +532,7 @@ where
         {
             type Value = UncertainName<Octets>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a domain name")
             }
 
@@ -618,7 +618,7 @@ impl From<UncertainDnameErrorEnum> for UncertainDnameError {
 //--- Display and Error
 
 impl fmt::Display for UncertainDnameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             UncertainDnameErrorEnum::BadLabel(ref err) => err.fmt(f),
             UncertainDnameErrorEnum::CompressedName => {

--- a/src/base/net/nostd.rs
+++ b/src/base/net/nostd.rs
@@ -27,7 +27,7 @@ impl From<[u8; 4]> for Ipv4Addr {
 }
 
 impl fmt::Display for Ipv4Addr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}.{}.{}", self.0[0], self.0[1], self.0[2], self.0[3])
     }
 }
@@ -135,7 +135,7 @@ impl From<[u16; 8]> for Ipv6Addr {
 #[allow(clippy::many_single_char_names)]
 #[allow(clippy::needless_range_loop)]
 impl fmt::Display for Ipv6Addr {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.segments() {
             // We need special cases for :: and ::1, otherwise they're
             // formatted as ::0.0.0.[01]

--- a/src/base/opt/algsig.rs
+++ b/src/base/opt/algsig.rs
@@ -18,14 +18,13 @@ use super::super::iana::{OptionCode, SecurityAlgorithm};
 use super::super::message_builder::OptBuilder;
 use super::super::wire::{Compose, Composer, ParseError};
 use super::{
-    BuildDataError, OptData, ComposeOptData, LongOptData, Opt, ParseOptData
+    BuildDataError, ComposeOptData, LongOptData, Opt, OptData, ParseOptData,
 };
+use core::marker::PhantomData;
+use core::{borrow, fmt, hash, mem, slice};
 use octseq::builder::{EmptyBuilder, FromBuilder, OctetsBuilder};
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
-use core::{borrow, fmt, hash, mem, slice};
-use core::marker::PhantomData;
-
 
 //------------ Understood ----------------------------------------------------
 
@@ -110,7 +109,7 @@ impl<Variant, Octs> Understood<Variant, Octs> {
     pub unsafe fn from_octets_unchecked(octets: Octs) -> Self {
         Understood {
             marker: PhantomData,
-            octets
+            octets,
         }
     }
 
@@ -119,11 +118,11 @@ impl<Variant, Octs> Understood<Variant, Octs> {
     /// The operation will fail if the iterator returns more than 32,767
     /// algorithms.
     pub fn from_sec_algs(
-        sec_algs: impl IntoIterator<Item = SecurityAlgorithm>
+        sec_algs: impl IntoIterator<Item = SecurityAlgorithm>,
     ) -> Result<Self, BuildDataError>
     where
         Octs: FromBuilder,
-        <Octs as FromBuilder>::Builder: EmptyBuilder
+        <Octs as FromBuilder>::Builder: EmptyBuilder,
     {
         let mut octets = EmptyBuilder::empty();
         for item in sec_algs {
@@ -161,7 +160,7 @@ impl<Variant> Understood<Variant, [u8]> {
     fn check_slice(slice: &[u8]) -> Result<(), ParseError> {
         LongOptData::check_len(slice.len())?;
         if slice.len() % usize::from(u16::COMPOSE_LEN) != 0 {
-            return Err(ParseError::form_error("invalid understood data"))
+            return Err(ParseError::form_error("invalid understood data"));
         }
         Ok(())
     }
@@ -205,13 +204,13 @@ impl<Variant, Octs: ?Sized> Understood<Variant, Octs> {
     {
         unsafe {
             Understood::<Variant, _>::from_slice_unchecked(
-                self.octets.as_ref()
+                self.octets.as_ref(),
             )
         }
     }
 
     /// Returns an iterator over the algorithms in the data.
-    pub fn iter(&self) -> SecurityAlgorithmIter
+    pub fn iter(&self) -> SecurityAlgorithmIter<'_>
     where
         Octs: AsRef<[u8]>,
     {
@@ -234,19 +233,17 @@ impl Understood<N3uVariant, ()> {
 //--- OctetsFrom
 
 impl<Variant, O, OO> OctetsFrom<Understood<Variant, O>>
-for Understood<Variant, OO>
+    for Understood<Variant, OO>
 where
     OO: OctetsFrom<O>,
 {
     type Error = OO::Error;
 
     fn try_octets_from(
-        source: Understood<Variant, O>
+        source: Understood<Variant, O>,
     ) -> Result<Self, Self::Error> {
         Ok(unsafe {
-            Self::from_octets_unchecked(
-                OO::try_octets_from(source.octets)?
-            )
+            Self::from_octets_unchecked(OO::try_octets_from(source.octets)?)
         })
     }
 }
@@ -254,14 +251,18 @@ where
 //--- AsRef, AsMut, Borrow, BorrowMut
 
 impl<Variant, Octs> AsRef<[u8]> for Understood<Variant, Octs>
-where Octs: AsRef<[u8]> + ?Sized {
+where
+    Octs: AsRef<[u8]> + ?Sized,
+{
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
     }
 }
 
 impl<Variant, Octs> borrow::Borrow<[u8]> for Understood<Variant, Octs>
-where Octs: AsRef<[u8]> + ?Sized {
+where
+    Octs: AsRef<[u8]> + ?Sized,
+{
     fn borrow(&self) -> &[u8] {
         self.as_slice()
     }
@@ -269,8 +270,8 @@ where Octs: AsRef<[u8]> + ?Sized {
 
 //--- PartialEq and Eq
 
-impl<Var, OtherVar, Octs, OtherOcts> PartialEq<Understood<OtherVar, OtherOcts>>
-for Understood<Var, Octs>
+impl<Var, OtherVar, Octs, OtherOcts>
+    PartialEq<Understood<OtherVar, OtherOcts>> for Understood<Var, Octs>
 where
     Octs: AsRef<[u8]> + ?Sized,
     OtherOcts: AsRef<[u8]> + ?Sized,
@@ -280,7 +281,7 @@ where
     }
 }
 
-impl<Variant, Octs: AsRef<[u8]> + ?Sized> Eq for Understood<Variant, Octs> { }
+impl<Variant, Octs: AsRef<[u8]> + ?Sized> Eq for Understood<Variant, Octs> {}
 
 //--- Hash
 
@@ -311,45 +312,45 @@ impl<Octs: ?Sized> OptData for Understood<N3uVariant, Octs> {
 }
 
 impl<'a, Octs: Octets + ?Sized> ParseOptData<'a, Octs>
-for Understood<DauVariant, Octs::Range<'a>> {
+    for Understood<DauVariant, Octs::Range<'a>>
+{
     fn parse_option(
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
         if code == OptionCode::DAU {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
 }
 
 impl<'a, Octs: Octets + ?Sized> ParseOptData<'a, Octs>
-for Understood<DhuVariant, Octs::Range<'a>> {
+    for Understood<DhuVariant, Octs::Range<'a>>
+{
     fn parse_option(
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
         if code == OptionCode::DHU {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
 }
 
 impl<'a, Octs: Octets + ?Sized> ParseOptData<'a, Octs>
-for Understood<N3uVariant, Octs::Range<'a>> {
+    for Understood<N3uVariant, Octs::Range<'a>>
+{
     fn parse_option(
         code: OptionCode,
         parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
         if code == OptionCode::N3U {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
@@ -358,14 +359,19 @@ for Understood<N3uVariant, Octs::Range<'a>> {
 impl<Variant, Octs> ComposeOptData for Understood<Variant, Octs>
 where
     Self: OptData,
-    Octs: AsRef<[u8]> + ?Sized, 
+    Octs: AsRef<[u8]> + ?Sized,
 {
     fn compose_len(&self) -> u16 {
-        self.octets.as_ref().len().try_into().expect("long option data")
+        self.octets
+            .as_ref()
+            .len()
+            .try_into()
+            .expect("long option data")
     }
 
     fn compose_option<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         target.append_slice(self.octets.as_ref())
     }
@@ -375,7 +381,7 @@ where
 
 impl<'a, Variant, Octs> IntoIterator for &'a Understood<Variant, Octs>
 where
-    Octs: AsRef<[u8]> + ?Sized
+    Octs: AsRef<[u8]> + ?Sized,
 {
     type Item = SecurityAlgorithm;
     type IntoIter = SecurityAlgorithmIter<'a>;
@@ -391,7 +397,7 @@ impl<Variant, Octs> fmt::Display for Understood<Variant, Octs>
 where
     Octs: AsRef<[u8]> + ?Sized,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut first = true;
 
         for v in self.octets.as_ref() {
@@ -409,7 +415,7 @@ where
 //--- Debug
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<DauVariant, Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Understood<DauVariant>")
             .field(&format_args!("{}", self))
             .finish()
@@ -417,7 +423,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<DauVariant, Octs> {
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<DhuVariant, Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Understood<DhuVariant>")
             .field(&format_args!("{}", self))
             .finish()
@@ -425,7 +431,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<DhuVariant, Octs> {
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<N3uVariant, Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Understood<N3uVariant>")
             .field(&format_args!("{}", self))
             .finish()
@@ -438,7 +444,8 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Understood<N3uVariant, Octs> {
 impl<V, Octs: AsRef<[u8]>> serde::Serialize for Understood<V, Octs> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         use serde::ser::SerializeSeq;
         let mut list = serializer.serialize_seq(None)?;
         for item in self.iter() {
@@ -480,13 +487,16 @@ impl<Target: Composer> OptBuilder<'_, Target> {
     /// The DAU option lists the DNSSEC signature algorithms the requester
     /// supports.
     pub fn dau(
-        &mut self, algs: &impl AsRef<[SecurityAlgorithm]>,
+        &mut self,
+        algs: &impl AsRef<[SecurityAlgorithm]>,
     ) -> Result<(), BuildDataError> {
         Ok(self.push_raw_option(
             OptionCode::DAU,
             u16::try_from(
-                algs.as_ref().len() * usize::from(SecurityAlgorithm::COMPOSE_LEN)
-            ).map_err(|_| BuildDataError::LongOptData)?,
+                algs.as_ref().len()
+                    * usize::from(SecurityAlgorithm::COMPOSE_LEN),
+            )
+            .map_err(|_| BuildDataError::LongOptData)?,
             |octs| {
                 algs.as_ref().iter().try_for_each(|item| item.compose(octs))
             },
@@ -497,13 +507,16 @@ impl<Target: Composer> OptBuilder<'_, Target> {
     ///
     /// The DHU option lists the DS hash algorithms the requester supports.
     pub fn dhu(
-        &mut self, algs: &impl AsRef<[SecurityAlgorithm]>,
+        &mut self,
+        algs: &impl AsRef<[SecurityAlgorithm]>,
     ) -> Result<(), BuildDataError> {
         Ok(self.push_raw_option(
             OptionCode::DHU,
             u16::try_from(
-                algs.as_ref().len() * usize::from(SecurityAlgorithm::COMPOSE_LEN)
-            ).map_err(|_| BuildDataError::LongOptData)?,
+                algs.as_ref().len()
+                    * usize::from(SecurityAlgorithm::COMPOSE_LEN),
+            )
+            .map_err(|_| BuildDataError::LongOptData)?,
             |octs| {
                 algs.as_ref().iter().try_for_each(|item| item.compose(octs))
             },
@@ -514,13 +527,16 @@ impl<Target: Composer> OptBuilder<'_, Target> {
     ///
     /// The N3U option lists the NSEC3 hash algorithms the requester supports.
     pub fn n3u(
-        &mut self, algs: &impl AsRef<[SecurityAlgorithm]>,
+        &mut self,
+        algs: &impl AsRef<[SecurityAlgorithm]>,
     ) -> Result<(), BuildDataError> {
         Ok(self.push_raw_option(
             OptionCode::N3U,
             u16::try_from(
-                algs.as_ref().len() * usize::from(SecurityAlgorithm::COMPOSE_LEN)
-            ).map_err(|_| BuildDataError::LongOptData)?,
+                algs.as_ref().len()
+                    * usize::from(SecurityAlgorithm::COMPOSE_LEN),
+            )
+            .map_err(|_| BuildDataError::LongOptData)?,
             |octs| {
                 algs.as_ref().iter().try_for_each(|item| item.compose(octs))
             },
@@ -551,15 +567,15 @@ impl Iterator for SecurityAlgorithmIter<'_> {
 #[cfg(test)]
 #[cfg(all(feature = "std", feature = "bytes"))]
 mod test {
-    use super::*;
     use super::super::test::test_option_compose_parse;
+    use super::*;
 
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn dau_compose_parse() {
         test_option_compose_parse(
             &Dau::from_octets("foof").unwrap(),
-            |parser| Dau::parse(parser)
+            |parser| Dau::parse(parser),
         );
     }
 }

--- a/src/base/opt/chain.rs
+++ b/src/base/opt/chain.rs
@@ -11,8 +11,8 @@ use super::super::message_builder::OptBuilder;
 use super::super::name::{Name, ToName};
 use super::super::wire::{Composer, ParseError};
 use super::{ComposeOptData, Opt, OptData, ParseOptData};
-use core::{fmt, hash, mem};
 use core::cmp::Ordering;
+use core::{fmt, hash, mem};
 use octseq::builder::OctetsBuilder;
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
@@ -174,13 +174,13 @@ impl<Name: ToName> ComposeOptData for Chain<Name> {
 //--- Display and Debug
 
 impl<Name: fmt::Display> fmt::Display for Chain<Name> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.start)
     }
 }
 
 impl<Name: fmt::Display> fmt::Debug for Chain<Name> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Chain")
             .field("start", &format_args!("{}", self.start))
             .finish()

--- a/src/base/opt/cookie.rs
+++ b/src/base/opt/cookie.rs
@@ -19,18 +19,17 @@
 //! [RFC 7873]: https://tools.ietf.org/html/rfc7873
 //! [RFC 9018]: https://tools.ietf.org/html/rfc9018
 
+use super::super::iana::OptionCode;
+use super::super::message_builder::OptBuilder;
+use super::super::wire::{Composer, ParseError};
+use super::{ComposeOptData, Opt, OptData, ParseOptData};
+use crate::base::Serial;
+use crate::utils::base16;
 use core::{fmt, hash};
 use octseq::array::Array;
 use octseq::builder::OctetsBuilder;
 use octseq::octets::Octets;
 use octseq::parse::Parser;
-use crate::base::Serial;
-use crate::utils::base16;
-use super::super::iana::OptionCode;
-use super::super::message_builder::OptBuilder;
-use super::super::wire::{Composer, ParseError};
-use super::{Opt, OptData, ComposeOptData, ParseOptData};
-
 
 //------------ Cookie --------------------------------------------------------
 
@@ -51,11 +50,17 @@ use super::{Opt, OptData, ComposeOptData, ParseOptData};
 /// be a random client cookie, it needs the `rand` feature. The server can
 /// check whether a received cookie includes a server cookie created by it
 /// via the
-#[cfg_attr(feature = "siphasher", doc = "[`check_server_hash`](Self::check_server_hash)")]
+#[cfg_attr(
+    feature = "siphasher",
+    doc = "[`check_server_hash`](Self::check_server_hash)"
+)]
 #[cfg_attr(not(feature = "siphasher"), doc = "`check_server_hash`")]
 /// method. It needs the SipHash-2-4 algorithm and is thus available if the
 /// `siphasher` feature is enabled. The same feature also enables the
-#[cfg_attr(feature = "siphasher", doc = "[`create_response`](Self::create_response)")]
+#[cfg_attr(
+    feature = "siphasher",
+    doc = "[`create_response`](Self::create_response)"
+)]
 #[cfg_attr(not(feature = "siphasher"), doc = "`create_response`")]
 /// method which creates the server
 /// cookie to be included in a response.
@@ -64,7 +69,7 @@ use super::{Opt, OptData, ComposeOptData, ParseOptData};
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Cookie {
     /// The client cookie.
-    client: ClientCookie, 
+    client: ClientCookie,
 
     /// The optional server cookie.
     server: Option<ServerCookie>,
@@ -76,10 +81,7 @@ impl Cookie {
 
     /// Creates a new cookie from client and optional server cookie.
     #[must_use]
-    pub fn new(
-        client: ClientCookie,
-        server: Option<ServerCookie>
-    ) -> Self {
+    pub fn new(client: ClientCookie, server: Option<ServerCookie>) -> Self {
         Cookie { client, server }
     }
 
@@ -97,7 +99,7 @@ impl Cookie {
 
     /// Parses the cookie from its wire format.
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         Ok(Cookie::new(
             ClientCookie::parse(parser)?,
@@ -128,13 +130,14 @@ impl Cookie {
         secret: &[u8; 16],
         timestamp_ok: impl FnOnce(Serial) -> bool,
     ) -> bool {
-        self.server.as_ref().and_then(|server| {
-            server.try_to_standard()
-        }).and_then(|server| {
-            timestamp_ok(server.timestamp()).then_some(server)
-        }).map(|server| {
-            server.check_hash(self.client(), client_ip, secret)
-        }).unwrap_or(false)
+        self.server
+            .as_ref()
+            .and_then(|server| server.try_to_standard())
+            .and_then(|server| {
+                timestamp_ok(server.timestamp()).then_some(server)
+            })
+            .map(|server| server.check_hash(self.client(), client_ip, secret))
+            .unwrap_or(false)
     }
 
     /// Creates a random client cookie for including in an initial request.
@@ -150,18 +153,22 @@ impl Cookie {
     /// to produce a cookie option that should be included in a response.
     #[cfg(feature = "siphasher")]
     pub fn create_response(
-        &self, 
+        &self,
         timestamp: Serial,
         client_ip: crate::base::net::IpAddr,
-        secret: &[u8; 16]
+        secret: &[u8; 16],
     ) -> Self {
         Self::new(
             self.client,
             Some(
                 StandardServerCookie::calculate(
-                    self.client, timestamp, client_ip, secret
-                ).into()
-            )
+                    self.client,
+                    timestamp,
+                    client_ip,
+                    secret,
+                )
+                .into(),
+            ),
         )
     }
 
@@ -172,7 +179,6 @@ impl Cookie {
         Ok(src)
     }
 }
-
 
 //--- OptData
 
@@ -189,8 +195,7 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> ParseOptData<'a, Octs> for Cookie {
     ) -> Result<Option<Self>, ParseError> {
         if code == OptionCode::COOKIE {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
@@ -199,17 +204,16 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> ParseOptData<'a, Octs> for Cookie {
 impl ComposeOptData for Cookie {
     fn compose_len(&self) -> u16 {
         match self.server.as_ref() {
-            Some(server) => {
-                ClientCookie::COMPOSE_LEN.checked_add(
-                    server.compose_len()
-                ).expect("long server cookie")
-            }
-            None => ClientCookie::COMPOSE_LEN
+            Some(server) => ClientCookie::COMPOSE_LEN
+                .checked_add(server.compose_len())
+                .expect("long server cookie"),
+            None => ClientCookie::COMPOSE_LEN,
         }
     }
 
     fn compose_option<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         self.client.compose(target)?;
         if let Some(server) = self.server.as_ref() {
@@ -220,7 +224,7 @@ impl ComposeOptData for Cookie {
 }
 
 impl fmt::Display for Cookie {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.client, f)?;
         if let Some(server) = self.server.as_ref() {
             fmt::Display::fmt(server, f)?;
@@ -228,7 +232,6 @@ impl fmt::Display for Cookie {
         Ok(())
     }
 }
-
 
 //--- Extending Opt and OptBuilder
 
@@ -242,7 +245,8 @@ impl<Octs: Octets> Opt<Octs> {
 impl<Target: Composer> OptBuilder<'_, Target> {
     /// Appends a new cookie option.
     pub fn cookie(
-        &mut self, cookie: Cookie,
+        &mut self,
+        cookie: Cookie,
     ) -> Result<(), Target::AppendError> {
         self.push(&cookie)
     }
@@ -256,7 +260,6 @@ impl<Target: Composer> OptBuilder<'_, Target> {
         self.push(&Cookie::create_initial())
     }
 }
-
 
 //------------ ClientCookie --------------------------------------------------
 
@@ -272,7 +275,10 @@ impl<Target: Composer> OptBuilder<'_, Target> {
 /// originating a request, this has been relaxed and it is now suggested that
 /// the cookies is just random data. If the `rand` feature is enabled, the
 /// `new`
-#[cfg_attr(feature = "rand", doc = "[`new_random`][ClientCookie::new_random]")]
+#[cfg_attr(
+    feature = "rand",
+    doc = "[`new_random`][ClientCookie::new_random]"
+)]
 #[cfg_attr(not(feature = "rand"), doc = "`new_random`")]
 /// constructor can be used to generate such a random cookie. Otherwise,
 /// it needs to be created from the octets via
@@ -286,9 +292,10 @@ pub struct ClientCookie([u8; 8]);
 impl serde::Serialize for ClientCookie {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
-            use octseq::serde::SerializeOctets;
-            self.0.serialize_octets(serializer)
+        S: serde::Serializer,
+    {
+        use octseq::serde::SerializeOctets;
+        self.0.serialize_octets(serializer)
     }
 }
 
@@ -314,7 +321,7 @@ impl ClientCookie {
 
     /// Parses a client cookie from its wire format.
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         let mut res = Self::from_octets([0; 8]);
         parser.parse_buf(res.as_mut())?;
@@ -326,7 +333,8 @@ impl ClientCookie {
 
     /// Appends the wire format of the client cookie to the target.
     pub fn compose<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         target.append_slice(&self.0)
     }
@@ -380,11 +388,10 @@ impl hash::Hash for ClientCookie {
 //--- Display
 
 impl fmt::Display for ClientCookie {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         base16::display(self.0.as_ref(), f)
     }
 }
-
 
 //------------ ServerCookie --------------------------------------------------
 
@@ -414,7 +421,8 @@ pub struct ServerCookie(Array<32>);
 impl serde::Serialize for ServerCookie {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         use octseq::serde::SerializeOctets;
         self.0.serialize_octets(serializer)
     }
@@ -431,33 +439,32 @@ impl ServerCookie {
     pub fn from_octets(slice: &[u8]) -> Self {
         assert!(slice.len() >= 8, "server cookie shorter than 8 octets");
         let mut res = Array::new();
-        res.append_slice(slice).expect("server cookie longer tha 32 octets");
+        res.append_slice(slice)
+            .expect("server cookie longer tha 32 octets");
         Self(res)
     }
 
     /// Parses a server cookie from its wire format.
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         if parser.remaining() < 8 {
-            return Err(ParseError::form_error("short server cookie"))
+            return Err(ParseError::form_error("short server cookie"));
         }
         let mut res = Array::new();
-        res.resize_raw(parser.remaining()).map_err(|_| {
-            ParseError::form_error("long server cookie")
-        })?;
+        res.resize_raw(parser.remaining())
+            .map_err(|_| ParseError::form_error("long server cookie"))?;
         parser.parse_buf(res.as_slice_mut())?;
         Ok(Self(res))
     }
 
     /// Parses an optional server cookie from its wire format.
     pub fn parse_opt<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Option<Self>, ParseError> {
         if parser.remaining() > 0 {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
@@ -467,7 +474,9 @@ impl ServerCookie {
     /// This is possible if the length of the cookie is 16 octets. Returns
     /// `None` otherwise.
     pub fn try_to_standard(&self) -> Option<StandardServerCookie> {
-        TryFrom::try_from(self.0.as_slice()).map(StandardServerCookie).ok()
+        TryFrom::try_from(self.0.as_slice())
+            .map(StandardServerCookie)
+            .ok()
     }
 
     /// Returns the length of the wire format of the cookie.
@@ -478,7 +487,8 @@ impl ServerCookie {
 
     /// Appends the wire format of the cookie to the target.
     pub fn compose<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         target.append_slice(self.0.as_ref())
     }
@@ -503,11 +513,10 @@ impl AsRef<[u8]> for ServerCookie {
 //--- Display
 
 impl fmt::Display for ServerCookie {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         base16::display(self.0.as_ref(), f)
     }
 }
-
 
 //------------ StandardServerCookie ------------------------------------------
 
@@ -535,7 +544,7 @@ pub struct StandardServerCookie(
     // We let this type wrap a u8 array so we can provide AsRef<[u8]> it.
     // This makes reading the timestamp a tiny bit expensive on certain
     // systems, but so be it.
-    [u8; 16]
+    [u8; 16],
 );
 
 impl StandardServerCookie {
@@ -545,16 +554,27 @@ impl StandardServerCookie {
         version: u8,
         reserved: [u8; 3],
         timestamp: Serial,
-        hash: [u8; 8]
+        hash: [u8; 8],
     ) -> Self {
         let ts = timestamp.into_int().to_be_bytes();
-        Self(
-            [ version, reserved[0], reserved[1], reserved[2],
-              ts[0], ts[1], ts[2], ts[3],
-              hash[0], hash[1], hash[2], hash[3],
-              hash[4], hash[5], hash[6], hash[7],
-            ]
-        )
+        Self([
+            version,
+            reserved[0],
+            reserved[1],
+            reserved[2],
+            ts[0],
+            ts[1],
+            ts[2],
+            ts[3],
+            hash[0],
+            hash[1],
+            hash[2],
+            hash[3],
+            hash[4],
+            hash[5],
+            hash[6],
+            hash[7],
+        ])
     }
 
     /// Calculates the server cookie for the given components.
@@ -563,12 +583,10 @@ impl StandardServerCookie {
         client_cookie: ClientCookie,
         timestamp: Serial,
         client_ip: crate::base::net::IpAddr,
-        secret: &[u8; 16]
+        secret: &[u8; 16],
     ) -> Self {
         let mut res = Self::new(1, [0; 3], timestamp, [0; 8]);
-        res.set_hash(
-            res.calculate_hash(client_cookie, client_ip, secret)
-        );
+        res.set_hash(res.calculate_hash(client_cookie, client_ip, secret));
         res
     }
 
@@ -588,7 +606,7 @@ impl StandardServerCookie {
     #[must_use]
     pub fn timestamp(self) -> Serial {
         Serial::from_be_bytes(
-            TryFrom::try_from(&self.0[4..8]).expect("bad slicing")
+            TryFrom::try_from(&self.0[4..8]).expect("bad slicing"),
         )
     }
 
@@ -609,7 +627,7 @@ impl StandardServerCookie {
         self,
         client_cookie: ClientCookie,
         client_ip: crate::base::net::IpAddr,
-        secret: &[u8; 16]
+        secret: &[u8; 16],
     ) -> bool {
         self.calculate_hash(client_cookie, client_ip, secret) == self.hash()
     }
@@ -629,10 +647,10 @@ impl StandardServerCookie {
         self,
         client_cookie: ClientCookie,
         client_ip: crate::base::net::IpAddr,
-        secret: &[u8; 16]
+        secret: &[u8; 16],
     ) -> [u8; 8] {
-        use core::hash::{Hash, Hasher};
         use crate::base::net::IpAddr;
+        use core::hash::{Hash, Hasher};
 
         let mut hasher = siphasher::sip::SipHasher24::new_with_key(secret);
         client_cookie.hash(&mut hasher);
@@ -648,11 +666,10 @@ impl StandardServerCookie {
 //--- Display
 
 impl fmt::Display for StandardServerCookie {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         base16::display(self.0.as_ref(), f)
     }
 }
-
 
 //============ Tests =========================================================
 
@@ -664,29 +681,29 @@ mod test {
     /// Tests from Appendix A of RFC 9018.
     #[cfg(all(feature = "siphasher", feature = "std"))]
     mod standard_server {
+        use super::*;
         use crate::base::net::{IpAddr, Ipv4Addr, Ipv6Addr};
         use crate::base::wire::{compose_vec, parse_slice};
-        use super::*;
 
         const CLIENT_1: IpAddr = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 100));
         const CLIENT_2: IpAddr = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 203));
         const CLIENT_6: IpAddr = IpAddr::V6(Ipv6Addr::new(
-            0x2001, 0xdb8, 0x220, 0x1, 0x59de, 0xd0f4, 0x8769, 0x82b8
+            0x2001, 0xdb8, 0x220, 0x1, 0x59de, 0xd0f4, 0x8769, 0x82b8,
         ));
 
         const SECRET: [u8; 16] = [
-            0xe5, 0xe9, 0x73, 0xe5, 0xa6, 0xb2, 0xa4, 0x3f,
-            0x48, 0xe7, 0xdc, 0x84, 0x9e, 0x37, 0xbf, 0xcf,
+            0xe5, 0xe9, 0x73, 0xe5, 0xa6, 0xb2, 0xa4, 0x3f, 0x48, 0xe7, 0xdc,
+            0x84, 0x9e, 0x37, 0xbf, 0xcf,
         ];
 
         /// A.1. Learning a New Server Cookie
         #[test]
         fn new_cookie() {
             let request = Cookie::new(
-                ClientCookie::from_octets(
-                    [ 0x24, 0x64, 0xc4, 0xab, 0xcf, 0x10, 0xc9, 0x57 ]
-                ),
-                None
+                ClientCookie::from_octets([
+                    0x24, 0x64, 0xc4, 0xab, 0xcf, 0x10, 0xc9, 0x57,
+                ]),
+                None,
             );
             assert_eq!(
                 compose_vec(|vec| request.compose_option(vec)),
@@ -695,13 +712,18 @@ mod test {
 
             assert_eq!(
                 compose_vec(|vec| {
-                    request.create_response(
-                        Serial(1559731985), CLIENT_1, &SECRET
-                    ).compose_option(vec)
+                    request
+                        .create_response(
+                            Serial(1559731985),
+                            CLIENT_1,
+                            &SECRET,
+                        )
+                        .compose_option(vec)
                 }),
                 base16::decode_vec(
                     "2464c4abcf10c957010000005cf79f111f8130c3eee29480"
-                ).unwrap()
+                )
+                .unwrap()
             );
         }
 
@@ -710,26 +732,30 @@ mod test {
         fn renew_cookie() {
             let request = parse_slice(
                 &base16::decode_vec(
-                "2464c4abcf10c957010000005cf79f111f8130c3eee29480"
-                ).unwrap(),
-                Cookie::parse
-            ).unwrap();
-            assert!(
-                request.check_server_hash(
-                    CLIENT_1, &SECRET,
-                    |serial| serial == Serial(1559731985)
+                    "2464c4abcf10c957010000005cf79f111f8130c3eee29480",
                 )
-            );
+                .unwrap(),
+                Cookie::parse,
+            )
+            .unwrap();
+            assert!(request
+                .check_server_hash(CLIENT_1, &SECRET, |serial| serial
+                    == Serial(1559731985)));
 
             assert_eq!(
                 compose_vec(|vec| {
-                    request.create_response(
-                        Serial(1559734385), CLIENT_1, &SECRET
-                    ).compose_option(vec)
+                    request
+                        .create_response(
+                            Serial(1559734385),
+                            CLIENT_1,
+                            &SECRET,
+                        )
+                        .compose_option(vec)
                 }),
                 base16::decode_vec(
                     "2464c4abcf10c957010000005cf7a871d4a564a1442aca77"
-                ).unwrap()
+                )
+                .unwrap()
             );
         }
 
@@ -738,72 +764,79 @@ mod test {
         fn non_zero_reserved() {
             let request = parse_slice(
                 &base16::decode_vec(
-                    "fc93fc62807ddb8601abcdef5cf78f71a314227b6679ebf5"
-                ).unwrap(),
-                Cookie::parse
-            ).unwrap();
-            assert!(
-                request.check_server_hash(
-                    CLIENT_2, &SECRET,
-                    |serial| serial == Serial(1559727985)
+                    "fc93fc62807ddb8601abcdef5cf78f71a314227b6679ebf5",
                 )
-            );
+                .unwrap(),
+                Cookie::parse,
+            )
+            .unwrap();
+            assert!(request
+                .check_server_hash(CLIENT_2, &SECRET, |serial| serial
+                    == Serial(1559727985)));
 
             assert_eq!(
                 compose_vec(|vec| {
-                    request.create_response(
-                        Serial(1559734700), CLIENT_2, &SECRET
-                    ).compose_option(vec)
+                    request
+                        .create_response(
+                            Serial(1559734700),
+                            CLIENT_2,
+                            &SECRET,
+                        )
+                        .compose_option(vec)
                 }),
                 base16::decode_vec(
                     "fc93fc62807ddb86010000005cf7a9acf73a7810aca2381e"
-                ).unwrap()
+                )
+                .unwrap()
             );
         }
 
         /// A.4.  IPv6 Query with Rolled Over Secret
         #[test]
         fn new_secret() {
-
             const OLD_SECRET: [u8; 16] = [
-                0xdd, 0x3b, 0xdf, 0x93, 0x44, 0xb6, 0x78, 0xb1,
-                0x85, 0xa6, 0xf5, 0xcb, 0x60, 0xfc, 0xa7, 0x15,
+                0xdd, 0x3b, 0xdf, 0x93, 0x44, 0xb6, 0x78, 0xb1, 0x85, 0xa6,
+                0xf5, 0xcb, 0x60, 0xfc, 0xa7, 0x15,
             ];
             const NEW_SECRET: [u8; 16] = [
-                0x44, 0x55, 0x36, 0xbc, 0xd2, 0x51, 0x32, 0x98,
-                0x07, 0x5a, 0x5d, 0x37, 0x96, 0x63, 0xc9, 0x62,
+                0x44, 0x55, 0x36, 0xbc, 0xd2, 0x51, 0x32, 0x98, 0x07, 0x5a,
+                0x5d, 0x37, 0x96, 0x63, 0xc9, 0x62,
             ];
 
             let request = parse_slice(
                 &base16::decode_vec(
-                    "22681ab97d52c298010000005cf7c57926556bd0934c72f8"
-                ).unwrap(),
-                Cookie::parse
-            ).unwrap();
-            assert!(
-                !request.check_server_hash(
-                    CLIENT_6, &NEW_SECRET,
-                    |serial| serial == Serial(1559741817)
+                    "22681ab97d52c298010000005cf7c57926556bd0934c72f8",
                 )
-            );
-            assert!(
-                request.check_server_hash(
-                    CLIENT_6, &OLD_SECRET,
-                    |serial| serial == Serial(1559741817)
-                )
-            );
+                .unwrap(),
+                Cookie::parse,
+            )
+            .unwrap();
+            assert!(!request.check_server_hash(
+                CLIENT_6,
+                &NEW_SECRET,
+                |serial| serial == Serial(1559741817)
+            ));
+            assert!(request.check_server_hash(
+                CLIENT_6,
+                &OLD_SECRET,
+                |serial| serial == Serial(1559741817)
+            ));
 
             assert_eq!(
                 compose_vec(|vec| {
-                    request.create_response(
-                        Serial(1559741961), CLIENT_6, &NEW_SECRET
-                    ).compose_option(vec)
+                    request
+                        .create_response(
+                            Serial(1559741961),
+                            CLIENT_6,
+                            &NEW_SECRET,
+                        )
+                        .compose_option(vec)
                 }),
                 base16::decode_vec(
                     "22681ab97d52c298010000005cf7c609a6bb79d16625507a"
-                ).unwrap()
+                )
+                .unwrap()
             );
         }
     }
 }
-

--- a/src/base/opt/keytag.rs
+++ b/src/base/opt/keytag.rs
@@ -11,14 +11,13 @@
 use super::super::iana::OptionCode;
 use super::super::message_builder::OptBuilder;
 use super::super::wire::{Composer, ParseError};
-use super::{Opt, OptData, ComposeOptData, ParseOptData};
+use super::{ComposeOptData, Opt, OptData, ParseOptData};
+use core::cmp::Ordering;
+use core::convert::TryInto;
+use core::{borrow, fmt, hash, mem};
 use octseq::builder::OctetsBuilder;
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
-use core::{borrow, fmt, hash, mem};
-use core::cmp::Ordering;
-use core::convert::TryInto;
-
 
 //------------ KeyTag -------------------------------------------------------
 
@@ -37,7 +36,7 @@ impl KeyTag<()> {
     /// The option code for this option.
     pub(super) const CODE: OptionCode = OptionCode::KEY_TAG;
 }
-    
+
 impl<Octs> KeyTag<Octs> {
     /// Creates a new value from its content in wire format.
     ///
@@ -45,9 +44,11 @@ impl<Octs> KeyTag<Octs> {
     /// edns-key-tag option: the length needs to be an even number of
     /// octets and no longer than 65,536 octets.
     pub fn from_octets(octets: Octs) -> Result<Self, ParseError>
-    where Octs: AsRef<[u8]> {
+    where
+        Octs: AsRef<[u8]>,
+    {
         KeyTag::check_len(octets.as_ref().len())?;
-        Ok(unsafe { Self::from_octets_unchecked(octets ) })
+        Ok(unsafe { Self::from_octets_unchecked(octets) })
     }
 
     /// Creates a new value from its wire-format content without checking.
@@ -62,7 +63,7 @@ impl<Octs> KeyTag<Octs> {
     }
 
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
-        parser: &mut Parser<'a, Src>
+        parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
         let len = parser.remaining();
         KeyTag::check_len(len)?;
@@ -97,11 +98,9 @@ impl KeyTag<[u8]> {
     fn check_len(len: usize) -> Result<(), ParseError> {
         if len > usize::from(u16::MAX) {
             Err(ParseError::form_error("long edns-key-tag option"))
-        }
-        else if len % 2 == 1 {
+        } else if len % 2 == 1 {
             Err(ParseError::form_error("invalid edns-key-tag option length"))
-        }
-        else {
+        } else {
             Ok(())
         }
     }
@@ -150,8 +149,10 @@ impl<Octs: ?Sized> KeyTag<Octs> {
     }
 
     /// Returns an iterator over the individual key tags.
-    pub fn iter(&self) -> KeyTagIter
-    where Octs: AsRef<[u8]> {
+    pub fn iter(&self) -> KeyTagIter<'_>
+    where
+        Octs: AsRef<[u8]>,
+    {
         KeyTagIter(self.octets.as_ref())
     }
 }
@@ -159,13 +160,14 @@ impl<Octs: ?Sized> KeyTag<Octs> {
 //--- OctetsFrom
 
 impl<Octs, SrcOcts> OctetsFrom<KeyTag<SrcOcts>> for KeyTag<Octs>
-where Octs: OctetsFrom<SrcOcts> {
+where
+    Octs: OctetsFrom<SrcOcts>,
+{
     type Error = Octs::Error;
 
     fn try_octets_from(src: KeyTag<SrcOcts>) -> Result<Self, Self::Error> {
-        Octs::try_octets_from(src.octets).map(|octets| unsafe {
-            Self::from_octets_unchecked(octets)
-        })
+        Octs::try_octets_from(src.octets)
+            .map(|octets| unsafe { Self::from_octets_unchecked(octets) })
     }
 }
 
@@ -191,7 +193,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> borrow::Borrow<[u8]> for KeyTag<Octs> {
 
 impl<Octs> borrow::BorrowMut<[u8]> for KeyTag<Octs>
 where
-    Octs: AsMut<[u8]> + AsRef<[u8]> + ?Sized
+    Octs: AsMut<[u8]> + AsRef<[u8]> + ?Sized,
 {
     fn borrow_mut(&mut self) -> &mut [u8] {
         self.as_slice_mut()
@@ -213,8 +215,7 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for KeyTag<Octs::Range<'a>> {
     ) -> Result<Option<Self>, ParseError> {
         if code == OptionCode::KEY_TAG {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
@@ -222,16 +223,20 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for KeyTag<Octs::Range<'a>> {
 
 impl<Octs: AsRef<[u8]> + ?Sized> ComposeOptData for KeyTag<Octs> {
     fn compose_len(&self) -> u16 {
-        self.octets.as_ref().len().try_into().expect("long option data")
+        self.octets
+            .as_ref()
+            .len()
+            .try_into()
+            .expect("long option data")
     }
 
     fn compose_option<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         target.append_slice(self.octets.as_ref())
     }
 }
-
 
 //--- IntoIterator
 
@@ -244,13 +249,12 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> IntoIterator for &'a KeyTag<Octs> {
     }
 }
 
-
 //--- Display and Debug
 
-impl<Octets: AsRef<[u8]> + ?Sized> fmt::Display  for KeyTag<Octets> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<Octets: AsRef<[u8]> + ?Sized> fmt::Display for KeyTag<Octets> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut first = true;
-        
+
         for v in self.octets.as_ref() {
             if first {
                 write!(f, "{:X}", ((*v as u16) << 8) | *v as u16)?;
@@ -264,12 +268,11 @@ impl<Octets: AsRef<[u8]> + ?Sized> fmt::Display  for KeyTag<Octets> {
     }
 }
 
-impl<Octets: AsRef<[u8]> + ?Sized> fmt::Debug  for KeyTag<Octets> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<Octets: AsRef<[u8]> + ?Sized> fmt::Debug for KeyTag<Octets> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "KeyTag([{}])", self)
     }
 }
-
 
 //--- PartialEq and Eq
 
@@ -283,7 +286,7 @@ where
     }
 }
 
-impl<Octs: AsRef<[u8]> + ?Sized> Eq for KeyTag<Octs> { }
+impl<Octs: AsRef<[u8]> + ?Sized> Eq for KeyTag<Octs> {}
 
 //--- PartialOrd and Ord
 
@@ -329,7 +332,8 @@ impl<Target: Composer> OptBuilder<'_, Target> {
     /// The option contains a list of the key tags of the trust anchor keys
     /// a validating resolver is using for DNSSEC validation.
     pub fn key_tag(
-        &mut self, key_tag: &KeyTag<impl AsRef<[u8]> + ?Sized>,
+        &mut self,
+        key_tag: &KeyTag<impl AsRef<[u8]> + ?Sized>,
     ) -> Result<(), Target::AppendError> {
         self.push(key_tag)
     }
@@ -341,7 +345,8 @@ impl<Target: Composer> OptBuilder<'_, Target> {
 impl<Octs: AsRef<[u8]>> serde::Serialize for KeyTag<Octs> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         use serde::ser::SerializeSeq;
 
         let mut list = serializer.serialize_seq(None)?;
@@ -369,8 +374,7 @@ impl Iterator for KeyTagIter<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.0.len() < 2 {
             None
-        }
-        else {
+        } else {
             let (item, tail) = self.0.split_at(2);
             self.0 = tail;
             Some(u16::from_be_bytes(item.try_into().unwrap()))
@@ -378,22 +382,20 @@ impl Iterator for KeyTagIter<'_> {
     }
 }
 
-
 //============ Testing ======================================================
 
 #[cfg(test)]
 #[cfg(all(feature = "std", feature = "bytes"))]
 mod test {
-    use super::*;
     use super::super::test::test_option_compose_parse;
-    
+    use super::*;
+
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn nsid_compose_parse() {
         test_option_compose_parse(
             &KeyTag::from_octets("fooo").unwrap(),
-            |parser| KeyTag::parse(parser)
+            |parser| KeyTag::parse(parser),
         );
     }
 }
-

--- a/src/base/opt/macros.rs
+++ b/src/base/opt/macros.rs
@@ -146,7 +146,7 @@ macro_rules! opt_types {
 
         impl<Octs, Name> fmt::Debug for AllOptData<Octs, Name>
         where Octs: AsRef<[u8]>, Name: fmt::Display {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match *self {
                     $( $(
                         AllOptData::$opt(ref inner) => {

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -365,14 +365,14 @@ impl<Octs: AsRef<[u8]> + ?Sized> ComposeRecordData for Opt<Octs> {
 //--- Display
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Opt<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // XXX TODO Print this properly.
         f.write_str("OPT ...")
     }
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Opt<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Opt(")?;
         fmt::Display::fmt(self, f)?;
         f.write_str(")")
@@ -714,7 +714,7 @@ impl<Octs> AsRef<Opt<Octs>> for OptRecord<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for OptRecord<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OptRecord")
             .field("udp_payload_size", &self.udp_payload_size)
             .field("ext_rcord", &self.ext_rcode)
@@ -762,7 +762,7 @@ impl OptionHeader {
     }
 
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>,
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         Ok(OptionHeader::new(
             parser.parse_u16_be()?,
@@ -1042,13 +1042,13 @@ impl<Octs: AsRef<[u8]>> ComposeOptData for UnknownOptData<Octs> {
 //--- Display and Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Display for UnknownOptData<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         base16::display(self.data.as_ref(), f)
     }
 }
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for UnknownOptData<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("UnknownOptData")
             .field("code", &self.code)
             .field("data", &format_args!("{}", self))
@@ -1086,7 +1086,7 @@ impl From<LongOptData> for ParseError {
 }
 
 impl fmt::Display for LongOptData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -1135,7 +1135,7 @@ impl<T: Into<ShortBuf>> From<T> for BuildDataError {
 //--- Display and Error
 
 impl fmt::Display for BuildDataError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::LongOptData => f.write_str("long option data"),
             Self::ShortBuf => ShortBuf.fmt(f),
@@ -1221,7 +1221,7 @@ pub(super) mod test {
     pub fn test_option_compose_parse<In, F, Out>(data: &In, parse: F)
     where
         In: ComposeOptData + PartialEq<Out> + Debug,
-        F: FnOnce(&mut Parser<Bytes>) -> Result<Out, ParseError>,
+        F: FnOnce(&mut Parser<'_, Bytes>) -> Result<Out, ParseError>,
         Out: Debug,
     {
         let mut buf = BytesMut::new();

--- a/src/base/opt/nsid.rs
+++ b/src/base/opt/nsid.rs
@@ -11,14 +11,13 @@ use super::super::iana::OptionCode;
 use super::super::message_builder::OptBuilder;
 use super::super::wire::{Composer, ParseError};
 use super::{
-    BuildDataError, LongOptData, Opt, OptData, ComposeOptData, ParseOptData
+    BuildDataError, ComposeOptData, LongOptData, Opt, OptData, ParseOptData,
 };
+use core::cmp::Ordering;
+use core::{borrow, fmt, hash, mem, str};
 use octseq::builder::OctetsBuilder;
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
-use core::{borrow, fmt, hash, mem, str};
-use core::cmp::Ordering;
-
 
 //------------ Nsid ---------------------------------------------------------/
 
@@ -47,18 +46,21 @@ impl Nsid<()> {
 impl<Octs: octseq::serde::SerializeOctets> serde::Serialize for Nsid<Octs> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         self.octets.serialize_octets(serializer)
     }
 }
-    
+
 impl<Octs> Nsid<Octs> {
     /// Creates a value from the ocets of the name server identifier.
     ///
     /// The function returns an error if `octets` is longer than 65,535
     /// octets.
     pub fn from_octets(octets: Octs) -> Result<Self, LongOptData>
-    where Octs: AsRef<[u8]> {
+    where
+        Octs: AsRef<[u8]>,
+    {
         LongOptData::check_len(octets.as_ref().len())?;
         Ok(unsafe { Self::from_octets_unchecked(octets) })
     }
@@ -75,13 +77,11 @@ impl<Octs> Nsid<Octs> {
 
     /// Parses a value from its wire format.
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
-        parser: &mut Parser<'a, Src>
+        parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
         let len = parser.remaining();
         LongOptData::check_len(len)?;
-        Ok(unsafe { Self::from_octets_unchecked(
-            parser.parse_octets(len)?
-        )})
+        Ok(unsafe { Self::from_octets_unchecked(parser.parse_octets(len)?) })
     }
 }
 
@@ -139,7 +139,7 @@ impl<Octs: ?Sized> Nsid<Octs> {
     /// Returns a value over an octets slice.
     pub fn for_slice(&self) -> &Nsid<[u8]>
     where
-        Octs: AsRef<[u8]>
+        Octs: AsRef<[u8]>,
     {
         unsafe { Nsid::from_slice_unchecked(self.octets.as_ref()) }
     }
@@ -148,13 +148,14 @@ impl<Octs: ?Sized> Nsid<Octs> {
 //--- OctetsFrom
 
 impl<Octs, SrcOcts> OctetsFrom<Nsid<SrcOcts>> for Nsid<Octs>
-where Octs: OctetsFrom<SrcOcts> {
+where
+    Octs: OctetsFrom<SrcOcts>,
+{
     type Error = Octs::Error;
 
     fn try_octets_from(src: Nsid<SrcOcts>) -> Result<Self, Self::Error> {
-        Octs::try_octets_from(src.octets).map(|octets| unsafe {
-            Self::from_octets_unchecked(octets)
-        })
+        Octs::try_octets_from(src.octets)
+            .map(|octets| unsafe { Self::from_octets_unchecked(octets) })
     }
 }
 
@@ -187,8 +188,7 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for Nsid<Octs::Range<'a>> {
     ) -> Result<Option<Self>, ParseError> {
         if code == OptionCode::NSID {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
@@ -196,11 +196,16 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for Nsid<Octs::Range<'a>> {
 
 impl<Octs: AsRef<[u8]> + ?Sized> ComposeOptData for Nsid<Octs> {
     fn compose_len(&self) -> u16 {
-        self.octets.as_ref().len().try_into().expect("long option data")
+        self.octets
+            .as_ref()
+            .len()
+            .try_into()
+            .expect("long option data")
     }
 
     fn compose_option<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         target.append_slice(self.octets.as_ref())
     }
@@ -209,7 +214,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> ComposeOptData for Nsid<Octs> {
 //--- Display and Debug
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Nsid<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // RFC 5001 § 2.4:
         // | User interfaces MUST read and write the contents of the NSID
         // | option as a sequence of hexadecimal digits, two digits per
@@ -225,7 +230,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Nsid<Octs> {
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Nsid<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Nsid({})", self)
     }
 }
@@ -242,7 +247,7 @@ where
     }
 }
 
-impl<Octs: AsRef<[u8]> + ?Sized> Eq for Nsid<Octs> { }
+impl<Octs: AsRef<[u8]> + ?Sized> Eq for Nsid<Octs> {}
 
 //--- PartialOrd and Ord
 
@@ -294,7 +299,8 @@ impl<Target: Composer> OptBuilder<'_, Target> {
     /// empty. You can use [`client_nsid`][Self::client_nsid] to easily
     /// append this version of the option.
     pub fn nsid(
-        &mut self, data: &(impl AsRef<[u8]> + ?Sized)
+        &mut self,
+        data: &(impl AsRef<[u8]> + ?Sized),
     ) -> Result<(), BuildDataError> {
         Ok(self.push(Nsid::from_slice(data.as_ref())?)?)
     }
@@ -315,15 +321,15 @@ impl<Target: Composer> OptBuilder<'_, Target> {
 #[cfg(test)]
 #[cfg(all(feature = "std", feature = "bytes"))]
 mod test {
-    use super::*;
     use super::super::test::test_option_compose_parse;
-    
+    use super::*;
+
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn nsid_compose_parse() {
         test_option_compose_parse(
             &Nsid::from_octets("foo").unwrap(),
-            |parser| Nsid::parse(parser)
+            |parser| Nsid::parse(parser),
         );
     }
 }

--- a/src/base/opt/padding.rs
+++ b/src/base/opt/padding.rs
@@ -8,15 +8,14 @@
 //! you should generally just use the [`OptBuilder::padding`] and
 //! [`OptBuilder::random_padding`] methods when constructing a message.
 
-use core::{borrow, fmt, str};
 use super::super::iana::OptionCode;
 use super::super::message_builder::OptBuilder;
 use super::super::wire::{Compose, Composer, ParseError};
-use super::{LongOptData, OptData, ComposeOptData, ParseOptData};
+use super::{ComposeOptData, LongOptData, OptData, ParseOptData};
+use core::{borrow, fmt, str};
 use octseq::builder::OctetsBuilder;
 use octseq::octets::{Octets, OctetsFrom};
 use octseq::parse::Parser;
-
 
 //------------ Padding -------------------------------------------------------
 
@@ -46,7 +45,9 @@ impl<Octs> Padding<Octs> {
     ///
     /// Returns an error if `octets` are longer than 65,535 octets.
     pub fn from_octets(octets: Octs) -> Result<Self, LongOptData>
-    where Octs: AsRef<[u8]> {
+    where
+        Octs: AsRef<[u8]>,
+    {
         LongOptData::check_len(octets.as_ref().len())?;
         Ok(unsafe { Self::from_octets_unchecked(octets) })
     }
@@ -63,13 +64,11 @@ impl<Octs> Padding<Octs> {
 
     /// Parses a value from its wire formal.
     pub fn parse<'a, Src: Octets<Range<'a> = Octs> + ?Sized>(
-        parser: &mut Parser<'a, Src>
+        parser: &mut Parser<'a, Src>,
     ) -> Result<Self, ParseError> {
         let len = parser.remaining();
         LongOptData::check_len(len)?;
-        Ok(unsafe { Self::from_octets_unchecked(
-            parser.parse_octets(len)?
-        )})
+        Ok(unsafe { Self::from_octets_unchecked(parser.parse_octets(len)?) })
     }
 }
 
@@ -99,13 +98,14 @@ impl<Octs: ?Sized> Padding<Octs> {
 //--- OctetsFrom
 
 impl<Octs, SrcOcts> OctetsFrom<Padding<SrcOcts>> for Padding<Octs>
-where Octs: OctetsFrom<SrcOcts> {
+where
+    Octs: OctetsFrom<SrcOcts>,
+{
     type Error = Octs::Error;
 
     fn try_octets_from(src: Padding<SrcOcts>) -> Result<Self, Self::Error> {
-        Octs::try_octets_from(src.octets).map(|octets| unsafe {
-            Self::from_octets_unchecked(octets)
-        })
+        Octs::try_octets_from(src.octets)
+            .map(|octets| unsafe { Self::from_octets_unchecked(octets) })
     }
 }
 
@@ -138,8 +138,7 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for Padding<Octs::Range<'a>> {
     ) -> Result<Option<Self>, ParseError> {
         if code == OptionCode::PADDING {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
@@ -147,11 +146,16 @@ impl<'a, Octs: Octets> ParseOptData<'a, Octs> for Padding<Octs::Range<'a>> {
 
 impl<Octs: AsRef<[u8]>> ComposeOptData for Padding<Octs> {
     fn compose_len(&self) -> u16 {
-        self.octets.as_ref().len().try_into().expect("long option data")
+        self.octets
+            .as_ref()
+            .len()
+            .try_into()
+            .expect("long option data")
     }
 
     fn compose_option<Target: OctetsBuilder + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         target.append_slice(self.octets.as_ref())
     }
@@ -160,7 +164,7 @@ impl<Octs: AsRef<[u8]>> ComposeOptData for Padding<Octs> {
 //--- Display and Debug
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Padding<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for v in self.octets.as_ref() {
             write!(f, "{:X} ", *v)?;
         }
@@ -172,7 +176,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Padding<Octs> {
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Padding<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Padding({})", self)
     }
 }
@@ -180,36 +184,28 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Padding<Octs> {
 //--- Extended OptBuilder
 
 impl<Target: Composer> OptBuilder<'_, Target> {
-    pub fn padding( &mut self, len: u16) -> Result<(), Target::AppendError> {
-        self.push_raw_option(
-            OptionCode::PADDING,
-            len,
-            |target| {
-                for _ in 0..len {
-                    0u8.compose(target)?
-                }
-                Ok(())
+    pub fn padding(&mut self, len: u16) -> Result<(), Target::AppendError> {
+        self.push_raw_option(OptionCode::PADDING, len, |target| {
+            for _ in 0..len {
+                0u8.compose(target)?
             }
-        )
+            Ok(())
+        })
     }
 
     #[cfg(feature = "rand")]
     pub fn random_padding(
-        &mut self, len: u16
+        &mut self,
+        len: u16,
     ) -> Result<(), Target::AppendError> {
-        self.push_raw_option(
-            OptionCode::PADDING,
-            len,
-            |target| {
-                for _ in 0..len {
-                    rand::random::<u8>().compose(target)?
-                }
-                Ok(())
+        self.push_raw_option(OptionCode::PADDING, len, |target| {
+            for _ in 0..len {
+                rand::random::<u8>().compose(target)?
             }
-        )
+            Ok(())
+        })
     }
 }
-
 
 //--- Serialize
 
@@ -217,7 +213,8 @@ impl<Target: Composer> OptBuilder<'_, Target> {
 impl<Octs: AsRef<[u8]>> serde::Serialize for Padding<Octs> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         use octseq::serde::SerializeOctets;
         self.octets.as_ref().serialize_octets(serializer)
     }

--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -293,13 +293,13 @@ impl<N: hash::Hash> hash::Hash for Question<N> {
 //--- Display and Debug
 
 impl<N: fmt::Display> fmt::Display for Question<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.\t{}\t{}", self.qname, self.qtype, self.qclass)
     }
 }
 
 impl<N: fmt::Debug> fmt::Debug for Question<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Question")
             .field("qname", &self.qname)
             .field("qtype", &self.qtype)
@@ -400,7 +400,7 @@ impl From<PresentationErrorEnum> for FromStrError {
 //--- Display and Error
 
 impl fmt::Display for FromStrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             FromStrError::Presentation(err) => err.fmt(f),
             FromStrError::ShortBuf => ShortBuf.fmt(f),
@@ -445,7 +445,7 @@ impl From<name::PresentationError> for PresentationError {
 //--- Display and Error
 
 impl fmt::Display for PresentationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             PresentationErrorEnum::BadName(err) => err.fmt(f),
             PresentationErrorEnum::MissingQname => {

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -459,7 +459,7 @@ impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
 //--- Display
 
 impl<Octs: AsRef<[u8]>> fmt::Display for UnknownRecordData<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\\# {}", self.data.as_ref().len())?;
         for ch in self.data.as_ref() {
             write!(f, " {:02x}", *ch)?
@@ -471,7 +471,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for UnknownRecordData<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for UnknownRecordData<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("UnknownRecordData(")?;
         fmt::Display::fmt(self, f)?;
         f.write_str(")")
@@ -530,7 +530,7 @@ impl LongRecordData {
 }
 
 impl fmt::Display for LongRecordData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -571,7 +571,7 @@ pub(crate) mod test {
     pub fn test_compose_parse<In, F, Out>(data: &In, parse: F)
     where
         In: ComposeRecordData + PartialEq<Out> + Debug,
-        F: FnOnce(&mut Parser<Bytes>) -> Result<Out, ParseError>,
+        F: FnOnce(&mut Parser<'_, Bytes>) -> Result<Out, ParseError>,
         Out: Debug,
     {
         let mut buf = BytesMut::new();

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -404,7 +404,7 @@ where
     Name: fmt::Display,
     Data: RecordData + fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}. {} {} {} {}",
@@ -422,7 +422,7 @@ where
     Name: fmt::Debug,
     Data: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Record")
             .field("owner", &self.owner)
             .field("class", &self.class)
@@ -677,7 +677,7 @@ impl<Name> RecordHeader<Name> {
 impl RecordHeader<()> {
     /// Parses only the record length and skips over all the other fields.
     fn parse_rdlen<Octs: Octets + ?Sized>(
-        parser: &mut Parser<Octs>,
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<u16, ParseError> {
         ParsedName::skip(parser)?;
         parser.advance(
@@ -852,7 +852,7 @@ impl<Name: hash::Hash> hash::Hash for RecordHeader<Name> {
 //--- Debug
 
 impl<Name: fmt::Debug> fmt::Debug for RecordHeader<Name> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RecordHeader")
             .field("owner", &self.owner)
             .field("rtype", &self.rtype)
@@ -1057,7 +1057,7 @@ where
     N: fmt::Display,
     D: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             RecordParseError::Name(ref name) => name.fmt(f),
             RecordParseError::Data(ref data) => data.fmt(f),

--- a/src/base/scan.rs
+++ b/src/base/scan.rs
@@ -727,7 +727,7 @@ impl From<char> for Symbol {
 //--- Display
 
 impl fmt::Display for Symbol {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Symbol::Char(ch) => write!(f, "{}", ch),
             Symbol::SimpleEscape(ch) => write!(f, "\\{}", ch as char),
@@ -1066,7 +1066,7 @@ impl SymbolCharsError {
 //--- Display and Error
 
 impl fmt::Display for SymbolCharsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -1108,7 +1108,7 @@ impl SymbolOctetsError {
 //--- Display and Error
 
 impl fmt::Display for SymbolOctetsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -1157,7 +1157,7 @@ impl BadSymbol {
 //--- Display and Error
 
 impl fmt::Display for BadSymbol {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -1203,7 +1203,7 @@ impl From<ShortBuf> for StrError {
 }
 
 impl fmt::Display for StrError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.0)
     }
 }

--- a/src/base/serde.rs
+++ b/src/base/serde.rs
@@ -39,7 +39,7 @@ where
         {
             type Value = T;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "a u8 or string")
             }
 
@@ -77,7 +77,7 @@ where
         {
             type Value = T;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "a u16 or string")
             }
 
@@ -115,7 +115,7 @@ where
         {
             type Value = T;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "a u32 or string")
             }
 

--- a/src/base/serial.rs
+++ b/src/base/serial.rs
@@ -101,7 +101,7 @@ impl Serial {
     pub const COMPOSE_LEN: u16 = u32::COMPOSE_LEN;
 
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>,
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         u32::parse(parser).map(Into::into)
     }
@@ -147,7 +147,7 @@ impl str::FromStr for Serial {
 //--- Display
 
 impl fmt::Display for Serial {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -190,7 +190,7 @@ impl CanonicalOrd for Serial {
 pub struct IllegalSignatureTime(());
 
 impl fmt::Display for IllegalSignatureTime {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("illegal signature time")
     }
 }

--- a/src/base/wire.rs
+++ b/src/base/wire.rs
@@ -270,7 +270,7 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized, const N: usize> Parse<'a, Octs>
 #[cfg(feature = "std")]
 pub fn parse_slice<F, T>(data: &[u8], op: F) -> Result<T, ParseError>
 where
-    F: FnOnce(&mut Parser<[u8]>) -> Result<T, ParseError>,
+    F: FnOnce(&mut Parser<'_, [u8]>) -> Result<T, ParseError>,
 {
     let mut parser = Parser::from_ref(data);
     let res = op(&mut parser)?;
@@ -336,7 +336,7 @@ impl From<FormError> for ParseError {
 //--- Display and Error
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ParseError::ShortInput => f.write_str("unexpected end of input"),
             ParseError::Form(ref err) => err.fmt(f),
@@ -368,7 +368,7 @@ impl FormError {
 //--- Display and Error
 
 impl fmt::Display for FormError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.0)
     }
 }

--- a/src/crypto/common.rs
+++ b/src/crypto/common.rs
@@ -249,7 +249,7 @@ pub enum AlgorithmError {
 //--- Display, Error
 
 impl fmt::Display for AlgorithmError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             AlgorithmError::Unsupported => "unsupported algorithm",
             AlgorithmError::BadSig => "bad signature",

--- a/src/dnssec/sign/keys/keyset.rs
+++ b/src/dnssec/sign/keys/keyset.rs
@@ -922,7 +922,7 @@ pub enum RollType {
 }
 
 impl RollType {
-    fn rollfn(&self) -> fn(RollOp, &mut KeySet) -> Result<(), Error> {
+    fn rollfn(&self) -> fn(RollOp<'_>, &mut KeySet) -> Result<(), Error> {
         match self {
             RollType::KskRoll => ksk_roll,
             RollType::ZskRoll => zsk_roll,
@@ -1007,7 +1007,7 @@ impl fmt::Display for Error {
     }
 }
 
-fn ksk_roll(rollop: RollOp, ks: &mut KeySet) -> Result<(), Error> {
+fn ksk_roll(rollop: RollOp<'_>, ks: &mut KeySet) -> Result<(), Error> {
     match rollop {
         RollOp::Start(old, new) => {
             // First check if the current KSK-roll state is idle. We need to
@@ -1150,7 +1150,7 @@ fn ksk_roll_actions(rollstate: RollState) -> Vec<Action> {
     actions
 }
 
-fn zsk_roll(rollop: RollOp, ks: &mut KeySet) -> Result<(), Error> {
+fn zsk_roll(rollop: RollOp<'_>, ks: &mut KeySet) -> Result<(), Error> {
     match rollop {
         RollOp::Start(old, new) => {
             // First check if the current ZSK-roll state is idle. We need
@@ -1294,7 +1294,7 @@ fn zsk_roll_actions(rollstate: RollState) -> Vec<Action> {
     actions
 }
 
-fn csk_roll(rollop: RollOp, ks: &mut KeySet) -> Result<(), Error> {
+fn csk_roll(rollop: RollOp<'_>, ks: &mut KeySet) -> Result<(), Error> {
     match rollop {
         RollOp::Start(old, new) => {
             // First check if the current CSK-roll state is idle. We need

--- a/src/dnssec/sign/mod.rs
+++ b/src/dnssec/sign/mod.rs
@@ -380,7 +380,7 @@ where
 /// [`Zone`]: crate::zonetree::Zone
 pub fn sign_zone<N, Octs, S, Inner, Sort, T>(
     apex_owner: &N,
-    mut in_out: SignableZoneInOut<N, Octs, S, T, Sort>,
+    mut in_out: SignableZoneInOut<'_, '_, N, Octs, S, T, Sort>,
     signing_config: &SigningConfig<Octs, Sort>,
     signing_keys: &[&SigningKey<Octs, Inner>],
 ) -> Result<(), SigningError>

--- a/src/dnssec/sign/records.rs
+++ b/src/dnssec/sign/records.rs
@@ -185,15 +185,15 @@ where
         }
     }
 
-    pub fn owner_rrs(&self) -> RecordsIter<N, D> {
+    pub fn owner_rrs(&self) -> RecordsIter<'_, N, D> {
         RecordsIter::new(&self.records)
     }
 
-    pub fn rrsets(&self) -> RrsetIter<N, D> {
+    pub fn rrsets(&self) -> RrsetIter<'_, N, D> {
         RrsetIter::new(&self.records)
     }
 
-    pub fn find_soa(&self) -> Option<Rrset<N, D>>
+    pub fn find_soa(&self) -> Option<Rrset<'_, N, D>>
     where
         N: ToName,
         D: RecordData,
@@ -205,7 +205,7 @@ where
         &self,
         name: &N,
         rtype: Rtype,
-    ) -> Option<Rrset<N, D>>
+    ) -> Option<Rrset<'_, N, D>>
     where
         N: CanonicalOrd + ToName,
         D: RecordData,

--- a/src/dnssec/validator/anchor.rs
+++ b/src/dnssec/validator/anchor.rs
@@ -70,7 +70,7 @@ impl TrustAnchor {
     }
 
     /// An iterator over the anchor's records.
-    pub fn iter(&mut self) -> Iter<RrType> {
+    pub fn iter(&mut self) -> Iter<'_, RrType> {
         self.rrs.iter()
     }
 }

--- a/src/dnssec/validator/group.rs
+++ b/src/dnssec/validator/group.rs
@@ -296,7 +296,7 @@ impl Group {
     }
 
     /// Return an iterator over the RRset in a group.
-    pub fn rr_iter(&mut self) -> Iter<RrType> {
+    pub fn rr_iter(&mut self) -> Iter<'_, RrType> {
         self.rr_set.iter()
     }
 
@@ -306,7 +306,7 @@ impl Group {
     }
 
     /// Return an iterator over the signature records in a group.
-    pub fn sig_iter(&mut self) -> Iter<SigType> {
+    pub fn sig_iter(&mut self) -> Iter<'_, SigType> {
         self.sig_set.iter()
     }
 
@@ -840,7 +840,7 @@ impl GroupSet {
     }
 
     /// Return an iterator over the group set.
-    pub fn iter(&mut self) -> Iter<Group> {
+    pub fn iter(&mut self) -> Iter<'_, Group> {
         self.0.iter()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::uninlined_format_args)]
+#![warn(elided_lifetimes_in_paths)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]

--- a/src/net/client/dgram.rs
+++ b/src/net/client/dgram.rs
@@ -444,7 +444,7 @@ impl From<QueryError> for std::io::Error {
 }
 
 impl fmt::Display for QueryError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}: {}", self.kind.error_str(), self.io)
     }
 }
@@ -481,7 +481,7 @@ impl QueryErrorKind {
 }
 
 impl fmt::Display for QueryErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Self::Connect => "connecting failed",
             Self::Send => "sending request failed",

--- a/src/net/client/load_balancer.rs
+++ b/src/net/client/load_balancer.rs
@@ -390,7 +390,7 @@ impl GetResponse for Request {
 }
 
 impl Debug for Request {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Request")
             .field("fut", &format_args!("_"))
             .finish()

--- a/src/net/client/redundant.rs
+++ b/src/net/client/redundant.rs
@@ -216,7 +216,7 @@ impl GetResponse for Request {
 }
 
 impl Debug for Request {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Request")
             .field("fut", &format_args!("_"))
             .finish()

--- a/src/net/client/stream.rs
+++ b/src/net/client/stream.rs
@@ -334,7 +334,7 @@ impl GetResponse for Request {
 }
 
 impl Debug for Request {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Request")
             .field("fut", &format_args!("_"))
             .finish()
@@ -391,7 +391,7 @@ impl GetResponseMulti for RequestMulti {
 }
 
 impl Debug for RequestMulti {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Request")
             .field("fut", &format_args!("_"))
             .finish()

--- a/src/net/server/middleware/tsig.rs
+++ b/src/net/server/middleware/tsig.rs
@@ -273,7 +273,7 @@ where
 
     fn mk_signed_truncated_response(
         request: &Request<RequestOctets>,
-        truncation_ctx: TruncationContext<KS::Key, tsig::Key>,
+        truncation_ctx: TruncationContext<'_, KS::Key, tsig::Key>,
     ) -> Result<AdditionalBuilder<StreamTarget<NextSvc::Target>>, ServiceError>
     {
         let builder = mk_builder_for_target();

--- a/src/net/server/sock.rs
+++ b/src/net/server/sock.rs
@@ -36,7 +36,7 @@ pub trait AsyncDgramSock {
     /// Attempts to send data on the socket to a given address.
     fn poll_send_to(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         data: &[u8],
         dest: &SocketAddr,
     ) -> Poll<io::Result<usize>>;
@@ -67,7 +67,7 @@ pub trait AsyncDgramSock {
 impl AsyncDgramSock for UdpSocket {
     fn poll_send_to(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         data: &[u8],
         dest: &SocketAddr,
     ) -> Poll<io::Result<usize>> {
@@ -91,7 +91,7 @@ impl AsyncDgramSock for UdpSocket {
 impl AsyncDgramSock for Arc<UdpSocket> {
     fn poll_send_to(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         data: &[u8],
         dest: &SocketAddr,
     ) -> Poll<io::Result<usize>> {
@@ -137,7 +137,7 @@ pub trait AsyncAccept {
     /// If there is no connection to accept, Poll::Pending is returned.
     fn poll_accept(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
     ) -> Poll<io::Result<(Self::Future, SocketAddr)>>;
 }
 
@@ -148,7 +148,7 @@ impl AsyncAccept for TcpListener {
 
     fn poll_accept(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
     ) -> Poll<io::Result<(Self::Future, SocketAddr)>> {
         TcpListener::poll_accept(self, cx).map(|res| {
             // TODO: Should we support some sort of callback here to set

--- a/src/net/server/tests/integration.rs
+++ b/src/net/server/tests/integration.rs
@@ -218,7 +218,7 @@ async fn server_tests(#[files("test-data/server/*.rpl")] rpl_file: PathBuf) {
 #[allow(clippy::type_complexity)]
 fn mk_servers<Svc>(
     service: Svc,
-    server_config: &ServerConfig,
+    server_config: &ServerConfig<'_>,
     dgram_server_conn: ClientServerChannel,
     stream_server_conn: ClientServerChannel,
 ) -> (
@@ -375,7 +375,7 @@ fn mk_client_factory(
 }
 
 fn mk_server_configs(
-    config: &ServerConfig,
+    config: &ServerConfig<'_>,
 ) -> (server::dgram::Config, server::stream::Config) {
     let dgram_config = server::dgram::Config::default();
 
@@ -448,7 +448,7 @@ struct CookieConfig<'a> {
     ip_deny_list: Vec<IpAddr>,
 }
 
-fn parse_server_config(config: &Config) -> ServerConfig {
+fn parse_server_config(config: &Config) -> ServerConfig<'_> {
     let mut parsed_config = ServerConfig::default();
     let mut in_server_block = false;
     let mut zone_name = None;

--- a/src/net/server/tests/unit.rs
+++ b/src/net/server/tests/unit.rs
@@ -220,7 +220,7 @@ impl AsyncAccept for MockListener {
     /// Accept mock connections one at a time at a defined rate.
     fn poll_accept(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
     ) -> Poll<Result<(Self::Future, SocketAddr), io::Error>> {
         match self.ready.load(Ordering::Relaxed) {
             true => {

--- a/src/net/server/util.rs
+++ b/src/net/server/util.rs
@@ -234,7 +234,7 @@ pub fn add_edns_options<F, Target>(
 ) -> Result<(), PushError>
 where
     F: FnOnce(
-        &mut OptBuilder<StreamTarget<Target>>,
+        &mut OptBuilder<'_, StreamTarget<Target>>,
     ) -> Result<
         (),
         <StreamTarget<Target> as OctetsBuilder>::AppendError,

--- a/src/net/xfr/protocol/interpreter.rs
+++ b/src/net/xfr/protocol/interpreter.rs
@@ -70,7 +70,7 @@ impl XfrResponseInterpreter {
     pub fn interpret_response(
         &mut self,
         resp: Message<Bytes>,
-    ) -> Result<XfrZoneUpdateIterator, Error> {
+    ) -> Result<XfrZoneUpdateIterator<'_, '_>, Error> {
         if self.is_finished() {
             return Err(Error::Finished);
         }

--- a/src/rdata/aaaa.rs
+++ b/src/rdata/aaaa.rs
@@ -54,7 +54,7 @@ impl Aaaa {
     }
 
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>,
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         Ipv6Addr::parse(parser).map(Self::new)
     }
@@ -152,7 +152,7 @@ impl ComposeRecordData for Aaaa {
 //--- Display
 
 impl fmt::Display for Aaaa {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.addr.fmt(f)
     }
 }

--- a/src/rdata/cds.rs
+++ b/src/rdata/cds.rs
@@ -63,7 +63,9 @@ impl<Octs> Cdnskey<Octs> {
     {
         LongRecordData::check_len(
             usize::from(
-                u16::COMPOSE_LEN + u8::COMPOSE_LEN + SecurityAlgorithm::COMPOSE_LEN,
+                u16::COMPOSE_LEN
+                    + u8::COMPOSE_LEN
+                    + SecurityAlgorithm::COMPOSE_LEN,
             )
             .checked_add(public_key.as_ref().len())
             .expect("long key"),
@@ -281,7 +283,9 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Cdnskey<Octs> {
             u16::try_from(self.public_key.as_ref().len())
                 .expect("long key")
                 .checked_add(
-                    u16::COMPOSE_LEN + u8::COMPOSE_LEN + SecurityAlgorithm::COMPOSE_LEN,
+                    u16::COMPOSE_LEN
+                        + u8::COMPOSE_LEN
+                        + SecurityAlgorithm::COMPOSE_LEN,
                 )
                 .expect("long key"),
         )
@@ -308,7 +312,7 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Cdnskey<Octs> {
 //--- Display
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Cdnskey<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {} {} ", self.flags, self.protocol, self.algorithm)?;
         base64::display(&self.public_key, f)
     }
@@ -317,7 +321,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Cdnskey<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Cdnskey<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Cdnskey")
             .field("flags", &self.flags)
             .field("protocol", &self.protocol)
@@ -650,7 +654,7 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Cds<Octs> {
 //--- Display
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Cds<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} ",
@@ -666,7 +670,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Cds<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Cds<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Cds")
             .field("key_tag", &self.key_tag)
             .field("algorithm", &self.algorithm)
@@ -711,7 +715,8 @@ mod test {
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn cdnskey_compose_parse_scan() {
-        let rdata = Cdnskey::new(10, 11, SecurityAlgorithm::RSASHA1, b"key").unwrap();
+        let rdata =
+            Cdnskey::new(10, 11, SecurityAlgorithm::RSASHA1, b"key").unwrap();
         test_rdlen(&rdata);
         test_compose_parse(&rdata, |parser| Cdnskey::parse(parser));
         test_scan(&["10", "11", "5", "a2V5"], Cdnskey::scan, &rdata);
@@ -722,8 +727,13 @@ mod test {
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn cds_compose_parse_scan() {
-        let rdata =
-            Cds::new(10, SecurityAlgorithm::RSASHA1, DigestAlgorithm::SHA256, b"key").unwrap();
+        let rdata = Cds::new(
+            10,
+            SecurityAlgorithm::RSASHA1,
+            DigestAlgorithm::SHA256,
+            b"key",
+        )
+        .unwrap();
         test_rdlen(&rdata);
         test_compose_parse(&rdata, |parser| Cds::parse(parser));
         test_scan(&["10", "5", "2", "6b6579"], Cds::scan, &rdata);

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -75,7 +75,9 @@ impl<Octs> Dnskey<Octs> {
     {
         LongRecordData::check_len(
             usize::from(
-                u16::COMPOSE_LEN + u8::COMPOSE_LEN + SecurityAlgorithm::COMPOSE_LEN,
+                u16::COMPOSE_LEN
+                    + u8::COMPOSE_LEN
+                    + SecurityAlgorithm::COMPOSE_LEN,
             )
             .checked_add(public_key.as_ref().len())
             .expect("long key"),
@@ -386,7 +388,9 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Dnskey<Octs> {
             u16::try_from(self.public_key.as_ref().len())
                 .expect("long key")
                 .checked_add(
-                    u16::COMPOSE_LEN + u8::COMPOSE_LEN + SecurityAlgorithm::COMPOSE_LEN,
+                    u16::COMPOSE_LEN
+                        + u8::COMPOSE_LEN
+                        + SecurityAlgorithm::COMPOSE_LEN,
                 )
                 .expect("long key"),
         )
@@ -413,7 +417,7 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Dnskey<Octs> {
 //--- Display
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Dnskey<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {} {} ", self.flags, self.protocol, self.algorithm)?;
         base64::display(&self.public_key, f)
     }
@@ -422,7 +426,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Dnskey<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Dnskey<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Dnskey")
             .field("flags", &self.flags)
             .field("protocol", &self.protocol)
@@ -708,7 +712,7 @@ impl Timestamp {
     pub const COMPOSE_LEN: u16 = Serial::COMPOSE_LEN;
 
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>,
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         Serial::parse(parser).map(Self)
     }
@@ -778,7 +782,7 @@ impl str::FromStr for Timestamp {
 //--- Display
 
 impl fmt::Display for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -1349,7 +1353,7 @@ where
     Octs: AsRef<[u8]>,
     Name: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} {} {} {} {} {}. ",
@@ -1373,7 +1377,7 @@ where
     Octs: AsRef<[u8]>,
     Name: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Rrsig")
             .field("type_covered", &self.type_covered)
             .field("algorithm", &self.algorithm)
@@ -1676,7 +1680,7 @@ where
     Octs: AsRef<[u8]>,
     Name: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}. {}", self.next_name, self.types)
     }
 }
@@ -1688,7 +1692,7 @@ where
     Octs: AsRef<[u8]>,
     Name: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Nsec")
             .field("next_name", &self.next_name)
             .field("types", &self.types)
@@ -2018,7 +2022,7 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Ds<Octs> {
 //--- Display
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Ds<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} ",
@@ -2034,7 +2038,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Ds<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Ds<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Ds")
             .field("key_tag", &self.key_tag)
             .field("algorithm", &self.algorithm)
@@ -2132,7 +2136,7 @@ impl<Octs: AsRef<[u8]>> RtypeBitmap<Octs> {
         self.0.as_ref()
     }
 
-    pub fn iter(&self) -> RtypeBitmapIter {
+    pub fn iter(&self) -> RtypeBitmapIter<'_> {
         RtypeBitmapIter::new(self.0.as_ref())
     }
 
@@ -2262,7 +2266,7 @@ impl<'a, Octs: AsRef<[u8]>> IntoIterator for &'a RtypeBitmap<Octs> {
 //--- Display
 
 impl<Octs: AsRef<[u8]>> fmt::Display for RtypeBitmap<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut iter = self.iter();
         if let Some(rtype) = iter.next() {
             fmt::Display::fmt(&rtype, f)?;
@@ -2288,7 +2292,7 @@ impl<Octs: AsRef<[u8]>> ZonefileFmt for RtypeBitmap<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for RtypeBitmap<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("RtypeBitmap(")?;
         fmt::Display::fmt(self, f)?;
         f.write_str(")")
@@ -2362,7 +2366,7 @@ where
         {
             type Value = RtypeBitmap<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a record type bitmap")
             }
 
@@ -2415,7 +2419,7 @@ where
         {
             type Value = RtypeBitmap<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a record type bitmap")
             }
 
@@ -2637,8 +2641,9 @@ impl Iterator for RtypeBitmapIter<'_> {
         if self.data.is_empty() {
             return None;
         }
-        let res =
-            Rtype::from_int(self.block | ((self.octet as u16) << 3) | self.bit);
+        let res = Rtype::from_int(
+            self.block | ((self.octet as u16) << 3) | self.bit,
+        );
         self.advance();
         Some(res)
     }
@@ -2679,7 +2684,7 @@ impl From<RtypeBitmapErrorEnum> for RtypeBitmapError {
 //--- Display and Error
 
 impl fmt::Display for RtypeBitmapError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             RtypeBitmapErrorEnum::ShortInput => ParseError::ShortInput.fmt(f),
             RtypeBitmapErrorEnum::BadRtypeBitmap => {
@@ -2725,7 +2730,7 @@ fn read_window(data: &[u8]) -> Option<((u8, &[u8]), &[u8])> {
 pub struct IllegalSignatureTime(());
 
 impl fmt::Display for IllegalSignatureTime {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("illegal signature time")
     }
 }
@@ -2752,7 +2757,8 @@ mod test {
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn dnskey_compose_parse_scan() {
-        let rdata = Dnskey::new(10, 11, SecurityAlgorithm::RSASHA1, b"key0").unwrap();
+        let rdata =
+            Dnskey::new(10, 11, SecurityAlgorithm::RSASHA1, b"key0").unwrap();
         test_rdlen(&rdata);
         test_compose_parse(&rdata, |parser| Dnskey::parse(parser));
         test_scan(&["10", "11", "5", "a2V5MA=="], Dnskey::scan, &rdata);
@@ -2823,8 +2829,13 @@ mod test {
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
     fn ds_compose_parse_scan() {
-        let rdata =
-            Ds::new(10, SecurityAlgorithm::RSASHA1, DigestAlgorithm::SHA256, b"key").unwrap();
+        let rdata = Ds::new(
+            10,
+            SecurityAlgorithm::RSASHA1,
+            DigestAlgorithm::SHA256,
+            b"key",
+        )
+        .unwrap();
         test_rdlen(&rdata);
         test_compose_parse(&rdata, |parser| Ds::parse(parser));
         test_scan(&["10", "5", "2", "6b6579"], Ds::scan, &rdata);
@@ -2969,9 +2980,13 @@ mod test {
 
     #[test]
     fn dnskey_flags() {
-        let dnskey =
-            Dnskey::new(257, 3, SecurityAlgorithm::RSASHA256, bytes::Bytes::new())
-                .unwrap();
+        let dnskey = Dnskey::new(
+            257,
+            3,
+            SecurityAlgorithm::RSASHA256,
+            bytes::Bytes::new(),
+        )
+        .unwrap();
         assert!(dnskey.is_zone_key());
         assert!(dnskey.is_secure_entry_point());
         assert!(!dnskey.is_revoked());

--- a/src/rdata/macros.rs
+++ b/src/rdata/macros.rs
@@ -456,7 +456,7 @@ macro_rules! rdata_types {
             O: AsRef<[u8]>,
             N: fmt::Display
         {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match *self {
                     $( $( $(
                         ZoneRecordData::$mtype(ref inner) => {
@@ -475,7 +475,7 @@ macro_rules! rdata_types {
             O: AsRef<[u8]>,
             N: fmt::Debug
         {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match *self {
                     $( $( $(
                         ZoneRecordData::$mtype(ref inner) => {
@@ -1070,7 +1070,7 @@ macro_rules! rdata_types {
         impl<O, N> fmt::Display for AllRecordData<O, N>
         where O: Octets, N: fmt::Display {
             fn fmt(
-                &self, f: &mut fmt::Formatter
+                &self, f: &mut fmt::Formatter<'_>
             ) -> fmt::Result {
                 match *self {
                     $( $( $(
@@ -1092,7 +1092,7 @@ macro_rules! rdata_types {
         impl<O, N> fmt::Debug for AllRecordData<O, N>
         where O: Octets, N: fmt::Debug {
             fn fmt(
-                &self, f: &mut fmt::Formatter
+                &self, f: &mut fmt::Formatter<'_>
             ) -> fmt::Result {
                 match *self {
                     $( $( $(
@@ -1340,7 +1340,7 @@ macro_rules! name_type_base {
         //--- Display
 
         impl<N: fmt::Display> fmt::Display for $target<N> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "{}.", self.$field)
             }
         }

--- a/src/rdata/naptr.rs
+++ b/src/rdata/naptr.rs
@@ -448,7 +448,7 @@ where
     Octs: AsRef<[u8]>,
     Name: fmt::Display,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{} {} {} {} {} {}.",
@@ -469,7 +469,7 @@ where
     Octs: AsRef<[u8]>,
     Name: fmt::Debug,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Naptr")
             .field("order", &self.order)
             .field("preference", &self.preference)

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -355,7 +355,7 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Nsec3<Octs> {
 //--- Display, and Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Nsec3<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} {} ",
@@ -370,7 +370,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Nsec3<Octs> {
 }
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Nsec3<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Nsec3")
             .field("hash_algorithm", &self.hash_algorithm)
             .field("flags", &self.flags)
@@ -460,9 +460,9 @@ pub struct Nsec3param<Octs> {
     ///    but at a higher computational cost for both the server and
     ///    resolver.  See Section 5 for details of the use of this field, and
     ///    Section 10.3 for limitations on the value."
-    /// 
+    ///
     /// https://www.rfc-editor.org/rfc/rfc9276.html#section-3.1
-    /// 3.1. Best Practice for Zone Publishers 
+    /// 3.1. Best Practice for Zone Publishers
     ///   "If NSEC3 must be used, then an iterations count of 0 MUST be used
     ///    to alleviate computational burdens."
     iterations: u16,
@@ -472,9 +472,9 @@ pub struct Nsec3param<Octs> {
     ///   "The Salt field is appended to the original owner name before
     ///    hashing in order to defend against pre-calculated dictionary
     ///    attacks."
-    /// 
+    ///
     /// https://www.rfc-editor.org/rfc/rfc9276.html#section-3.1
-    /// 3.1. Best Practice for Zone Publishers 
+    /// 3.1. Best Practice for Zone Publishers
     ///   "Operators SHOULD NOT use a salt by indicating a zero-length salt
     ///   value instead (represented as a "-" in the presentation format)."
     salt: Nsec3Salt<Octs>,
@@ -514,7 +514,7 @@ impl<Octs> Nsec3param<Octs> {
 
     pub fn opt_out_flag(&self) -> bool {
         self.flags & NSEC3_OPT_OUT_FLAG_MASK == NSEC3_OPT_OUT_FLAG_MASK
-    }    
+    }
 
     pub fn iterations(&self) -> u16 {
         self.iterations
@@ -770,7 +770,7 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Nsec3param<Octs> {
 //--- Display and Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Nsec3param<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} {}",
@@ -780,7 +780,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Nsec3param<Octs> {
 }
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Nsec3param<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Nsec3param")
             .field("hash_algorithm", &self.hash_algorithm)
             .field("flags", &self.flags)
@@ -1106,7 +1106,7 @@ impl<T: AsRef<[u8]> + ?Sized> hash::Hash for Nsec3Salt<T> {
 //--- Display and Debug
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Nsec3Salt<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = self.as_slice();
         if s.is_empty() {
             // https://www.rfc-editor.org/rfc/rfc5155.html#section-3.3
@@ -1120,7 +1120,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for Nsec3Salt<Octs> {
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for Nsec3Salt<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Nsec3Salt")
             .field(&format_args!("{}", self))
             .finish()
@@ -1188,7 +1188,7 @@ where
         {
             type Value = Nsec3Salt<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an NSEC3 salt value")
             }
 
@@ -1228,7 +1228,7 @@ where
         {
             type Value = Nsec3Salt<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an NSEC3 salt value")
             }
 
@@ -1508,13 +1508,13 @@ impl<T: AsRef<[u8]> + ?Sized> hash::Hash for OwnerHash<T> {
 //--- Display
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Display for OwnerHash<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         base32::display_hex(self.as_slice(), f)
     }
 }
 
 impl<Octs: AsRef<[u8]> + ?Sized> fmt::Debug for OwnerHash<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("OwnerHash")
             .field(&format_args!("{}", self))
             .finish()
@@ -1564,7 +1564,7 @@ where
         {
             type Value = OwnerHash<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an owner name hash value")
             }
 
@@ -1604,7 +1604,7 @@ where
         {
             type Value = OwnerHash<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an owner name hash value")
             }
 
@@ -1642,7 +1642,7 @@ where
 pub struct Nsec3SaltError(());
 
 impl fmt::Display for Nsec3SaltError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("illegal NSEC3 salt")
     }
 }
@@ -1659,7 +1659,7 @@ impl std::error::Error for Nsec3SaltError {}
 pub struct OwnerHashError(());
 
 impl fmt::Display for OwnerHashError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("illegal owner name hash")
     }
 }

--- a/src/rdata/rfc1035/a.rs
+++ b/src/rdata/rfc1035/a.rs
@@ -68,7 +68,7 @@ impl A {
     }
 
     pub fn parse<Octs: AsRef<[u8]> + ?Sized>(
-        parser: &mut Parser<Octs>,
+        parser: &mut Parser<'_, Octs>,
     ) -> Result<Self, ParseError> {
         Ipv4Addr::parse(parser).map(Self::new)
     }
@@ -166,7 +166,7 @@ impl ComposeRecordData for A {
 //--- Display
 
 impl fmt::Display for A {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.addr.fmt(f)
     }
 }

--- a/src/rdata/rfc1035/hinfo.rs
+++ b/src/rdata/rfc1035/hinfo.rs
@@ -219,7 +219,7 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Hinfo<Octs> {
 //--- Display
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Hinfo<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {}",
@@ -232,7 +232,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Hinfo<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Hinfo<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Hinfo")
             .field("cpu", &self.cpu)
             .field("os", &self.os)

--- a/src/rdata/rfc1035/minfo.rs
+++ b/src/rdata/rfc1035/minfo.rs
@@ -8,9 +8,7 @@ use crate::base::name::{FlattenInto, ParsedName, ToName};
 use crate::base::rdata::{ComposeRecordData, ParseRecordData, RecordData};
 use crate::base::scan::Scanner;
 use crate::base::wire::{Composer, ParseError};
-use crate::base::zonefile_fmt::{
-    self, Formatter, ZonefileFmt,
-};
+use crate::base::zonefile_fmt::{self, Formatter, ZonefileFmt};
 use core::cmp::Ordering;
 use core::fmt;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
@@ -240,7 +238,7 @@ impl<Name: ToName> ComposeRecordData for Minfo<Name> {
 //--- Display
 
 impl<N: fmt::Display> fmt::Display for Minfo<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}. {}.", self.rmailbx, self.emailbx)
     }
 }

--- a/src/rdata/rfc1035/mx.rs
+++ b/src/rdata/rfc1035/mx.rs
@@ -5,14 +5,12 @@
 use crate::base::cmp::CanonicalOrd;
 use crate::base::iana::Rtype;
 use crate::base::name::{FlattenInto, ParsedName, ToName};
-use crate::base::rdata::{
-    ComposeRecordData, ParseRecordData, RecordData,
-};
+use crate::base::rdata::{ComposeRecordData, ParseRecordData, RecordData};
 use crate::base::scan::{Scan, Scanner};
-use crate::base::zonefile_fmt::{self, Formatter, ZonefileFmt};
 use crate::base::wire::{Compose, Composer, Parse, ParseError};
-use core::fmt;
+use crate::base::zonefile_fmt::{self, Formatter, ZonefileFmt};
 use core::cmp::Ordering;
+use core::fmt;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
 use octseq::parse::Parser;
 
@@ -24,7 +22,7 @@ use octseq::parse::Parser;
 /// the owner name.
 ///
 /// The Mx record type is defined in [RFC 1035, section 3.3.9][1].
-/// 
+///
 /// [1]: https://tools.ietf.org/html/rfc1035#section-3.3.9
 #[derive(Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -69,7 +67,9 @@ impl<N> Mx<N> {
     pub(in crate::rdata) fn flatten<TargetName>(
         self,
     ) -> Result<Mx<TargetName>, N::AppendError>
-    where N: FlattenInto<TargetName> {
+    where
+        N: FlattenInto<TargetName>,
+    {
         Ok(Mx::new(self.preference, self.exchange.try_flatten_into()?))
     }
 
@@ -223,7 +223,7 @@ impl<Name: ToName> ComposeRecordData for Mx<Name> {
 //--- Display
 
 impl<N: fmt::Display> fmt::Display for Mx<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}.", self.preference, self.exchange)
     }
 }
@@ -265,4 +265,3 @@ mod test {
         test_scan(&["12", "mail.example.com"], Mx::scan, &rdata);
     }
 }
-

--- a/src/rdata/rfc1035/null.rs
+++ b/src/rdata/rfc1035/null.rs
@@ -12,9 +12,7 @@ use crate::base::rdata::{
     ComposeRecordData, LongRecordData, ParseRecordData, RecordData,
 };
 use crate::base::wire::{Composer, ParseError};
-use crate::base::zonefile_fmt::{
-    self, Formatter, ZonefileFmt,
-};
+use crate::base::zonefile_fmt::{self, Formatter, ZonefileFmt};
 use core::cmp::Ordering;
 use core::{fmt, hash, mem};
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
@@ -267,7 +265,7 @@ impl<Octs: AsRef<Other>, Other> AsRef<Other> for Null<Octs> {
 //--- Display and Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Null<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\\# {}", self.data.as_ref().len())?;
         for ch in self.data.as_ref().iter() {
             write!(f, " {:02x}", ch)?;
@@ -277,7 +275,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Null<Octs> {
 }
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Null<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Null(")?;
         fmt::Display::fmt(self, f)?;
         f.write_str(")")

--- a/src/rdata/rfc1035/soa.rs
+++ b/src/rdata/rfc1035/soa.rs
@@ -10,9 +10,7 @@ use crate::base::record::Ttl;
 use crate::base::scan::{Scan, Scanner};
 use crate::base::serial::Serial;
 use crate::base::wire::{Compose, Composer, ParseError};
-use crate::base::zonefile_fmt::{
-    self, Formatter, ZonefileFmt,
-};
+use crate::base::zonefile_fmt::{self, Formatter, ZonefileFmt};
 use core::cmp::Ordering;
 use core::fmt;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
@@ -389,7 +387,7 @@ impl<Name: ToName> Soa<Name> {
 //--- Display
 
 impl<N: fmt::Display> fmt::Display for Soa<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}. {}. {} {} {} {} {}",

--- a/src/rdata/rfc1035/txt.rs
+++ b/src/rdata/rfc1035/txt.rs
@@ -205,14 +205,14 @@ impl<Octs: AsRef<[u8]> + ?Sized> Txt<Octs> {
     /// Returns an iterator over the character strings as slices.
     ///
     /// The returned iterator will always return at least one octets slice.
-    pub fn iter(&self) -> TxtIter {
+    pub fn iter(&self) -> TxtIter<'_> {
         TxtIter(self.iter_charstrs())
     }
 
     /// Returns an iterator over the character strings.
     ///
     /// The returned iterator will always return at least one octets slice.
-    pub fn iter_charstrs(&self) -> TxtCharStrIter {
+    pub fn iter_charstrs(&self) -> TxtCharStrIter<'_> {
         TxtCharStrIter(Parser::from_ref(self.0.as_ref()))
     }
 
@@ -421,13 +421,12 @@ impl<Octs: AsRef<[u8]>> ComposeRecordData for Txt<Octs> {
 //--- Display
 
 impl<Octs: AsRef<[u8]>> fmt::Display for Txt<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut first = true;
         for slice in self.iter_charstrs() {
             if !first {
                 f.write_str(" ")?;
-            }
-            else {
+            } else {
                 first = false;
             }
             write!(f, "{}", slice.display_quoted())?;
@@ -439,7 +438,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Txt<Octs> {
 //--- Debug
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Txt<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Txt(")?;
         fmt::Display::fmt(self, f)?;
         f.write_str(")")
@@ -495,8 +494,7 @@ where
 
         if serializer.is_human_readable() {
             serializer.serialize_newtype_struct("Txt", &TxtSeq(self))
-        }
-        else {
+        } else {
             serializer.serialize_newtype_struct(
                 "Txt",
                 &self.0.as_serialized_octets(),
@@ -526,7 +524,7 @@ where
         {
             type Value = Txt<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("TXT record data")
             }
 
@@ -555,7 +553,7 @@ where
         {
             type Value = Txt<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("TXT record data")
             }
 
@@ -583,17 +581,19 @@ where
                 mut seq: A,
             ) -> Result<Self::Value, A::Error> {
                 let mut builder = <Octs as FromBuilder>::Builder::empty();
-                while seq.next_element_seed(
-                    DeserializeCharStrSeed::new(&mut builder)
-                )?.is_some() {
-                    LongRecordData::check_len(
-                        builder.as_ref().len()
-                    ).map_err(serde::de::Error::custom)?;
+                while seq
+                    .next_element_seed(DeserializeCharStrSeed::new(
+                        &mut builder,
+                    ))?
+                    .is_some()
+                {
+                    LongRecordData::check_len(builder.as_ref().len())
+                        .map_err(serde::de::Error::custom)?;
                 }
                 if builder.as_ref().is_empty() {
-                    builder.append_slice(b"\0").map_err(|_| {
-                        serde::de::Error::custom(ShortBuf)
-                    })?;
+                    builder
+                        .append_slice(b"\0")
+                        .map_err(|_| serde::de::Error::custom(ShortBuf))?;
                 }
                 Ok(Txt(builder.freeze()))
             }
@@ -609,7 +609,7 @@ where
         {
             type Value = Txt<Octs>;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("TXT record data")
             }
 
@@ -633,9 +633,8 @@ where
             }
         }
 
-        deserializer.deserialize_newtype_struct(
-            "Txt", NewtypeVisitor(PhantomData)
-        )
+        deserializer
+            .deserialize_newtype_struct("Txt", NewtypeVisitor(PhantomData))
     }
 }
 
@@ -713,10 +712,12 @@ impl<Builder: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>> TxtBuilder<Builder> {
     /// Errors out if either appending the slice would result in exceeding the
     /// record data length limit or the underlying builder runs out of space.
     fn builder_append_slice(
-        &mut self, slice: &[u8]
+        &mut self,
+        slice: &[u8],
     ) -> Result<(), TxtAppendError> {
         LongRecordData::check_append_len(
-            self.builder.as_ref().len(), slice.len()
+            self.builder.as_ref().len(),
+            slice.len(),
         )?;
         self.builder.append_slice(slice)?;
         Ok(())
@@ -739,7 +740,8 @@ impl<Builder: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>> TxtBuilder<Builder> {
     /// data already. I.e., you should consider the builder corrupt if the
     /// method returns an error.
     pub fn append_slice(
-        &mut self, mut slice: &[u8]
+        &mut self,
+        mut slice: &[u8],
     ) -> Result<(), TxtAppendError> {
         if let Some(start) = self.start {
             let left = 255 - (self.builder.as_ref().len() - (start + 1));
@@ -785,12 +787,13 @@ impl<Builder: OctetsBuilder + AsRef<[u8]> + AsMut<[u8]>> TxtBuilder<Builder> {
     /// data already. I.e., you should consider the builder corrupt if the
     /// method returns an error.
     pub fn append_charstr<Octs: AsRef<[u8]> + ?Sized>(
-        &mut self, s: &CharStr<Octs>
+        &mut self,
+        s: &CharStr<Octs>,
     ) -> Result<(), TxtAppendError> {
         self.close_charstr();
         LongRecordData::check_append_len(
             self.builder.as_ref().len(),
-            usize::from(s.compose_len())
+            usize::from(s.compose_len()),
         )?;
         s.compose(&mut self.builder)?;
         Ok(())
@@ -870,7 +873,7 @@ impl From<TxtError> for FormError {
 }
 
 impl fmt::Display for TxtError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -884,7 +887,7 @@ pub enum TxtAppendError {
     LongRecordData,
 
     /// The octets builder did not have enough space.
-    ShortBuf
+    ShortBuf,
 }
 
 impl TxtAppendError {
@@ -893,7 +896,7 @@ impl TxtAppendError {
     pub fn as_str(self) -> &'static str {
         match self {
             TxtAppendError::LongRecordData => "record data too long",
-            TxtAppendError::ShortBuf => "buffer size exceeded"
+            TxtAppendError::ShortBuf => "buffer size exceeded",
         }
     }
 }
@@ -911,7 +914,7 @@ impl<T: Into<ShortBuf>> From<T> for TxtAppendError {
 }
 
 impl fmt::Display for TxtAppendError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -926,8 +929,6 @@ mod test {
         test_compose_parse, test_rdlen, test_scan,
     };
     use std::vec::Vec;
-
-
 
     #[test]
     #[allow(clippy::redundant_closure)] // lifetimes ...
@@ -1080,9 +1081,8 @@ mod test {
             ],
         );
 
-        let txt = Txt::from_octets(
-            Vec::from(b"\x03foo\x04\\bar".as_ref())
-        ).unwrap();
+        let txt = Txt::from_octets(Vec::from(b"\x03foo\x04\\bar".as_ref()))
+            .unwrap();
         assert_tokens(
             &txt.clone().compact(),
             &[
@@ -1136,4 +1136,3 @@ mod test {
         // to CharStr::display_quoted which is tested ...
     }
 }
-

--- a/src/rdata/srv.rs
+++ b/src/rdata/srv.rs
@@ -9,8 +9,8 @@ use crate::base::iana::Rtype;
 use crate::base::name::{FlattenInto, ParsedName, ToName};
 use crate::base::rdata::{ComposeRecordData, ParseRecordData, RecordData};
 use crate::base::scan::{Scan, Scanner};
-use crate::base::zonefile_fmt::{self, Formatter, ZonefileFmt};
 use crate::base::wire::{Compose, Composer, Parse, ParseError};
+use crate::base::zonefile_fmt::{self, Formatter, ZonefileFmt};
 use core::cmp::Ordering;
 use core::fmt;
 use octseq::octets::{Octets, OctetsFrom, OctetsInto};
@@ -33,7 +33,6 @@ impl Srv<()> {
 }
 
 impl<N> Srv<N> {
-
     pub fn new(priority: u16, weight: u16, port: u16, target: N) -> Self {
         Srv {
             priority,
@@ -77,7 +76,9 @@ impl<N> Srv<N> {
     pub(super) fn flatten<TargetName>(
         self,
     ) -> Result<Srv<TargetName>, N::AppendError>
-    where N: FlattenInto<TargetName> {
+    where
+        N: FlattenInto<TargetName>,
+    {
         Ok(Srv::new(
             self.priority,
             self.weight,
@@ -274,7 +275,7 @@ impl<Name: ToName> Srv<Name> {
 //--- Display
 
 impl<N: fmt::Display> fmt::Display for Srv<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} {}",

--- a/src/rdata/svcb/rdata.rs
+++ b/src/rdata/svcb/rdata.rs
@@ -61,18 +61,16 @@ use octseq::parse::Parser;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "serde",
-    serde(
-        bound(
-            serialize = "
+    serde(bound(
+        serialize = "
                 Name: serde::Serialize,
                 Octs: octseq::serde::SerializeOctets
             ",
-            deserialize = "
+        deserialize = "
                 Name: serde::Deserialize<'de>,
                 Octs: octseq::serde::DeserializeOctets<'de>
             ",
-        )
-    )
+    ))
 )]
 pub struct SvcbRdata<Variant, Octs, Name> {
     /// The priority field of the service binding record.
@@ -133,15 +131,20 @@ impl<Variant, Octs, Name> SvcbRdata<Variant, Octs, Name> {
     /// Returns an error if the wire format of the record data would exceed
     /// the length of 65,535 octets.
     pub fn new(
-        priority: u16, target: Name, params: SvcParams<Octs>
+        priority: u16,
+        target: Name,
+        params: SvcParams<Octs>,
     ) -> Result<Self, LongRecordData>
-    where Octs: AsRef<[u8]>, Name: ToName {
+    where
+        Octs: AsRef<[u8]>,
+        Name: ToName,
+    {
         LongRecordData::check_len(
-            usize::from(
-                u16::COMPOSE_LEN + target.compose_len()
-            ).checked_add(params.len()).expect("long params")
+            usize::from(u16::COMPOSE_LEN + target.compose_len())
+                .checked_add(params.len())
+                .expect("long params"),
         )?;
-        Ok( unsafe { Self::new_unchecked(priority, target, params) })
+        Ok(unsafe { Self::new_unchecked(priority, target, params) })
     }
 
     /// Creates a new value from its components without checking.
@@ -151,9 +154,16 @@ impl<Variant, Octs, Name> SvcbRdata<Variant, Octs, Name> {
     /// The called must ensure that the wire format of the record data does
     /// not exceed a length of 65,535 octets.
     pub unsafe fn new_unchecked(
-        priority: u16, target: Name, params: SvcParams<Octs>
+        priority: u16,
+        target: Name,
+        params: SvcParams<Octs>,
     ) -> Self {
-        SvcbRdata { priority, target, params, marker: PhantomData }
+        SvcbRdata {
+            priority,
+            target,
+            params,
+            marker: PhantomData,
+        }
     }
 }
 
@@ -204,7 +214,7 @@ impl<Variant, Octs, Name> SvcbRdata<Variant, Octs, Name> {
 
     /// Returns an identical value using different octets sequence types.
     pub(crate) fn convert_octets<TOcts, TName>(
-        self
+        self,
     ) -> Result<SvcbRdata<Variant, TOcts, TName>, TOcts::Error>
     where
         TOcts: OctetsFrom<Octs>,
@@ -274,7 +284,7 @@ where
 
 impl<Variant, OtherVariant, Octs, OtherOcts, Name, OtherName>
     PartialEq<SvcbRdata<OtherVariant, OtherOcts, OtherName>>
-for SvcbRdata<Variant, Octs, Name>
+    for SvcbRdata<Variant, Octs, Name>
 where
     Octs: AsRef<[u8]>,
     OtherOcts: AsRef<[u8]>,
@@ -282,7 +292,8 @@ where
     OtherName: ToName,
 {
     fn eq(
-        &self, other: &SvcbRdata<OtherVariant, OtherOcts, OtherName>
+        &self,
+        other: &SvcbRdata<OtherVariant, OtherOcts, OtherName>,
     ) -> bool {
         self.priority == other.priority
             && self.target.name_eq(&other.target)
@@ -291,12 +302,15 @@ where
 }
 
 impl<Variant, Octs: AsRef<[u8]>, Name: ToName> Eq
-for SvcbRdata<Variant, Octs, Name> { }
+    for SvcbRdata<Variant, Octs, Name>
+{
+}
 
 //--- Hash
 
 impl<Variant, Octs: AsRef<[u8]>, Name: hash::Hash> hash::Hash
-for SvcbRdata<Variant, Octs, Name> {
+    for SvcbRdata<Variant, Octs, Name>
+{
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.priority.hash(state);
         self.target.hash(state);
@@ -308,7 +322,7 @@ for SvcbRdata<Variant, Octs, Name> {
 
 impl<Variant, OtherVariant, Octs, OtherOcts, Name, OtherName>
     PartialOrd<SvcbRdata<OtherVariant, OtherOcts, OtherName>>
-for SvcbRdata<Variant, Octs, Name>
+    for SvcbRdata<Variant, Octs, Name>
 where
     Octs: AsRef<[u8]>,
     OtherOcts: AsRef<[u8]>,
@@ -316,30 +330,32 @@ where
     OtherName: ToName,
 {
     fn partial_cmp(
-        &self, other: &SvcbRdata<OtherVariant, OtherOcts, OtherName>
+        &self,
+        other: &SvcbRdata<OtherVariant, OtherOcts, OtherName>,
     ) -> Option<cmp::Ordering> {
         match self.priority.partial_cmp(&other.priority) {
-            Some(cmp::Ordering::Equal) => { }
-            other => return other
+            Some(cmp::Ordering::Equal) => {}
+            other => return other,
         }
         match self.target.name_cmp(&other.target) {
-            cmp::Ordering::Equal => { }
-            other => return Some(other)
+            cmp::Ordering::Equal => {}
+            other => return Some(other),
         }
         self.params.partial_cmp(&other.params)
     }
 }
 
 impl<Variant, Octs: AsRef<[u8]>, Name: ToName> Ord
-for SvcbRdata<Variant, Octs, Name> {
+    for SvcbRdata<Variant, Octs, Name>
+{
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         match self.priority.cmp(&other.priority) {
-            cmp::Ordering::Equal => { }
-            other => return other
+            cmp::Ordering::Equal => {}
+            other => return other,
         }
         match self.target.name_cmp(&other.target) {
-            cmp::Ordering::Equal => { }
-            other => return other
+            cmp::Ordering::Equal => {}
+            other => return other,
         }
         self.params.cmp(&other.params)
     }
@@ -347,7 +363,7 @@ for SvcbRdata<Variant, Octs, Name> {
 
 impl<Variant, OtherVariant, Octs, OtherOcts, Name, OtherName>
     CanonicalOrd<SvcbRdata<OtherVariant, OtherOcts, OtherName>>
-for SvcbRdata<Variant, Octs, Name>
+    for SvcbRdata<Variant, Octs, Name>
 where
     Octs: AsRef<[u8]>,
     OtherOcts: AsRef<[u8]>,
@@ -355,15 +371,16 @@ where
     OtherName: ToName,
 {
     fn canonical_cmp(
-        &self, other: &SvcbRdata<OtherVariant, OtherOcts, OtherName>
+        &self,
+        other: &SvcbRdata<OtherVariant, OtherOcts, OtherName>,
     ) -> cmp::Ordering {
         match self.priority.cmp(&other.priority) {
-            cmp::Ordering::Equal => { }
-            other => return other
+            cmp::Ordering::Equal => {}
+            other => return other,
         }
         match self.target.name_cmp(&other.target) {
-            cmp::Ordering::Equal => { }
-            other => return other
+            cmp::Ordering::Equal => {}
+            other => return other,
         }
         self.params.canonical_cmp(&other.params)
     }
@@ -384,46 +401,54 @@ impl<Octs, Name> RecordData for SvcbRdata<HttpsVariant, Octs, Name> {
 }
 
 impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
-for SvcbRdata<SvcbVariant, Octs::Range<'a>, ParsedName<Octs::Range<'a>>> {
+    for SvcbRdata<SvcbVariant, Octs::Range<'a>, ParsedName<Octs::Range<'a>>>
+{
     fn parse_rdata(
-        rtype: Rtype, parser: &mut Parser<'a, Octs>
+        rtype: Rtype,
+        parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
         if rtype == Rtype::SVCB {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
 }
 
 impl<'a, Octs: Octets + ?Sized> ParseRecordData<'a, Octs>
-for SvcbRdata<HttpsVariant, Octs::Range<'a>, ParsedName<Octs::Range<'a>>> {
+    for SvcbRdata<HttpsVariant, Octs::Range<'a>, ParsedName<Octs::Range<'a>>>
+{
     fn parse_rdata(
-        rtype: Rtype, parser: &mut Parser<'a, Octs>
+        rtype: Rtype,
+        parser: &mut Parser<'a, Octs>,
     ) -> Result<Option<Self>, ParseError> {
         if rtype == Rtype::HTTPS {
             Self::parse(parser).map(Some)
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
 }
 
 impl<Variant, Octs, Name> ComposeRecordData for SvcbRdata<Variant, Octs, Name>
-where Self: RecordData, Octs: AsRef<[u8]>, Name: ToName {
+where
+    Self: RecordData,
+    Octs: AsRef<[u8]>,
+    Name: ToName,
+{
     fn rdlen(&self, _compress: bool) -> Option<u16> {
         Some(
             u16::checked_add(
                 u16::COMPOSE_LEN + self.target.compose_len(),
                 self.params.len().try_into().expect("long params"),
-            ).expect("long record data")
+            )
+            .expect("long record data"),
         )
     }
 
     fn compose_rdata<Target: Composer + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         self.priority.compose(target)?;
         self.target.compose(target)?;
@@ -431,7 +456,8 @@ where Self: RecordData, Octs: AsRef<[u8]>, Name: ToName {
     }
 
     fn compose_canonical_rdata<Target: Composer + ?Sized>(
-        &self, target: &mut Target
+        &self,
+        target: &mut Target,
     ) -> Result<(), Target::AppendError> {
         self.compose_rdata(target)
     }
@@ -444,7 +470,7 @@ where
     Octs: Octets,
     Name: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}. {}", self.priority, self.target, self.params)
     }
 }
@@ -454,7 +480,7 @@ where
     Octs: Octets,
     Name: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SvcbRdata")
             .field("priority", &self.priority)
             .field("target", &self.target)
@@ -485,12 +511,12 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use super::super::UnknownSvcParam;
     use super::super::value::AllValues;
+    use super::super::UnknownSvcParam;
+    use super::*;
     use crate::base::Name;
-    use octseq::array::Array;
     use core::str::FromStr;
+    use octseq::array::Array;
 
     type Octets512 = Array<512>;
     type Dname512 = Name<Array<512>>;
@@ -502,8 +528,7 @@ mod test {
 
     #[test]
     fn test_vectors_alias() {
-        let rdata =
-            b"\x00\x00\
+        let rdata = b"\x00\x00\
               \x03\x66\x6f\x6f\
                 \x07\x65\x78\x61\x6d\x70\x6c\x65\
                 \x03\x63\x6f\x6d\
@@ -521,9 +546,9 @@ mod test {
         assert_eq!(0, svcb.params.len());
 
         // compose test
-        let svcb_builder = Svcb::new(
-            svcb.priority, svcb.target, Params512::default()
-        ).unwrap();
+        let svcb_builder =
+            Svcb::new(svcb.priority, svcb.target, Params512::default())
+                .unwrap();
 
         let mut buf = Octets512::new();
         svcb_builder.compose_rdata(&mut buf).unwrap();
@@ -532,8 +557,7 @@ mod test {
 
     #[test]
     fn test_vectors_unknown_param() {
-        let rdata =
-            b"\x00\x01\
+        let rdata = b"\x00\x01\
               \x03\x66\x6f\x6f\
                 \x07\x65\x78\x61\x6d\x70\x6c\x65\
                 \x03\x63\x6f\x6d\
@@ -564,16 +588,18 @@ mod test {
 
         // compose test
         let svcb_builder = Svcb::new(
-            svcb.priority, svcb.target,
+            svcb.priority,
+            svcb.target,
             Params512::from_values(|builder| {
                 builder.push(
-                    &UnknownSvcParam::new(0x029b.into(), b"hello").unwrap()
+                    &UnknownSvcParam::new(0x029b.into(), b"hello").unwrap(),
                 )
-            }).unwrap()
-        ).unwrap();
+            })
+            .unwrap(),
+        )
+        .unwrap();
         let mut buf = Octets512::new();
         svcb_builder.compose_rdata(&mut buf).unwrap();
         assert_eq!(rdata.as_ref(), buf.as_ref());
     }
 }
-

--- a/src/rdata/zonemd.rs
+++ b/src/rdata/zonemd.rs
@@ -207,7 +207,7 @@ impl<Octs: AsRef<[u8]> + ?Sized> Eq for Zonemd<Octs> {}
 
 // section 2.4
 impl<Octs: AsRef<[u8]>> fmt::Display for Zonemd<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} ( ",
@@ -221,7 +221,7 @@ impl<Octs: AsRef<[u8]>> fmt::Display for Zonemd<Octs> {
 }
 
 impl<Octs: AsRef<[u8]>> fmt::Debug for Zonemd<Octs> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Zonemd(")?;
         fmt::Display::fmt(self, f)?;
         f.write_str(")")
@@ -372,7 +372,10 @@ ns2           3600   IN  AAAA    2001:db8::63
                         ZoneRecordData::Zonemd(rd) => {
                             assert_eq!(2018031900, rd.serial().into_int());
                             assert_eq!(ZonemdScheme::SIMPLE, rd.scheme());
-                            assert_eq!(ZonemdAlgorithm::SHA384, rd.algorithm());
+                            assert_eq!(
+                                ZonemdAlgorithm::SHA384,
+                                rd.algorithm()
+                            );
                         }
                         _ => panic!(),
                     }

--- a/src/resolv/lookup/host.rs
+++ b/src/resolv/lookup/host.rs
@@ -132,7 +132,7 @@ where
     }
 
     /// Returns an iterator over the IP addresses returned by the lookup.
-    pub fn iter(&self) -> FoundHostsIter {
+    pub fn iter(&self) -> FoundHostsIter<'_> {
         FoundHostsIter {
             aaaa_name: self
                 .aaaa
@@ -166,7 +166,7 @@ where
     /// The socket addresses are gained by combining the IP addresses with
     /// `port`. The returned iterator implements `ToSocketAddrs` and thus
     /// can be used where `std::net` wants addresses right away.
-    pub fn port_iter(&self, port: u16) -> FoundHostsSocketIter {
+    pub fn port_iter(&self, port: u16) -> FoundHostsSocketIter<'_> {
         FoundHostsSocketIter {
             iter: self.iter(),
             port,

--- a/src/resolv/stub/conf.rs
+++ b/src/resolv/stub/conf.rs
@@ -384,7 +384,7 @@ impl ResolvConf {
 
     fn parse_nameserver(
         &mut self,
-        mut words: SplitWhitespace,
+        mut words: SplitWhitespace<'_>,
     ) -> Result<(), Error> {
         use std::net::ToSocketAddrs;
 
@@ -396,14 +396,17 @@ impl ResolvConf {
 
     fn parse_domain(
         &mut self,
-        mut words: SplitWhitespace,
+        mut words: SplitWhitespace<'_>,
     ) -> Result<(), Error> {
         let domain = SearchSuffix::from_str(next_word(&mut words)?)?;
         self.options.search = domain.into();
         no_more_words(words)
     }
 
-    fn parse_search(&mut self, words: SplitWhitespace) -> Result<(), Error> {
+    fn parse_search(
+        &mut self,
+        words: SplitWhitespace<'_>,
+    ) -> Result<(), Error> {
         let mut search = SearchList::new();
         let mut root = false;
         for word in words {
@@ -429,7 +432,10 @@ impl ResolvConf {
     }
     */
 
-    fn parse_options(&mut self, words: SplitWhitespace) -> Result<(), Error> {
+    fn parse_options(
+        &mut self,
+        words: SplitWhitespace<'_>,
+    ) -> Result<(), Error> {
         for word in words {
             match split_arg(word)? {
                 ("debug", None) => {}
@@ -478,7 +484,7 @@ impl Default for ResolvConf {
 //--- Display
 
 impl fmt::Display for ResolvConf {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for server in &self.servers {
             let server = server.addr;
             f.write_str("nameserver ")?;
@@ -656,7 +662,7 @@ impl AsRef<[SearchSuffix]> for SearchList {
 
 /// Returns a reference to the next word or an error.
 fn next_word<'a>(
-    words: &'a mut str::SplitWhitespace,
+    words: &'a mut str::SplitWhitespace<'_>,
 ) -> Result<&'a str, Error> {
     match words.next() {
         Some(word) => Ok(word),
@@ -665,7 +671,7 @@ fn next_word<'a>(
 }
 
 /// Returns nothing but errors out if there are words left.
-fn no_more_words(mut words: str::SplitWhitespace) -> Result<(), Error> {
+fn no_more_words(mut words: str::SplitWhitespace<'_>) -> Result<(), Error> {
     match words.next() {
         Some(..) => Err(Error::ParseError),
         None => Ok(()),
@@ -719,7 +725,7 @@ impl convert::From<::std::num::ParseIntError> for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Error::ParseError => write!(f, "error parsing configuration"),
             Error::Io(ref e) => e.fmt(f),

--- a/src/stelline/channel.rs
+++ b/src/stelline/channel.rs
@@ -421,7 +421,7 @@ impl AsyncDgramSend for ClientServerChannel {
 impl AsyncDgramSock for ClientServerChannel {
     fn poll_send_to(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         data: &[u8],
         dest: &SocketAddr,
     ) -> Poll<io::Result<usize>> {
@@ -529,7 +529,7 @@ impl AsyncAccept for ClientServerChannel {
 
     fn poll_accept(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
     ) -> Poll<io::Result<(Self::Future, SocketAddr)>> {
         let mut server_socket = self.server.lock().unwrap();
         let rx = &mut server_socket.rx;

--- a/src/stelline/matches.rs
+++ b/src/stelline/matches.rs
@@ -29,14 +29,14 @@ impl Matches {
 pub struct DidNotMatch;
 
 impl Entry {
-    pub fn match_multi_msg_ordered(&self) -> OrderedMultiMatcher {
+    pub fn match_multi_msg_ordered(&self) -> OrderedMultiMatcher<'_> {
         OrderedMultiMatcher {
             entry: self,
             answer_idx: 0,
         }
     }
 
-    pub fn match_multi_msg_unordered(&self) -> UnorderedMultiMatcher {
+    pub fn match_multi_msg_unordered(&self) -> UnorderedMultiMatcher<'_> {
         let all_answers =
             self.sections.answer.iter().flatten().cloned().collect();
         UnorderedMultiMatcher {

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -331,7 +331,7 @@ impl Key {
     /// Checks whether the key in the record is this key.
     fn check_tsig<Octs: Octets + ?Sized>(
         &self,
-        tsig: &MessageTsig<Octs>,
+        tsig: &MessageTsig<'_, Octs>,
     ) -> Result<(), ValidationError> {
         if *tsig.record.owner() != self.name
             || *tsig.record.data().algorithm() != self.algorithm().to_name()
@@ -1739,7 +1739,7 @@ impl str::FromStr for Algorithm {
 //--- Display
 
 impl fmt::Display for Algorithm {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",
@@ -1863,13 +1863,13 @@ impl<K: AsRef<Key>> ServerError<K> {
 //--- Debug, Display, and Error
 
 impl<K> fmt::Debug for ServerError<K> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("ServerError").field(&self.0).finish()
     }
 }
 
 impl<K> fmt::Debug for ServerErrorInner<K> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ServerErrorInner::Unsigned { error } => {
                 f.debug_struct("Unsigned").field("error", &error).finish()
@@ -1883,7 +1883,7 @@ impl<K> fmt::Debug for ServerErrorInner<K> {
 }
 
 impl<K> fmt::Display for ServerError<K> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.error().fmt(f)
     }
 }
@@ -1903,7 +1903,7 @@ pub enum NewKeyError {
 //--- Display and Error
 
 impl fmt::Display for NewKeyError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             NewKeyError::BadMinMacLen => {
                 f.write_str("minimum signature length out of bounds")
@@ -1948,7 +1948,7 @@ impl From<ring::error::Unspecified> for GenerateKeyError {
 //--- Display and Error
 
 impl fmt::Display for GenerateKeyError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             GenerateKeyError::BadMinMacLen => {
                 f.write_str("minimum signature length out of bounds")
@@ -1975,7 +1975,7 @@ pub struct AlgorithmError;
 //--- Display and Error
 
 impl fmt::Display for AlgorithmError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("invalid algorithm")
     }
 }
@@ -2013,7 +2013,7 @@ impl From<ParseError> for ValidationError {
 //--- Display and Error
 
 impl fmt::Display for ValidationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ValidationError::BadAlg => f.write_str("unknown algorithm"),
             ValidationError::BadOther => {

--- a/src/utils/base16.rs
+++ b/src/utils/base16.rs
@@ -89,7 +89,7 @@ pub fn encode_display<Octets: AsRef<[u8]> + ?Sized>(
     struct Display<'a>(&'a [u8]);
 
     impl fmt::Display for Display<'_> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             display(self.0, f)
         }
     }
@@ -139,7 +139,7 @@ pub mod serde {
         {
             type Value = Octets;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an Base16-encoded string")
             }
 

--- a/src/utils/base32.rs
+++ b/src/utils/base32.rs
@@ -119,7 +119,7 @@ pub fn encode_display_hex<Octets: AsRef<[u8]>>(
     struct Display<'a>(&'a [u8]);
 
     impl fmt::Display for Display<'_> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             display_hex(self.0, f)
         }
     }
@@ -169,7 +169,7 @@ pub mod serde {
         {
             type Value = Octets;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an Base32-encoded string")
             }
 

--- a/src/utils/base64.rs
+++ b/src/utils/base64.rs
@@ -105,7 +105,7 @@ pub fn encode_display<Octets: AsRef<[u8]>>(
     struct Display<'a>(&'a [u8]);
 
     impl fmt::Display for Display<'_> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             display(self.0, f)
         }
     }
@@ -156,7 +156,7 @@ pub mod serde {
         {
             type Value = Octets;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("an Base64-encoded string")
             }
 
@@ -456,7 +456,7 @@ impl From<ShortBuf> for DecodeError {
 //--- Display and Error
 
 impl fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DecodeError::TrailingInput => f.write_str("trailing input"),
             DecodeError::IllegalChar(ch) => {

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -1625,7 +1625,7 @@ impl From<BadSymbol> for EntryError {
 }
 
 impl fmt::Display for EntryError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.msg)?;
         #[cfg(feature = "std")]
         if let Some(context) = &self.context {
@@ -1648,7 +1648,7 @@ pub struct Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}: {}", self.line, self.col, self.err)
     }
 }
@@ -1666,7 +1666,7 @@ mod test {
     use octseq::Parser;
     use std::vec::Vec;
 
-    fn with_entry(s: &str, op: impl FnOnce(EntryScanner)) {
+    fn with_entry(s: &str, op: impl FnOnce(EntryScanner<'_>)) {
         let mut zone = Zonefile::with_capacity(s.len());
         zone.extend_from_slice(s.as_bytes());
         let entry = EntryScanner::new(&mut zone).unwrap();

--- a/src/zonetree/in_memory/nodes.rs
+++ b/src/zonetree/in_memory/nodes.rs
@@ -294,7 +294,7 @@ impl NodeRrsets {
             .for_each(|rrset| rrset.remove(version));
     }
 
-    pub(super) fn iter(&self) -> NodeRrsetsIter {
+    pub(super) fn iter(&self) -> NodeRrsetsIter<'_> {
         NodeRrsetsIter::new(self.rrsets.read())
     }
 }

--- a/src/zonetree/tree.rs
+++ b/src/zonetree/tree.rs
@@ -62,7 +62,7 @@ impl ZoneTree {
     }
 
     /// Returns an iterator over all of the [`Zone`]s in the tree.
-    pub fn iter_zones(&self) -> ZoneSetIter {
+    pub fn iter_zones(&self) -> ZoneSetIter<'_> {
         ZoneSetIter::new(self)
     }
 


### PR DESCRIPTION
This language feature is deprecated, but the lint for it is not enabled by default.  Enabling the lint and fixing all occurrences also resolves some new Clippy lints.  This does not affect the API or behaviour of the code in any way.