### PR TITLE
Remove extra feature gates from `validator_test` module.

### DIFF
--- a/src/net/client/cache.rs
+++ b/src/net/client/cache.rs
@@ -26,6 +26,8 @@
 //! responses should be cached and whether truncated responses should be cached
 //! or not.
 
+#![cfg(feature = "unstable-client-cache")]
+
 use crate::base::iana::{Class, Opcode, OptRcode, Rtype};
 use crate::base::name::ToName;
 use crate::base::{

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -244,7 +244,6 @@
 #![warn(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
 
-#[cfg(feature = "unstable-client-cache")]
 pub mod cache;
 pub mod dgram;
 pub mod dgram_stream;
@@ -255,11 +254,5 @@ pub mod redundant;
 pub mod request;
 pub mod stream;
 pub mod tsig;
-#[cfg(all(
-    feature = "unstable-validator",
-    any(feature = "ring", feature = "openssl")
-))]
 pub mod validator;
-
-#[cfg(all(test, feature = "unstable-validator"))]
 pub mod validator_test;

--- a/src/net/client/validator.rs
+++ b/src/net/client/validator.rs
@@ -39,6 +39,11 @@
 //! twice. One solution to that is to create a new type of cache that only
 //! caches DS and DNSKEY records and insert that upstream of the validator.
 
+#![cfg(all(
+    feature = "unstable-validator",
+    any(feature = "ring", feature = "openssl")
+))]
+
 //! # Example
 //! ```rust,no_run
 //! # use domain::base::{MessageBuilder, Name, Rtype};

--- a/src/net/client/validator_test.rs
+++ b/src/net/client/validator_test.rs
@@ -1,5 +1,7 @@
 //! Module for testing the validator client transport.
 
+#![cfg(all(test, feature = "unstable-validator"))]
+
 use std::fs::File;
 use std::path::PathBuf;
 use std::string::ToString;


### PR DESCRIPTION
This PR removes the additional feature gates from the `validator_test` module so that the tests don’t quietly succeed if you don’t include insufficient features.