### PR TITLE
Alloc + no_std: part 1

### DIFF
--- a/src/base/charstr.rs
+++ b/src/base/charstr.rs
@@ -1112,8 +1112,7 @@ impl fmt::Display for CharStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CharStrError {}
+impl core::error::Error for CharStrError {}
 
 //------------ FromStrError --------------------------------------------------
 
@@ -1152,8 +1151,7 @@ impl fmt::Display for FromStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FromStrError {}
+impl core::error::Error for FromStrError {}
 
 //------------ PresentationError ---------------------------------------------
 
@@ -1208,8 +1206,7 @@ impl fmt::Display for PresentationError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PresentationError {}
+impl core::error::Error for PresentationError {}
 
 //============ Testing =======================================================
 

--- a/src/base/header.rs
+++ b/src/base/header.rs
@@ -938,8 +938,7 @@ impl fmt::Display for FlagsFromStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FlagsFromStrError {}
+impl core::error::Error for FlagsFromStrError {}
 
 //------------ CountOverflow -------------------------------------------------
 
@@ -953,8 +952,7 @@ impl fmt::Display for CountOverflow {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CountOverflow {}
+impl core::error::Error for CountOverflow {}
 
 //============ Testing ======================================================
 

--- a/src/base/iana/macros.rs
+++ b/src/base/iana/macros.rs
@@ -520,8 +520,7 @@ macro_rules! from_str_error {
         #[derive(Clone, Debug)]
         pub struct FromStrError(());
 
-        #[cfg(feature = "std")]
-        impl std::error::Error for FromStrError {
+        impl core::error::Error for FromStrError {
             fn description(&self) -> &str {
                 $description
             }

--- a/src/base/iana/rcode.rs
+++ b/src/base/iana/rcode.rs
@@ -911,8 +911,7 @@ impl fmt::Display for InvalidRcode {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidRcode {}
+impl core::error::Error for InvalidRcode {}
 
 //============ Tests =========================================================
 

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -1306,8 +1306,7 @@ impl fmt::Display for ShortMessage {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ShortMessage {}
+impl core::error::Error for ShortMessage {}
 
 //------------ CopyRecordsError ----------------------------------------------
 
@@ -1346,8 +1345,7 @@ impl fmt::Display for CopyRecordsError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CopyRecordsError {}
+impl core::error::Error for CopyRecordsError {}
 
 //============ Testing =======================================================
 

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -2693,8 +2693,7 @@ impl fmt::Display for PushError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PushError {}
+impl core::error::Error for PushError {}
 
 //============ Testing =======================================================
 

--- a/src/base/name/absolute.rs
+++ b/src/base/name/absolute.rs
@@ -1217,8 +1217,7 @@ impl fmt::Display for NameError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for NameError {}
+impl core::error::Error for NameError {}
 
 //============ Testing =======================================================
 //

--- a/src/base/name/builder.rs
+++ b/src/base/name/builder.rs
@@ -562,8 +562,7 @@ impl fmt::Display for PushError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PushError {}
+impl core::error::Error for PushError {}
 
 //------------ PushNameError -------------------------------------------------
 
@@ -596,8 +595,7 @@ impl fmt::Display for PushNameError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PushNameError {}
+impl core::error::Error for PushNameError {}
 
 //------------ LabelFromStrError ---------------------------------------------
 
@@ -655,8 +653,7 @@ impl fmt::Display for LabelFromStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LabelFromStrError {}
+impl core::error::Error for LabelFromStrError {}
 
 //------------ FromStrError --------------------------------------------------
 
@@ -713,8 +710,7 @@ impl fmt::Display for FromStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FromStrError {}
+impl core::error::Error for FromStrError {}
 
 //------------ PresentationError ---------------------------------------------
 
@@ -761,8 +757,7 @@ impl fmt::Display for PresentationError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PresentationError {}
+impl core::error::Error for PresentationError {}
 
 //============ Testing =======================================================
 

--- a/src/base/name/chain.rs
+++ b/src/base/name/chain.rs
@@ -373,8 +373,7 @@ impl fmt::Display for LongChainError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LongChainError {}
+impl core::error::Error for LongChainError {}
 
 //============ Testing =======================================================
 

--- a/src/base/name/label.rs
+++ b/src/base/name/label.rs
@@ -808,8 +808,7 @@ impl fmt::Display for LabelTypeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LabelTypeError {}
+impl core::error::Error for LabelTypeError {}
 
 //------------ LongLabelError ------------------------------------------------
 
@@ -825,8 +824,7 @@ impl fmt::Display for LongLabelError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LongLabelError {}
+impl core::error::Error for LongLabelError {}
 
 //------------ SplitLabelError -----------------------------------------------
 
@@ -879,8 +877,7 @@ impl fmt::Display for SplitLabelError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SplitLabelError {}
+impl core::error::Error for SplitLabelError {}
 
 //============ Testing =======================================================
 

--- a/src/base/name/parsed.rs
+++ b/src/base/name/parsed.rs
@@ -707,8 +707,7 @@ impl fmt::Display for ParsedDnameError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParsedDnameError {}
+impl core::error::Error for ParsedDnameError {}
 
 impl From<LabelTypeError> for ParsedDnameError {
     fn from(err: LabelTypeError) -> Self {

--- a/src/base/name/relative.rs
+++ b/src/base/name/relative.rs
@@ -1043,8 +1043,7 @@ impl fmt::Display for RelativeNameError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RelativeNameError {}
+impl core::error::Error for RelativeNameError {}
 
 //------------ RelativeFromStrError ------------------------------------------
 
@@ -1079,8 +1078,7 @@ impl fmt::Display for RelativeFromStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RelativeFromStrError {}
+impl core::error::Error for RelativeFromStrError {}
 
 //------------ StripSuffixError ----------------------------------------------
 
@@ -1096,8 +1094,7 @@ impl fmt::Display for StripSuffixError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for StripSuffixError {}
+impl core::error::Error for StripSuffixError {}
 
 //============ Testing =======================================================
 

--- a/src/base/name/uncertain.rs
+++ b/src/base/name/uncertain.rs
@@ -637,8 +637,7 @@ impl fmt::Display for UncertainDnameError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for UncertainDnameError {}
+impl core::error::Error for UncertainDnameError {}
 
 //============ Testing =======================================================
 

--- a/src/base/opt/keepalive.rs
+++ b/src/base/opt/keepalive.rs
@@ -227,8 +227,7 @@ impl fmt::Display for FromDurationError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FromDurationError {}
+impl core::error::Error for FromDurationError {}
 
 //============ Testing =======================================================
 

--- a/src/base/opt/mod.rs
+++ b/src/base/opt/mod.rs
@@ -1103,8 +1103,7 @@ impl fmt::Display for LongOptData {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LongOptData {}
+impl core::error::Error for LongOptData {}
 
 //------------ BuildDataError ------------------------------------------------
 
@@ -1155,8 +1154,7 @@ impl fmt::Display for BuildDataError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BuildDataError {}
+impl core::error::Error for BuildDataError {}
 
 //============ Tests =========================================================
 

--- a/src/base/question.rs
+++ b/src/base/question.rs
@@ -408,8 +408,7 @@ impl fmt::Display for FromStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FromStrError {}
+impl core::error::Error for FromStrError {}
 
 //------------ PresentationError ---------------------------------------------
 
@@ -466,5 +465,4 @@ impl fmt::Display for PresentationError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PresentationError {}
+impl core::error::Error for PresentationError {}

--- a/src/base/rdata.rs
+++ b/src/base/rdata.rs
@@ -535,8 +535,7 @@ impl fmt::Display for LongRecordData {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LongRecordData {}
+impl core::error::Error for LongRecordData {}
 
 //============ Testing ======================================================
 

--- a/src/base/record.rs
+++ b/src/base/record.rs
@@ -1068,11 +1068,10 @@ where
     }
 }
 
-#[cfg(feature = "std")]
-impl<N, D> std::error::Error for RecordParseError<N, D>
+impl<N, D> core::error::Error for RecordParseError<N, D>
 where
-    N: std::error::Error,
-    D: std::error::Error,
+    N: core::error::Error,
+    D: core::error::Error,
 {
 }
 

--- a/src/base/scan.rs
+++ b/src/base/scan.rs
@@ -25,6 +25,7 @@ use crate::base::charstr::{CharStr, CharStrBuilder};
 use crate::base::name::{Name, ToName};
 use crate::base::wire::{Compose, Composer};
 use core::convert::{TryFrom, TryInto};
+use core::error;
 use core::iter::Peekable;
 use core::marker::PhantomData;
 use core::{fmt, str};
@@ -33,8 +34,6 @@ use octseq::{
     EmptyBuilder, FreezeBuilder, FromBuilder, OctetsBuilder, ShortBuf,
     Truncate,
 };
-#[cfg(feature = "std")]
-use std::error;
 
 use super::Ttl;
 
@@ -286,11 +285,7 @@ macro_rules! declare_error_trait {
     }
 }
 
-#[cfg(feature = "std")]
 declare_error_trait!(ScannerError: Sized + error::Error);
-
-#[cfg(not(feature = "std"))]
-declare_error_trait!(ScannerError: Sized + fmt::Debug + fmt::Display);
 
 #[cfg(feature = "std")]
 impl ScannerError for std::io::Error {
@@ -1083,8 +1078,7 @@ impl fmt::Display for SymbolCharsError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SymbolCharsError {}
+impl core::error::Error for SymbolCharsError {}
 
 //------------ SymbolOctetsError ---------------------------------------------
 
@@ -1125,8 +1119,7 @@ impl fmt::Display for SymbolOctetsError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SymbolOctetsError {}
+impl core::error::Error for SymbolOctetsError {}
 
 //------------ BadSymbol -----------------------------------------------------
 
@@ -1174,8 +1167,7 @@ impl fmt::Display for BadSymbol {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BadSymbol {}
+impl core::error::Error for BadSymbol {}
 
 #[cfg(feature = "std")]
 impl From<BadSymbol> for std::io::Error {
@@ -1220,8 +1212,7 @@ impl fmt::Display for StrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for StrError {}
+impl core::error::Error for StrError {}
 
 //============ Testing =======================================================
 

--- a/src/base/serial.rs
+++ b/src/base/serial.rs
@@ -201,8 +201,7 @@ impl fmt::Display for IllegalSignatureTime {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for IllegalSignatureTime {}
+impl core::error::Error for IllegalSignatureTime {}
 
 //============ Testing =======================================================
 

--- a/src/base/wire.rs
+++ b/src/base/wire.rs
@@ -344,8 +344,7 @@ impl fmt::Display for ParseError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseError {}
+impl core::error::Error for ParseError {}
 
 //------------ FormError -----------------------------------------------------
 
@@ -373,5 +372,4 @@ impl fmt::Display for FormError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FormError {}
+impl core::error::Error for FormError {}

--- a/src/crypto/common.rs
+++ b/src/crypto/common.rs
@@ -48,8 +48,8 @@ const _: () = {
     );
 };
 
+use core::error;
 use core::fmt;
-use std::error;
 use std::vec::Vec;
 
 use crate::rdata::Dnskey;

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -72,7 +72,7 @@ impl fmt::Display for FromBytesError {
 
 //--- Error
 
-impl std::error::Error for FromBytesError {}
+impl core::error::Error for FromBytesError {}
 
 //----------- GenerateError --------------------------------------------------
 
@@ -109,7 +109,7 @@ impl fmt::Display for GenerateError {
 
 //--- Error
 
-impl std::error::Error for GenerateError {}
+impl core::error::Error for GenerateError {}
 
 //----------- DigestBuilder --------------------------------------------------
 

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -57,7 +57,7 @@ impl fmt::Display for FromBytesError {
 
 //--- Error
 
-impl std::error::Error for FromBytesError {}
+impl core::error::Error for FromBytesError {}
 
 //----------- GenerateError --------------------------------------------------
 
@@ -94,7 +94,7 @@ impl fmt::Display for GenerateError {
 
 //--- Error
 
-impl std::error::Error for GenerateError {}
+impl core::error::Error for GenerateError {}
 
 //----------- DigestBuilder --------------------------------------------------
 

--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -923,7 +923,7 @@ impl fmt::Display for FromBytesError {
 
 //--- Error
 
-impl std::error::Error for FromBytesError {}
+impl core::error::Error for FromBytesError {}
 
 //----------- GenerateError --------------------------------------------------
 
@@ -978,7 +978,7 @@ impl fmt::Display for GenerateError {
 
 //--- Error
 
-impl std::error::Error for GenerateError {}
+impl core::error::Error for GenerateError {}
 
 //----------- SignError ------------------------------------------------------
 
@@ -1050,7 +1050,7 @@ impl fmt::Display for SignError {
     }
 }
 
-impl std::error::Error for SignError {}
+impl core::error::Error for SignError {}
 
 //----------- BindFormatError ------------------------------------------------
 
@@ -1081,7 +1081,7 @@ impl fmt::Display for BindFormatError {
 
 //--- Error
 
-impl std::error::Error for BindFormatError {}
+impl core::error::Error for BindFormatError {}
 
 //============ Tests =========================================================
 

--- a/src/dnssec/common.rs
+++ b/src/dnssec/common.rs
@@ -17,7 +17,7 @@ use crate::dep::octseq::{
 use crate::rdata::nsec3::{Nsec3Salt, OwnerHash};
 use crate::rdata::{Dnskey, Nsec3param};
 
-use std::error;
+use core::error;
 use std::fmt;
 use std::str::FromStr;
 

--- a/src/dnssec/sign/keys/keyset.rs
+++ b/src/dnssec/sign/keys/keyset.rs
@@ -2681,10 +2681,10 @@ mod tests {
     use crate::dnssec::sign::keys::keyset::{
         Action, Available, KeySet, KeyType, RollType, UnixTime,
     };
-    use crate::std::string::ToString;
     use mock_instant::global::MockClock;
     use std::str::FromStr;
     use std::string::String;
+    use std::string::ToString;
     use std::time::Duration;
     use std::vec::Vec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@
 //! of unstable features. These will follow proper Semver practice but may
 //! change significantly in releases with breaking changes.
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::uninlined_format_args)]
@@ -186,12 +186,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]
-extern crate alloc;
-
-#[cfg(feature = "std")]
 #[allow(unused_imports)] // Import macros even if unused.
 #[macro_use]
-extern crate std;
+extern crate alloc;
 
 // The 'domain-macros' crate introduces 'derive' macros which can be used by
 // users of the 'domain' crate, but also by the 'domain' crate itself.  Within

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@
 //! of unstable features. These will follow proper Semver practice but may
 //! change significantly in releases with breaking changes.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::uninlined_format_args)]
@@ -186,9 +186,12 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "std")]
 #[allow(unused_imports)] // Import macros even if unused.
 #[macro_use]
-extern crate alloc;
+extern crate std;
 
 // The 'domain-macros' crate introduces 'derive' macros which can be used by
 // users of the 'domain' crate, but also by the 'domain' crate itself.  Within

--- a/src/net/server/service.rs
+++ b/src/net/server/service.rs
@@ -254,8 +254,7 @@ impl Display for ServiceError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ServiceError {}
+impl core::error::Error for ServiceError {}
 
 //--- From<PushError>
 

--- a/src/new/base/build/message.rs
+++ b/src/new/base/build/message.rs
@@ -309,8 +309,7 @@ pub enum MessageBuildError {
     Truncated(TruncationError),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MessageBuildError {}
+impl core::error::Error for MessageBuildError {}
 
 impl From<TruncationError> for MessageBuildError {
     fn from(value: TruncationError) -> Self {

--- a/src/new/base/charstr.rs
+++ b/src/new/base/charstr.rs
@@ -444,9 +444,7 @@ pub enum CharStrParseError {
     InvalidChar,
 }
 
-// TODO(1.81.0): Use 'core::error::Error' instead.
-#[cfg(feature = "std")]
-impl std::error::Error for CharStrParseError {}
+impl core::error::Error for CharStrParseError {}
 
 impl fmt::Display for CharStrParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -859,9 +859,7 @@ impl From<LabelParseError> for NameParseError {
     }
 }
 
-// TODO(1.81.0): Use 'core::error::Error' instead.
-#[cfg(feature = "std")]
-impl std::error::Error for NameParseError {}
+impl core::error::Error for NameParseError {}
 
 impl fmt::Display for NameParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -802,9 +802,7 @@ pub enum LabelParseError {
     InvalidEscape,
 }
 
-// TODO(1.81.0): Use 'core::error::Error' instead.
-#[cfg(feature = "std")]
-impl std::error::Error for LabelParseError {}
+impl core::error::Error for LabelParseError {}
 
 impl fmt::Display for LabelParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/new/base/wire/build.rs
+++ b/src/new/base/wire/build.rs
@@ -250,8 +250,7 @@ pub use domain_macros::AsBytes;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TruncationError;
 
-#[cfg(feature = "std")]
-impl std::error::Error for TruncationError {}
+impl core::error::Error for TruncationError {}
 
 //--- Formatting
 

--- a/src/rdata/caa.rs
+++ b/src/rdata/caa.rs
@@ -624,8 +624,8 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> Parse<'a, Octs> for CaaFlags {
 #[cfg(all(feature = "std", feature = "bytes"))]
 mod test {
     use super::*;
-    use crate::std::string::ToString;
     use octseq::array::Array;
+    use std::string::ToString;
 
     #[test]
     fn caa_eq() {

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -2682,8 +2682,7 @@ impl fmt::Display for RtypeBitmapError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RtypeBitmapError {}
+impl core::error::Error for RtypeBitmapError {}
 
 //============ Friendly Helper Functions =====================================
 
@@ -2723,8 +2722,7 @@ impl fmt::Display for IllegalSignatureTime {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for IllegalSignatureTime {}
+impl core::error::Error for IllegalSignatureTime {}
 
 //============ Test ==========================================================
 

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -1273,8 +1273,7 @@ impl fmt::Display for Nsec3SaltFromStrError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Nsec3SaltFromStrError {}
+impl core::error::Error for Nsec3SaltFromStrError {}
 
 //------------ OwnerHash -----------------------------------------------------
 
@@ -1647,8 +1646,7 @@ impl fmt::Display for Nsec3SaltError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Nsec3SaltError {}
+impl core::error::Error for Nsec3SaltError {}
 
 //------------ OwnerHashError ------------------------------------------------
 
@@ -1664,8 +1662,7 @@ impl fmt::Display for OwnerHashError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for OwnerHashError {}
+impl core::error::Error for OwnerHashError {}
 
 //============ Testing ======================================================
 

--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -1122,8 +1122,7 @@ impl fmt::Display for LongSvcParam {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LongSvcParam {}
+impl core::error::Error for LongSvcParam {}
 
 //------------ PushError -----------------------------------------------------
 
@@ -1153,8 +1152,7 @@ impl fmt::Display for PushError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PushError {}
+impl core::error::Error for PushError {}
 
 //============ Tests =========================================================
 

--- a/src/rdata/svcb/value.rs
+++ b/src/rdata/svcb/value.rs
@@ -2271,8 +2271,7 @@ impl fmt::Display for BuildValueError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BuildValueError {}
+impl core::error::Error for BuildValueError {}
 
 //------------ PushValueError ------------------------------------------------
 
@@ -2331,8 +2330,7 @@ impl fmt::Display for PushValueError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PushValueError {}
+impl core::error::Error for PushValueError {}
 
 //------------ BuildAlpnError ------------------------------------------------
 
@@ -2369,8 +2367,7 @@ impl fmt::Display for BuildAlpnError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BuildAlpnError {}
+impl core::error::Error for BuildAlpnError {}
 
 //------------ PushAlpnError -------------------------------------------------
 
@@ -2429,8 +2426,7 @@ impl fmt::Display for PushAlpnError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PushAlpnError {}
+impl core::error::Error for PushAlpnError {}
 
 //============ Tests =========================================================
 

--- a/src/resolv/lookup/srv.rs
+++ b/src/resolv/lookup/srv.rs
@@ -406,7 +406,7 @@ impl fmt::Display for SrvError {
     }
 }
 
-impl std::error::Error for SrvError {}
+impl core::error::Error for SrvError {}
 
 impl From<io::Error> for SrvError {
     fn from(err: io::Error) -> SrvError {

--- a/src/tsig/mod.rs
+++ b/src/tsig/mod.rs
@@ -1891,8 +1891,7 @@ impl<K> fmt::Display for ServerError<K> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<K> std::error::Error for ServerError<K> {}
+impl<K> core::error::Error for ServerError<K> {}
 
 //------------ NewKeyError ---------------------------------------------------
 
@@ -1918,8 +1917,7 @@ impl fmt::Display for NewKeyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for NewKeyError {}
+impl core::error::Error for NewKeyError {}
 
 //------------ GenerateKeyError ----------------------------------------------
 
@@ -1966,8 +1964,7 @@ impl fmt::Display for GenerateKeyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for GenerateKeyError {}
+impl core::error::Error for GenerateKeyError {}
 
 //------------ AlgorithmError ------------------------------------------------
 
@@ -1983,8 +1980,7 @@ impl fmt::Display for AlgorithmError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AlgorithmError {}
+impl core::error::Error for AlgorithmError {}
 
 //------------ ValidationError -----------------------------------------------
 
@@ -2044,8 +2040,7 @@ impl fmt::Display for ValidationError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ValidationError {}
+impl core::error::Error for ValidationError {}
 
 //------------ TsigError -----------------------------------------------------
 

--- a/src/utils/base64.rs
+++ b/src/utils/base64.rs
@@ -468,8 +468,7 @@ impl fmt::Display for DecodeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeError {}
+impl core::error::Error for DecodeError {}
 
 //============ Constants =====================================================
 

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -1698,8 +1698,7 @@ impl fmt::Display for EntryError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for EntryError {}
+impl core::error::Error for EntryError {}
 
 //------------ Error ---------------------------------------------------------
 
@@ -1716,8 +1715,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 //============ Tests =========================================================
 


### PR DESCRIPTION
The `no_std` and `alloc` features lack of consistency. A user should be able to `StreamTarget::new_vec()` without `std` but `alloc` features, which is not the case at the moment. I would like to help, but there is a lot to change. I propose to go by step. Here a first PR that:

- Uses `impl core::error` instead  of `std::error`, and remove the `std` feature gate
- Replaced `extern crate std;` by a proper `cfg_attr` on `no_std`
- Removed duplicate `declare_error_trait!`

Refs: https://github.com/NLnetLabs/domain/issues/572, https://github.com/NLnetLabs/octseq/pull/68