### PR TITLE
Fix panic when reading more records after encountering a malformed record

### DIFF
--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -211,6 +211,9 @@ impl Zonefile {
     /// This method is identical to the `next` method of the iterator
     /// implementation but has the return type transposed for easier use
     /// with the question mark operator.
+    ///
+    /// If this function returns an error, do not attempt to read any further
+    /// entries, as the scanner is in an invalid state at that point.
     pub fn next_entry(&mut self) -> Result<Option<Entry>, Error> {
         loop {
             match EntryScanner::new(self)?.scan_entry()? {
@@ -307,6 +310,9 @@ impl<'a> EntryScanner<'a> {
     }
 
     /// Scans a single entry from the zone file.
+    ///
+    /// If this function returns an error, do not attempt to read any further
+    /// entries, as the scanner is in an invalid state at that point.
     fn scan_entry(&mut self) -> Result<ScannedEntry, Error> {
         self._scan_entry()
             .map_err(|err| self.zonefile.buf.error(err))

--- a/src/zonetree/parsed.rs
+++ b/src/zonetree/parsed.rs
@@ -322,10 +322,16 @@ impl TryFrom<inplace::Zonefile> for Zonefile {
                     // Not supported at this time.
                 }
 
-                Err(err) => match err.owner() {
-                    Some(name) => errors.add_error(name.clone(), err),
-                    None => errors.add_error(Name::root_bytes(), err),
-                },
+                Err(err) => {
+                    match err.owner() {
+                        Some(name) => errors.add_error(name.clone(), err),
+                        None => errors.add_error(Name::root_bytes(), err),
+                    }
+                    // The inplace::Zonefile parser is not capable of
+                    // continuing after an error, so we immediately return for
+                    // now.
+                    return Err(errors);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes: NLnetLabs/cascade/issues/72