### PR TITLE
Upgrade rand to 0.10.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +127,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +168,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -214,7 +240,7 @@ dependencies = [
  "constant_time_eq",
  "domain-macros",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.16.0",
  "heapless",
  "itertools",
  "lazy_static",
@@ -298,6 +324,12 @@ name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -428,8 +460,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -445,6 +491,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -465,6 +520,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -491,13 +552,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -530,6 +599,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -765,15 +840,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +847,16 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -817,34 +893,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1369,6 +1438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,7 +1490,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1475,6 +1559,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1792,6 +1910,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "yaml_serde"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,26 +2015,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ bumpalo        = { version = "3.12", optional = true }
 constant_time_eq = { version = "0.4.2", optional = true }
 octseq         = { version = "0.5.2", default-features = false }
 time           = { version = "0.3.1", default-features = false }
-rand           = { version = "0.8", optional = true }
+rand           = { version = "0.10.1", optional = true }
 arc-swap       = { version = "1.7.0", optional = true }
 bytes          = { version = "1.2", optional = true, default-features = false }
 chrono         = { version = "0.4.35", optional = true, default-features = false } # 0.4.35 deprecates Duration::seconds()

--- a/Changelog.md
+++ b/Changelog.md
@@ -76,6 +76,9 @@ Unstable features
 
 Other changes
 
+* Upgraded [rand] to 0.10. (#631)
+
+
 [#349]: https://github.com/NLnetLabs/domain/pull/349
 [#390]: https://github.com/NLnetLabs/domain/pull/390
 [#393]: https://github.com/NLnetLabs/domain/pull/393
@@ -97,10 +100,12 @@ Other changes
 [#608]: https://github.com/NLnetLabs/domain/pull/608
 [#614]: https://github.com/NLnetLabs/domain/pull/614
 [#620]: https://github.com/NLnetLabs/domain/pull/620
+[#631]: https://github.com/NLnetLabs/domain/pull/631
 [@rossmacarthur]: https://github.com/rossmacarthur
 [@weilence]: https://github.com/weilence
 [@WhyNotHugo]: https://github.com/WhyNotHugo
 [@rossmacarthur]: https://github.com/rossmacarthur
+[rand]: https://crates.io/crates/rand
 
 
 ## 0.11.1

--- a/examples/serve-zone.rs
+++ b/examples/serve-zone.rs
@@ -28,8 +28,8 @@ use std::time::Duration;
 
 use domain::rdata::{Soa, ZoneRecordData};
 use octseq::Octets;
-use rand::distributions::Alphanumeric;
-use rand::Rng;
+use rand::distr::Alphanumeric;
+use rand::RngExt;
 use tokio::net::{TcpListener, UdpSocket};
 use tracing_subscriber::EnvFilter;
 
@@ -244,7 +244,7 @@ async fn main() {
                     node.remove_rrset(Rtype::A).await.unwrap();
                 }
 
-                let random_string: String = rand::thread_rng()
+                let random_string: String = rand::rng()
                     .sample_iter(&Alphanumeric)
                     .take(7)
                     .map(char::from)

--- a/src/dnssec/sign/signatures/rrsigs.rs
+++ b/src/dnssec/sign/signatures/rrsigs.rs
@@ -362,6 +362,7 @@ mod tests {
     use bytes::Bytes;
     use core::str::FromStr;
     use pretty_assertions::assert_eq;
+    use rand::RngExt;
 
     use crate::base::iana::SecurityAlgorithm;
     use crate::base::Serial;
@@ -375,7 +376,6 @@ mod tests {
 
     use super::*;
     use crate::zonetree::types::StoredRecordData;
-    use rand::Rng;
 
     const TEST_INCEPTION: u32 = 0;
     const TEST_EXPIRATION: u32 = 100;
@@ -1235,7 +1235,7 @@ mod tests {
 
     impl Default for TestKey {
         fn default() -> Self {
-            Self(rand::thread_rng().gen())
+            Self(rand::rng().random())
         }
     }
 }

--- a/src/net/client/load_balancer.rs
+++ b/src/net/client/load_balancer.rs
@@ -56,7 +56,7 @@ use bytes::Bytes;
 use futures_util::stream::FuturesUnordered;
 use futures_util::StreamExt;
 use octseq::Octets;
-use rand::random;
+use rand::{random, random_range};
 use std::boxed::Box;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
@@ -641,7 +641,7 @@ impl<Req: Clone + Send + Sync + 'static> Query<Req> {
         // is non-zero then the upstream recently got work and does not need
         // to be probed.
         if conn_rt_len > 1 && random::<f64>() < PROBE_P {
-            let index: usize = 1 + random::<usize>() % (conn_rt_len - 1);
+            let index = random_range(1..conn_rt_len);
 
             if conn_rt[index].queue_length == 0 {
                 // Give the probe some head start. We may need a separate

--- a/src/net/client/load_balancer.rs
+++ b/src/net/client/load_balancer.rs
@@ -641,7 +641,7 @@ impl<Req: Clone + Send + Sync + 'static> Query<Req> {
         // is non-zero then the upstream recently got work and does not need
         // to be probed.
         if conn_rt_len > 1 && random::<f64>() < PROBE_P {
-            let index = random_range(1..conn_rt_len);
+            let index = random_range(1..=conn_rt_len - 1);
 
             if conn_rt[index].queue_length == 0 {
                 // Give the probe some head start. We may need a separate

--- a/src/net/client/redundant.rs
+++ b/src/net/client/redundant.rs
@@ -411,7 +411,7 @@ impl<Req: Clone + Send + Sync + 'static> Query<Req> {
 
         // Do we want to probe a less performant upstream?
         if conn_rt_len > 1 && random::<f64>() < PROBE_P {
-            let index = random_range(1..conn_rt_len);
+            let index = random_range(1..=conn_rt_len - 1);
 
             // Give the probe some head start. We may need a separate
             // configuration parameter. A multiple of min_rt. Just use

--- a/src/net/client/redundant.rs
+++ b/src/net/client/redundant.rs
@@ -7,7 +7,7 @@ use futures_util::StreamExt;
 
 use octseq::Octets;
 
-use rand::random;
+use rand::{random, random_range};
 
 use std::boxed::Box;
 use std::cmp::Ordering;
@@ -411,7 +411,7 @@ impl<Req: Clone + Send + Sync + 'static> Query<Req> {
 
         // Do we want to probe a less performant upstream?
         if conn_rt_len > 1 && random::<f64>() < PROBE_P {
-            let index: usize = 1 + random::<usize>() % (conn_rt_len - 1);
+            let index = random_range(1..conn_rt_len);
 
             // Give the probe some head start. We may need a separate
             // configuration parameter. A multiple of min_rt. Just use

--- a/src/net/server/middleware/cookies.rs
+++ b/src/net/server/middleware/cookies.rs
@@ -7,7 +7,7 @@ use std::vec::Vec;
 
 use futures_util::stream::{once, Once, Stream};
 use octseq::Octets;
-use rand::RngCore;
+use rand::Rng;
 use tracing::{debug, error, trace, warn};
 
 use crate::base::iana::{OptRcode, Rcode};
@@ -96,7 +96,7 @@ where
 
     pub fn with_random_secret(next_svc: NextSvc) -> Self {
         let mut server_secret = [0u8; 16];
-        rand::thread_rng().fill_bytes(&mut server_secret);
+        rand::rng().fill_bytes(&mut server_secret);
         Self::new(next_svc, server_secret)
     }
 

--- a/src/resolv/lookup/srv.rs
+++ b/src/resolv/lookup/srv.rs
@@ -10,7 +10,7 @@ use crate::resolv::resolver::Resolver;
 use core::fmt;
 use futures_util::stream::{self, Stream, StreamExt};
 use octseq::octets::Octets;
-use rand::distributions::{Distribution, Uniform};
+use rand::distr::{Distribution, Uniform};
 use std::net::{IpAddr, SocketAddr};
 use std::vec::Vec;
 use std::{io, mem, ops};
@@ -260,10 +260,11 @@ impl FoundSrvs {
 
     /// Reorders items in a priority level based on their weight
     fn reorder_by_weight(items: &mut [SrvItem], weight_sum: u32) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut weight_sum = weight_sum;
         for i in 0..items.len() {
-            let range = Uniform::new(0, weight_sum + 1);
+            #[allow(clippy::unwrap_used)]
+            let range = Uniform::new(0, weight_sum + 1).unwrap();
             let mut sum: u32 = 0;
             let pick = range.sample(&mut rng);
             for j in 0..items.len() {


### PR DESCRIPTION
This PR upgrades `rand` to 0.10.1.

While this mostly requires updating names functions and traits, there is a functional change in `src/net/client` as `random` is not available for `usize` any more.