### PR TITLE
HACK: Serve the original TTL of the RRSIG via XFR, not the RRSIG RRSET TTL.

### DIFF
--- a/src/net/server/middleware/xfr/responder.rs
+++ b/src/net/server/middleware/xfr/responder.rs
@@ -102,8 +102,13 @@ where
             for rr in rrset.data() {
                 last_rr_rtype = Some(rr.rtype());
 
+                let ttl = match rr {
+                    crate::rdata::ZoneRecordData::Rrsig(rrsig) => rrsig.original_ttl(),
+                    _ => rrset.ttl(),
+                };
+
                 if let Err(err) =
-                    batcher.push((owner.clone(), qclass, rrset.ttl(), rr))
+                    batcher.push((owner.clone(), qclass, ttl, rr))
                 {
                     match err {
                         BatchReadyError::MustFitInSingleMessage => {


### PR DESCRIPTION
As RRSIGs should not be grouped into RRSETs with a common TTL.