### PR TITLE
Add a to_system_time method to Timestamp.

### DIFF
--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -707,16 +707,19 @@ impl Timestamp {
         self.0.into_int()
     }
 
-    /// Return a SystemTime that meets two requirements:
-    /// 1) The SystemTime value has a duration since UNIX_EPOCH that
-    ///    modulo 2**32 is equal to our Timestamp value.
-    /// 2) The time difference between the SystemTime value and the
-    ///    reference time fits in an i32.
+    /// Returns a [`SytemTime`] close to a reference time.
     ///
-    /// This can be used to sort Timestamp values.
+    /// The returned [`SystemTime`] meets the following requirements:
+    ///
+    /// 1) The [`SystemTime`] value has a duration since `UNIX_EPOCH` that
+    ///    modulo `2**32` is equal to our [`Timestamp`] value.
+    /// 2) The time difference between the [`SystemTime`] value and the
+    ///    reference time fits in an [`i32`].
+    ///
+    /// This can be used to sort [`Timestamp`] values.
     #[must_use]
     #[cfg(feature = "std")]
-    pub fn to_system_time(&self, reference: SystemTime) -> SystemTime {
+    pub fn to_system_time(self, reference: SystemTime) -> SystemTime {
         // Timestamp is a 32-bit value. We cannot just add UNIX_EPOCH because
         // the timestamp may be too far in the future. We may have to add
         // n * 2**32 for some unknown value of n.


### PR DESCRIPTION
Add a method that converts a Timestamp into a SystemTime given a SystemTime references. This can be used for sorting.