### PR TITLE
Update rstest to 0.26.1, the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,21 +1002,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ arbitrary = ["dep:arbitrary"]
 itertools         = "0.13.0"
 lazy_static       = { version = "1.4.0" }
 pretty_assertions = "1.4.1"
-rstest             = "0.23.0"
+rstest             = "0.26.1"
 rustls-pemfile    = { version = "2.1.2" }
 serde_test        = "1.0.130"
 serde_json        = "1.0.113"


### PR DESCRIPTION
I confirmed that `cargo test -F ring` and `cargo test -F openssl` still pass.

https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md