### PR TITLE
Include missing client error context.

### DIFF
--- a/src/net/client/request.rs
+++ b/src/net/client/request.rs
@@ -781,13 +781,17 @@ impl fmt::Display for Error {
             Error::NoTransportAvailable => {
                 write!(f, "no transport available")
             }
-            Error::Dgram(err) => fmt::Display::fmt(err, f),
+            Error::Dgram(err) => {
+                write!(f, "dgram error: {err}")
+            }
 
             #[cfg(feature = "unstable-server-transport")]
             Error::ZoneWrite => write!(f, "error writing to zone"),
 
             #[cfg(feature = "tsig")]
-            Error::Authentication(err) => fmt::Display::fmt(err, f),
+            Error::Authentication(err) => {
+                write!(f, "authentication error: {err}")
+            }
 
             #[cfg(all(
                 feature = "unstable-validator",


### PR DESCRIPTION
If a FORMERR occurs during TSIG response validation this bubbles up to the user of `src::net::client` as an error that displays as "Error while sending request: format error".

This PR slightly improves this to say "Error while sending request: authentication error: format error" to indicate that the problem relates to message authentication. At the same time it also adds a little missing context to the variant "Error:::Dgram" as well which results from the same underlying kind of problem.

This doesn't resolve the problem that this occurs NOT when sending the request but when handling the response but it's an improvement.