### PR TITLE
Don't discard the NOTIFY SOA serial, if one is received.

### DIFF
--- a/examples/serve-zone.rs
+++ b/examples/serve-zone.rs
@@ -270,11 +270,12 @@ impl Notifiable for DemoNotifyTarget {
         &self,
         class: Class,
         apex_name: &StoredName,
+        serial: Option<Serial>,
         source: IpAddr,
     ) -> Pin<
         Box<dyn Future<Output = Result<(), NotifyError>> + Sync + Send + '_>,
     > {
-        eprintln!("Notify received from {source} of change to zone {apex_name} in class {class}");
+        eprintln!("Notify received from {source} of change to zone {apex_name} in class {class} with serial {serial:?}");
 
         let res = match apex_name.to_string().to_lowercase().as_str() {
             "example.com" => Ok(()),

--- a/src/net/server/tests/integration.rs
+++ b/src/net/server/tests/integration.rs
@@ -25,6 +25,7 @@ use crate::base::net::IpAddr;
 use crate::base::wire::Composer;
 use crate::base::Name;
 use crate::base::Rtype;
+use crate::base::Serial;
 use crate::logging::init_logging;
 use crate::net::client::request::{RequestMessage, RequestMessageMulti};
 use crate::net::client::{dgram, stream, tsig};
@@ -566,11 +567,12 @@ impl Notifiable for TestNotifyTarget {
         &self,
         class: Class,
         apex_name: &StoredName,
+        serial: Option<Serial>,
         source: IpAddr,
     ) -> Pin<
         Box<dyn Future<Output = Result<(), NotifyError>> + Sync + Send + '_>,
     > {
-        trace!("Notify received from {source} of change to zone {apex_name} in class {class}");
+        trace!("Notify received from {source} of change to zone {apex_name} in class {class} with serial {serial:?}");
 
         let res = match apex_name.to_string().to_lowercase().as_str() {
             "example.com" => Ok(()),


### PR DESCRIPTION
Resolves #561. Tested manually with an instance of NSD and the `serve-zone` example.