### PR TITLE
Fix position of TSIG middleware service in example middleware chain.

### DIFF
--- a/examples/serve-zone.rs
+++ b/examples/serve-zone.rs
@@ -339,7 +339,7 @@ impl XfrDataProvider<Option<Key>> for ZoneTreeWithDiffs {
         Octs: Octets + Send + Sync,
     {
         if req.metadata().is_none() {
-            eprintln!("Rejecting");
+            eprintln!("Rejecting request due to missing TSIG key");
             return Box::pin(ready(Err(XfrDataProviderError::Refused)));
         }
         let res = req


### PR DESCRIPTION
Otherwise the TSIG key is not available to the `XfrDataProvider` service and validly signed requests will be rejected.

Also improves the error message printed by the `serve-zone` example when a TSIG key is not present in the request as seen by the `XfrDataProvider` (which is what was happening prior to this PR).

Note: the difference can be seen using `dig`, as without this fix `dig` logs a warning:

```
$ dig @127.0.0.1 -p 8053 -y hmac-sha256:demo-key:zlCZbVJPIhobIs1gJNQfrsS3xCxxsR9pMUrGwG8OgG8= example.com AXFR
;; Warning: Message parser reports malformed message packet.
;; Couldn't verify signature: expected a TSIG or SIG(0)
...
```
