### PR TITLE
Implement missing core Error for ParseError

### DIFF
--- a/src/new/base/wire/parse.rs
+++ b/src/new/base/wire/parse.rs
@@ -581,6 +581,8 @@ impl ParseBytesInPlace for alloc::sync::Arc<[u8]> {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ParseError;
 
+impl core::error::Error for ParseError {}
+
 //--- Formatting
 
 impl fmt::Display for ParseError {


### PR DESCRIPTION
I noticed that `ParseError` does not implement `core::error::Error`, which prevents the error to be chained properly (for example with `thiserror`).