### PR TITLE
Fix double reference warning suggested by clippy

### DIFF
--- a/src/rdata/svcb/params.rs
+++ b/src/rdata/svcb/params.rs
@@ -315,7 +315,7 @@ impl<Octs: AsRef<[u8]>> SvcParams<Octs> {
         }
 
         SvcParams::from_octets(builder.freeze()).map_err(|e| {
-            println!("error in params::from_octets = {}", &e.0);
+            println!("error in params::from_octets = {}", e.0);
             S::Error::custom("invalid SvcParams")
         })
     }


### PR DESCRIPTION
In clippy version 1.97.0 a new check was introduced `clippy::useless_borrows_in_formatting`.

It checks for macros like `format!()` which have arguments passed as a reference.
The reference is unnecessary because the arguments get passed as a reference anyways.

As far as I understand it; the first reference is in the `std::fmt`trait.

```rust
fn fmt(&self, f: &mut Formatter<'_>) -> Result;
```

`&self`is passed as a reference which makes any second reference in the macro redundant and hinders performance.

[Clippy Documentation](https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting)