### PR TITLE
Fix typo in `src/resolv/stub/mod.rs`

### DIFF
--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -89,7 +89,7 @@ impl StubResolver {
         Self::from_conf(ResolvConf::default())
     }
 
-    /// Creates a new resolver using the given configuraiton.
+    /// Creates a new resolver using the given configuration.
     pub fn from_conf(conf: ResolvConf) -> Self {
         StubResolver {
             transport: None.into(),


### PR DESCRIPTION
I noticed a typo while reading the documentation.

This PR fixes the typo in `src/resolv/stub/mod.rs`.