### PR TITLE
Fix the glob for paths that trigger a CI run.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ on:
   pull_request:
     paths:
       - '**.rs'
-      - 'Cargo.{toml,lock}'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
       - '.github/workflows/ci.yml'
 
   # If a pull request is merged, at least one commit is added to the target


### PR DESCRIPTION
This PR attempts to fix the CI workflow to run for changes to the Cargo files. It seems that globs with curly braces don’t work in Github Actions.