### PR TITLE
[new/base/name] Allow nearby name compression refs

### DIFF
--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -399,13 +399,14 @@ impl<'a> SplitMessageBytes<'a> for NameBuf {
         // Traverse compression pointers.
         let mut old_start = start;
         while let Some(start) = pointer.map(usize::from) {
+            let start = start.checked_sub(12).ok_or(ParseError)?;
+
             // Ensure the referenced position comes earlier.
             if start >= old_start {
                 return Err(ParseError);
             }
 
             // Keep going, from the referenced position.
-            let start = start.checked_sub(12).ok_or(ParseError)?;
             let bytes = contents.get(start..).ok_or(ParseError)?;
             (pointer, _) = parse_segment(bytes, &mut buffer)?;
             old_start = start;
@@ -442,13 +443,14 @@ impl<'a> ParseMessageBytes<'a> for NameBuf {
         // Traverse compression pointers.
         let mut old_start = start;
         while let Some(start) = pointer.map(usize::from) {
+            let start = start.checked_sub(12).ok_or(ParseError)?;
+
             // Ensure the referenced position comes earlier.
             if start >= old_start {
                 return Err(ParseError);
             }
 
             // Keep going, from the referenced position.
-            let start = start.checked_sub(12).ok_or(ParseError)?;
             let bytes = contents.get(start..).ok_or(ParseError)?;
             (pointer, _) = parse_segment(bytes, &mut buffer)?;
             old_start = start;

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -324,13 +324,14 @@ impl<'a> SplitMessageBytes<'a> for RevNameBuf {
         // Traverse compression pointers.
         let mut old_start = start;
         while let Some(start) = pointer.map(usize::from) {
+            let start = start.checked_sub(12).ok_or(ParseError)?;
+
             // Ensure the referenced position comes earlier.
             if start >= old_start {
                 return Err(ParseError);
             }
 
             // Keep going, from the referenced position.
-            let start = start.checked_sub(12).ok_or(ParseError)?;
             let bytes = contents.get(start..).ok_or(ParseError)?;
             (pointer, _) = parse_segment(bytes, &mut buffer)?;
             old_start = start;
@@ -367,13 +368,14 @@ impl<'a> ParseMessageBytes<'a> for RevNameBuf {
         // Traverse compression pointers.
         let mut old_start = start;
         while let Some(start) = pointer.map(usize::from) {
+            let start = start.checked_sub(12).ok_or(ParseError)?;
+
             // Ensure the referenced position comes earlier.
             if start >= old_start {
                 return Err(ParseError);
             }
 
             // Keep going, from the referenced position.
-            let start = start.checked_sub(12).ok_or(ParseError)?;
             let bytes = contents.get(start..).ok_or(ParseError)?;
             (pointer, _) = parse_segment(bytes, &mut buffer)?;
             old_start = start;


### PR DESCRIPTION
A bug caused name compression references within 12 bytes to fail to be parsed.

Thanks for identifying the issue @Philip-NLnetLabs!