### PR TITLE
Alloc + no_std: part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "octseq"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8a0b46f254482682d1e09d35af3e3e9cfec83e2617ebbfd9434c3d3bc8864e"
+checksum = "182eab3e1cd9cdc0ecf1ce3342d9844f3dc7d098f0694569bfdf327b612d69fd"
 dependencies = [
  "bytes",
  "heapless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ jiff           = { version = "0.2.1", default-features = false }
 arbitrary      = { version = "1.4.1", optional = true, features = ["derive"] }
 bumpalo        = { version = "3.12", optional = true }
 constant_time_eq = { version = "0.4.2", optional = true }
-octseq         = { version = "0.6.0", default-features = false }
+octseq         = { version = "0.6.1", default-features = false }
 rand           = { version = "0.10.1", optional = true }
 arc-swap       = { version = "1.7.0", optional = true }
 bytes          = { version = "1.2", optional = true, default-features = false }
@@ -57,7 +57,7 @@ proc-macro2    = { version = "1.0.69", optional = true } # Force proc-macro2 to 
 ring           = { version = "0.17.2", optional = true }
 rustversion    = { version = "1", optional = true }
 secrecy        = { version = "0.10", optional = true }
-serde          = { version = "1.0.130", optional = true, features = ["derive"] }
+serde          = { version = "1.0.130", optional = true, default-features = false, features = ["derive"] }
 siphasher      = { version = "1", optional = true }
 smallvec       = { version = "1.3", optional = true }
 tokio          = { version = "1.33", optional = true, features = ["io-util", "macros", "net", "time", "sync", "rt-multi-thread" ] }
@@ -70,15 +70,15 @@ tracing-subscriber = { version = "0.3.18", optional = true, features = ["env-fil
 default     = ["std", "rand"]
 
 # Support for libraries
-alloc       = ["jiff/alloc"]
+alloc       = ["jiff/alloc", "octseq/alloc", "serde?/alloc"]
 bumpalo     = ["dep:bumpalo", "std"]
 bytes       = ["dep:bytes", "octseq/bytes"]
 chrono      = ["dep:chrono"]
 heapless    = ["dep:heapless", "octseq/heapless"]
 rand        = ["dep:rand"]
-serde       = ["std", "dep:serde", "octseq/serde"]
+serde       = ["dep:serde", "octseq/serde"]
 smallvec    = ["dep:smallvec", "octseq/smallvec"]
-std         = ["alloc", "dep:hashbrown", "bumpalo?/std", "bytes?/std", "octseq/std", "jiff/std"]
+std         = ["alloc", "dep:hashbrown", "bumpalo?/std", "bytes?/std", "octseq/std", "jiff/std", "serde?/std"]
 tracing     = ["dep:log", "dep:tracing"]
 
 # Cryptographic backends


### PR DESCRIPTION
This part 2 is a bit bigger, but changes are small and still reviewable in my opinion. I can split if you want.

- Prevented `serde` to enable `std`, and in a more generic way made sure that `serde` and `std` are 2 separated things
- Bumped `octseq` to `0.6.1` to benefit from https://github.com/NLnetLabs/octseq/pull/68
- Replaced `std` gates by `alloc` ones, when applicable
- Used `core` and `alloc` instead of `std`, when applicable
- Fixed a typo in `src/base/header.rs` where `std` gate was used instead of `rand`

I mention that Claude Code helped me to find references and test. I reviewed every single line.

Refs: https://github.com/NLnetLabs/domain/issues/572 https://github.com/NLnetLabs/domain/pull/641 https://github.com/NLnetLabs/octseq/pull/68
