### PR TITLE
Trigger CI on default pull-request activity types.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ on:
   # the commit history is rewritten) ... but only if build-related files
   # change.
   pull_request:
-    types: [synchronize]
     paths:
       - '**.rs'
       - 'Cargo.{toml,lock}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ name: CI
 # When the worflow runs
 # ---------------------
 on:
-  # Execute when a pull request's head changes (e.g. new commits are added or
-  # the commit history is rewritten) ... but only if build-related files
-  # change.
+  # Execute when a pull request is (re-) opened or its head changes (e.g. new
+  # commits are added or the commit history is rewritten) ... but only if
+  # build-related files change.
   pull_request:
     paths:
       - '**.rs'


### PR DESCRIPTION
This PR changes the CI trigger for pull requests to use the default activity types which – the Internet claims – is “open,” “synchronize,” and “reopen,” which sounds goods?