### PR TITLE
Improve documentation with examples, clarifications and pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,30 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all -- --check
 
+  # Build Documentation
+  # ----------------
+  #
+  # Validate that the documentation builds without any issues.
+  build-doc:
+    name: Build documentation for validation
+    runs-on: ubuntu-latest
+    steps:
+
+    # Load the repository.
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Set up the Rust toolchain.
+    - name: Set up Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+        cache: false
+
+    # Do the actual formatting check.
+    - name: Build documentation for validation
+      run: cargo doc --all-features
+
   # Determine MSRV
   # --------------
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,11 @@ jobs:
         cache: false
 
     # Do the actual formatting check.
+    # `-D warnings` promotes all warnings to errors which leads to failure
     - name: Build documentation for validation
-      run: cargo doc --all-features
+      run: |
+        RUSTDOCFLAGS="-D warnings" \
+          cargo doc --no-deps --all-features
 
   # Determine MSRV
   # --------------

--- a/src/base/iana/sshfp.rs
+++ b/src/base/iana/sshfp.rs
@@ -14,12 +14,12 @@ int_enum! {
     /// SSHFP fingerprint type.
     ///
     /// This type selects the digest algorithm used for the fingerprint in the
-    /// [SSHFP] record.
+    /// [`Sshfp`] record.
     ///
     /// For the currently registered values see the [IANA registration]. This
     /// type is complete as of 2025-09-04.
     ///
-    /// [SSHFP]: ../../../rdata/sshfp/index.html
+    /// [`Sshfp`]: crate::rdata::sshfp::Sshfp
     /// [IANA registration]: https://www.iana.org/assignments/dns-sshfp-rr-parameters/dns-sshfp-rr-parameters.xhtml#dns-sshfp-rr-parameters-2
     =>
     SshfpType, u8;
@@ -27,9 +27,13 @@ int_enum! {
     (RESERVED => 0, "Reserved")
 
     /// Specified that the SHA-1 algorithm is used. [RFC4255]
+    ///
+    /// [RFC4255]: <https://tools.ietf.org/html/rfc4255>
     (SHA1 => 1, "SHA-1")
 
     /// Specified that the SHA-256 algorithm is used. [RFC6594]
+    ///
+    /// [RFC6594]: <https://tools.ietf.org/html/rfc6594>
     (SHA256 => 2, "SHA-256")
 
 }
@@ -42,32 +46,44 @@ int_enum_zonefile_fmt_decimal!(SshfpType, "fingerprint type");
 int_enum! {
     /// SSHFP public key algorithms.
     ///
-    /// This type selects the algorithm of the public key associated with the [SSHFP].
+    /// This type selects the algorithm of the public key associated with the [`Sshfp`].
     ///
     /// For the currently registered values see the [IANA registration]. This
     /// type is complete as of 2025-09-04.
     ///
-    /// [SSHFP]: ../../../rdata/sshfp/index.html
+    /// [`Sshfp`]: crate::rdata::sshfp::Sshfp
     /// [IANA registration]: https://www.iana.org/assignments/dns-sshfp-rr-parameters/dns-sshfp-rr-parameters.xhtml#dns-sshfp-rr-parameters-1
     =>
     SshfpAlgorithm, u8;
 
     /// Specified that the Reserved algorithm is used. [RFC4255]
+    ///
+    /// [RFC4255]: <https://tools.ietf.org/html/rfc4255>
     (RESERVED => 0, "Reserved")
 
     /// Specified that the RSA algorithm is used. [RFC4255]
+    ///
+    /// [RFC4255]: <https://tools.ietf.org/html/rfc4255>
     (RSA => 1, "RSA")
 
     /// Specified that the DSA algorithm is used. [RFC4255]
+    ///
+    /// [RFC4255]: <https://tools.ietf.org/html/rfc4255>
     (DSA => 2, "DSA")
 
     /// Specified that the ECDSA algorithm is used. [RFC6594]
+    ///
+    /// [RFC6594]: <https://tools.ietf.org/html/rfc6594>
     (ECDSA => 3, "ECDSA")
 
     /// Specified that the Ed25519 algorithm is used. [RFC7479]
+    ///
+    /// [RFC7479]: <https://tools.ietf.org/html/rfc7479>
     (ED25519 => 4, "Ed25519")
 
     /// Specified that the Ed448 algorithm is used. [RFC8709]
+    ///
+    /// [RFC8709]: <https://tools.ietf.org/html/rfc8709>
     (ED448 => 6, "Ed448")
 }
 

--- a/src/base/iana/sshfp.rs
+++ b/src/base/iana/sshfp.rs
@@ -28,12 +28,12 @@ int_enum! {
 
     /// Specified that the SHA-1 algorithm is used. [RFC4255]
     ///
-    /// [RFC4255]: <https://tools.ietf.org/html/rfc4255>
+    /// [RFC4255]: https://tools.ietf.org/html/rfc4255
     (SHA1 => 1, "SHA-1")
 
     /// Specified that the SHA-256 algorithm is used. [RFC6594]
     ///
-    /// [RFC6594]: <https://tools.ietf.org/html/rfc6594>
+    /// [RFC6594]: https://tools.ietf.org/html/rfc6594
     (SHA256 => 2, "SHA-256")
 
 }
@@ -58,32 +58,32 @@ int_enum! {
 
     /// Specified that the Reserved algorithm is used. [RFC4255]
     ///
-    /// [RFC4255]: <https://tools.ietf.org/html/rfc4255>
+    /// [RFC4255]: https://tools.ietf.org/html/rfc4255
     (RESERVED => 0, "Reserved")
 
     /// Specified that the RSA algorithm is used. [RFC4255]
     ///
-    /// [RFC4255]: <https://tools.ietf.org/html/rfc4255>
+    /// [RFC4255]: https://tools.ietf.org/html/rfc4255
     (RSA => 1, "RSA")
 
     /// Specified that the DSA algorithm is used. [RFC4255]
     ///
-    /// [RFC4255]: <https://tools.ietf.org/html/rfc4255>
+    /// [RFC4255]: https://tools.ietf.org/html/rfc4255
     (DSA => 2, "DSA")
 
     /// Specified that the ECDSA algorithm is used. [RFC6594]
     ///
-    /// [RFC6594]: <https://tools.ietf.org/html/rfc6594>
+    /// [RFC6594]: https://tools.ietf.org/html/rfc6594
     (ECDSA => 3, "ECDSA")
 
     /// Specified that the Ed25519 algorithm is used. [RFC7479]
     ///
-    /// [RFC7479]: <https://tools.ietf.org/html/rfc7479>
+    /// [RFC7479]: https://tools.ietf.org/html/rfc7479
     (ED25519 => 4, "Ed25519")
 
     /// Specified that the Ed448 algorithm is used. [RFC8709]
     ///
-    /// [RFC8709]: <https://tools.ietf.org/html/rfc8709>
+    /// [RFC8709]: https://tools.ietf.org/html/rfc8709
     (ED448 => 6, "Ed448")
 }
 

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -1221,9 +1221,7 @@ where
 /// error but can continue with the next record. If parsing the entire record
 /// fails the item will be an error and subsequent attempts to continue will
 /// also produce errors. This case can be distinguished from an error while
-/// parsing the record data by [`next_section`] returning an error, too.
-///
-/// [`next_section`]: Self::next_section
+/// parsing the record data by [`Self::next_section()`] returning an error, too.
 #[derive(Debug)]
 pub struct AnyRecordIter<'a, Octs: ?Sized, Data> {
     section: RecordSection<'a, Octs>,

--- a/src/base/message_builder.rs
+++ b/src/base/message_builder.rs
@@ -1813,9 +1813,9 @@ impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
 
 /// A builder target for sending messages on stream transports.
 ///
-/// TODO: Rename this type and adjust the doc comments as it is usable both
-/// for datagram AND stream transports via [`as_dgram_slice`] and
-/// [`as_stream_slice`].
+/// TODO: Rename this type and adjust the doc comments as it is usable both for
+/// datagram AND stream transports via [`Self::as_dgram_slice()`] and
+/// [`Self::as_stream_slice()`].
 ///
 /// When messages are sent over stream-oriented transports such as TCP, a DNS
 /// message is preceded by a 16 bit length value in order to determine the end
@@ -1827,9 +1827,6 @@ impl<'a, Target: Composer + ?Sized> OptBuilder<'a, Target> {
 /// Because the length is 16 bits long, the assembled message can be at most
 /// 65536 octets long, independently of the maximum length the underlying
 /// builder allows.
-///
-/// [`as_dgram_slice`]: Self::as_dgram_slice
-/// [`as_stream_slice`]: Self::as_stream_slice
 #[derive(Clone, Debug, Default)]
 pub struct StreamTarget<Target> {
     /// The underlying octets builder.

--- a/src/base/name/mod.rs
+++ b/src/base/name/mod.rs
@@ -89,7 +89,7 @@
 //! labels.
 //!
 //! [`FromStr`]: std::str::FromStr
-//! [_punycode_]: <https://datatracker.ietf.org/doc/html/rfc3492>
+//! [_punycode_]: https://datatracker.ietf.org/doc/html/rfc3492
 
 pub use self::absolute::{Name, NameError};
 pub use self::builder::{

--- a/src/base/zonefile_fmt.rs
+++ b/src/base/zonefile_fmt.rs
@@ -82,7 +82,7 @@ pub trait FormatWriter: Sized {
 
     /// End a block of grouped tokens
     ///
-    /// This might push `'('` to the zonefile, but may be ignored by the
+    /// This might push `')'` to the zonefile, but may be ignored by the
     /// [`FormatWriter`].
     fn end_block(&mut self) -> Result;
 

--- a/src/base/zonefile_fmt.rs
+++ b/src/base/zonefile_fmt.rs
@@ -77,13 +77,13 @@ pub trait FormatWriter: Sized {
     /// Start a block of grouped tokens
     ///
     /// This might push `'('` to the zonefile, but may be ignored by the
-    /// `PresentationWriter`.
+    /// [`FormatWriter`].
     fn begin_block(&mut self) -> Result;
 
     /// End a block of grouped tokens
     ///
     /// This might push `'('` to the zonefile, but may be ignored by the
-    /// `PresentationWriter`.
+    /// [`FormatWriter`].
     fn end_block(&mut self) -> Result;
 
     /// Write a comment
@@ -283,8 +283,7 @@ impl<W: fmt::Write> fmt::Write for MultiLineWriter<W> {
     }
 }
 
-// TODO including all other PresentationWriter occurrences
-/// A more structured wrapper around a [`PresentationWriter`]
+/// A more structured wrapper around a [`FormatWriter`]
 pub trait Formatter: FormatWriter {
     /// Start a sequence of grouped tokens
     ///

--- a/src/base/zonefile_fmt.rs
+++ b/src/base/zonefile_fmt.rs
@@ -283,6 +283,7 @@ impl<W: fmt::Write> fmt::Write for MultiLineWriter<W> {
     }
 }
 
+// TODO including all other PresentationWriter occurrences
 /// A more structured wrapper around a [`PresentationWriter`]
 pub trait Formatter: FormatWriter {
     /// Start a sequence of grouped tokens

--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -175,9 +175,7 @@ pub trait SignRaw {
     /// The public key.
     ///
     /// This can be used to verify produced signatures.  It must use the same
-    /// algorithm as returned by [`algorithm()`].
-    ///
-    /// [`algorithm()`]: Self::algorithm()
+    /// algorithm as returned by [`Self::algorithm()`].
     fn dnskey(&self) -> Dnskey<Vec<u8>>;
 
     /// Sign the given bytes.

--- a/src/dnssec/sign/denial/config.rs
+++ b/src/dnssec/sign/denial/config.rs
@@ -31,14 +31,14 @@ where
     /// Note: While zones can have multiple NSEC3 chains, only the configuraton
     /// for a single chain can be expressed using this type.
     ///
-    /// https://datatracker.ietf.org/doc/html/rfc5155#section-7.3
+    /// <https://datatracker.ietf.org/doc/html/rfc5155#section-7.3>
     /// 7.3.  Secondary Servers
     ///   ...
     ///   "If there are multiple NSEC3PARAM RRs present, there are multiple
     ///    valid NSEC3 chains present.  The server must choose one of them,
     ///    but may use any criteria to do so."
     ///
-    /// https://datatracker.ietf.org/doc/html/rfc5155#section-12.1.3
+    /// <https://datatracker.ietf.org/doc/html/rfc5155#section-12.1.3>
     /// 12.1.3.  Transitioning to a New Hash Algorithm
     ///   "Although the NSEC3 and NSEC3PARAM RR formats include a hash
     ///    algorithm parameter, this document does not define a particular

--- a/src/dnssec/sign/denial/nsec3.rs
+++ b/src/dnssec/sign/denial/nsec3.rs
@@ -141,8 +141,8 @@ where
 /// This function may panic if the input records are not sorted in DNSSEC
 /// canonical order (see [`CanonicalOrd`]).
 ///
-/// [RFC 9077]: <https://www.rfc-editor.org/rfc/rfc9077.html>
-/// [RFC 9276]: <https://www.rfc-editor.org/rfc/rfc9276.html>
+/// [RFC 9077]: https://www.rfc-editor.org/rfc/rfc9077.html
+/// [RFC 9276]: https://www.rfc-editor.org/rfc/rfc9276.html
 // TODO: Add mutable iterator based variant.
 // TODO: Get rid of &mut for GenerateNsec3Config.
 pub fn generate_nsec3s<N, Octs, Sort>(

--- a/src/dnssec/sign/denial/nsec3.rs
+++ b/src/dnssec/sign/denial/nsec3.rs
@@ -55,7 +55,7 @@ where
     ///
     /// This is possible because RFC 5155 section 7.1 says:
     ///
-    /// https://www.rfc-editor.org/rfc/rfc5155.html#section-7.1
+    /// <https://www.rfc-editor.org/rfc/rfc5155.html#section-7.1>
     /// 7.1.  Zone Signing
     /// ...
     ///   "If Opt-Out is being used, owner names of unsigned delegations MAY
@@ -141,8 +141,8 @@ where
 /// This function may panic if the input records are not sorted in DNSSEC
 /// canonical order (see [`CanonicalOrd`]).
 ///
-/// [RFC 9077]: https://www.rfc-editor.org/rfc/rfc9077.html
-/// [RFC 9276]: https://www.rfc-editor.org/rfc/rfc9276.html
+/// [RFC 9077]: <https://www.rfc-editor.org/rfc/rfc9077.html>
+/// [RFC 9276]: <https://www.rfc-editor.org/rfc/rfc9276.html>
 // TODO: Add mutable iterator based variant.
 // TODO: Get rid of &mut for GenerateNsec3Config.
 pub fn generate_nsec3s<N, Octs, Sort>(

--- a/src/dnssec/sign/error.rs
+++ b/src/dnssec/sign/error.rs
@@ -26,7 +26,7 @@ pub enum SigningError {
 
     /// TODO
     ///
-    /// https://www.rfc-editor.org/rfc/rfc4035.html#section-2.2
+    /// <https://www.rfc-editor.org/rfc/rfc4035.html#section-2.2>
     /// 2.2.  Including RRSIG RRs in a Zone
     ///   ...
     ///   "An RRSIG RR itself MUST NOT be signed"

--- a/src/dnssec/sign/mod.rs
+++ b/src/dnssec/sign/mod.rs
@@ -71,7 +71,10 @@
 //! - Signing of unsorted zones, record collections must be sorted according
 //!   to [`CanonicalOrd`].
 //! - Signing of
-#![cfg_attr(feature = "unstable-zonetree", doc = "[`zonetree::Zone`](crate::zonetree::Zone)")]
+#![cfg_attr(
+    feature = "unstable-zonetree",
+    doc = "[`zonetree::Zone`](crate::zonetree::Zone)"
+)]
 #![cfg_attr(not(feature = "unstable-zonetree"), doc = "`Zone`")]
 //!   types or via an [`core::iter::Iterator`] over
 //!   [`Record`]s, only signing of slices is supported.

--- a/src/dnssec/sign/mod.rs
+++ b/src/dnssec/sign/mod.rs
@@ -71,7 +71,7 @@
 //! - Signing of unsorted zones, record collections must be sorted according
 //!   to [`CanonicalOrd`].
 //! - Signing of
-#![cfg_attr(feature = "unstable-zonetree", doc = "[`crate::zonetree::Zone`]")]
+#![cfg_attr(feature = "unstable-zonetree", doc = "[`zonetree::Zone`](crate::zonetree::Zone)")]
 #![cfg_attr(not(feature = "unstable-zonetree"), doc = "`Zone`")]
 //!   types or via an [`core::iter::Iterator`] over
 //!   [`Record`]s, only signing of slices is supported.

--- a/src/dnssec/sign/mod.rs
+++ b/src/dnssec/sign/mod.rs
@@ -71,7 +71,7 @@
 //! - Signing of unsorted zones, record collections must be sorted according
 //!   to [`CanonicalOrd`].
 //! - Signing of
-#![cfg_attr(feature = "unstable-zonetree", doc = "[`Zone`]")]
+#![cfg_attr(feature = "unstable-zonetree", doc = "[`crate::zonetree::Zone`]")]
 #![cfg_attr(not(feature = "unstable-zonetree"), doc = "`Zone`")]
 //!   types or via an [`core::iter::Iterator`] over
 //!   [`Record`]s, only signing of slices is supported.
@@ -81,12 +81,11 @@
 //!   older DSA or RSASHA1 algorithms (which is anyway only possible at
 //!   present if you bring your own cryptography).
 //!
-//! [`common`]: crate::sign::crypto::common
+//! [`common`]: crate::crypto::common
 //! [`keyset`]: crate::dnssec::sign::keys::keyset
-//! [`openssl`]: crate::sign::crypto::openssl
-//! [`ring`]: crate::sign::crypto::ring
+//! [`openssl`]: crate::crypto::openssl
+//! [`ring`]: crate::crypto::ring
 //! [`sign_rrset()`]: crate::dnssec::sign::signatures::rrsigs::sign_rrset
-//! [`DnssecSigningKey`]: crate::sign::keys::DnssecSigningKey
 //! [`Record`]: crate::base::record::Record
 //! [RFC 5155]: https://rfc-editor.org/rfc/rfc5155
 //! [RFC 6781 section 3.1]: https://rfc-editor.org/rfc/rfc6781#section-3.1
@@ -95,14 +94,13 @@
 //! [RFC 9364]: https://rfc-editor.org/rfc/rfc9364
 //! [RFC 9499 section 10]:
 //!     https://www.rfc-editor.org/rfc/rfc9499.html#section-10
-//! [`GenerateParams`]: crate::sign::crypto::common::GenerateParams
-//! [`KeyPair`]: crate::sign::crypto::common::KeyPair
+//! [`GenerateParams`]: crate::crypto::sign::GenerateParams
+//! [`KeyPair`]: crate::crypto::sign::KeyPair
 //! [`Signable`]: crate::dnssec::sign::traits::Signable
 //! [`SignableZone`]: crate::dnssec::sign::traits::SignableZone
 //! [`SignableZoneInPlace`]: crate::dnssec::sign::traits::SignableZoneInPlace
-//! [`SigningKey`]: crate::sign::keys::SigningKey
-//! [`SortedRecords`]: crate::sign::SortedRecords
-//! [`Zone`]: crate::zonetree::Zone
+//! [`SigningKey`]: crate::dnssec::sign::keys::signingkey::SigningKey
+//! [`SortedRecords`]: crate::dnssec::sign::records::SortedRecords
 
 #![cfg(feature = "unstable-sign")]
 // NOTE: Users should not interact with the `unstable-crypto-backend` feature
@@ -383,6 +381,7 @@ where
 /// [RFC 5155 section 2 Backwards Compatibility]:
 ///     https://www.rfc-editor.org/rfc/rfc5155.html#section-2
 /// [`SignableZoneInPlace`]: crate::dnssec::sign::traits::SignableZoneInPlace
+/// [`sign_rrset()`]: crate::dnssec::sign::signatures::rrsigs::sign_rrset
 /// [`SortedRecords`]: crate::dnssec::sign::records::SortedRecords
 /// [`Zone`]: crate::zonetree::Zone
 pub fn sign_zone<N, Octs, S, Inner, Sort, T>(

--- a/src/dnssec/sign/records.rs
+++ b/src/dnssec/sign/records.rs
@@ -45,7 +45,7 @@ pub trait Sorter {
 /// The default [`Sorter`] implementation used by [`SortedRecords`].
 ///
 /// The current implementation is the single threaded sort provided by Rust
-/// [`std::vec::Vec.sort_by()`].
+/// [`slice::sort_by()`].
 pub struct DefaultSorter;
 
 impl Sorter for DefaultSorter {

--- a/src/net/server/dgram.rs
+++ b/src/net/server/dgram.rs
@@ -318,9 +318,7 @@ where
     ///   responses.
     /// - A [`Config`] with settings to control the server behaviour.
     ///
-    /// Invoke [`run`] to receive and process incoming messages.
-    ///
-    /// [`run`]: Self::run()
+    /// Invoke [`Self::run()`] to receive and process incoming messages.
     #[must_use]
     pub fn with_config(
         sock: Sock,
@@ -388,9 +386,7 @@ where
     ///
     /// # Drop behaviour
     ///
-    /// When dropped [`shutdown`] will be invoked.
-    ///
-    /// [`shutdown`]: Self::shutdown
+    /// When dropped [`Self::shutdown()`] will be invoked.
     pub async fn run(&self) {
         if let Err(err) = self.run_until_error().await {
             error!("Server stopped due to error: {err}");

--- a/src/net/server/invoker.rs
+++ b/src/net/server/invoker.rs
@@ -49,6 +49,8 @@ pub enum InvokerStatus {
 ///
 /// Also handles [`ServiceFeedback`] by invoking fn impls on the trait
 /// implementing type.
+///
+/// [`ServiceError`]: domain::net::server::service::ServiceError
 pub trait ServiceInvoker<RequestOctets, Svc, RequestMeta, EnqueueMeta>
 where
     RequestOctets: Octets + Send + Sync + 'static,
@@ -60,13 +62,17 @@ where
     ///
     /// Dispatches the given request to the given [`Service`] impl and
     /// processes the stream of resulting responses, passing them to the trait
-    /// impl'd [`enqueue_response`] function with the provided metadata for
-    /// writing back to the network. until no more responses exist or the
-    /// trait impl'd [`status`] function reports that the state is
+    /// impl'd [`enqueue_response()`] function with the provided metadata
+    /// for writing back to the network. until no more responses exist or the
+    /// trait impl'd [`status()`] function reports that the state is
     /// [`InvokerStatus::Aborting`].
     ///
     /// On [`ServiceFeedback::Reconfigure`] passes the new configuration data
-    /// to the trait impl'd [`reconfugure`] function.
+    /// to the trait impl'd [`reconfigure()`] function.
+    ///
+    /// [`enqueue_response()`]: Self::enqueue_response()
+    /// [`status()`]: Self::status()
+    /// [`reconfigure()`]: Self::reconfigure()
     fn dispatch(
         &mut self,
         request: Request<RequestOctets, RequestMeta>,
@@ -112,12 +118,14 @@ where
 
     /// Processing a single response stream item.
     ///
-    /// Calls [`process_feedback`] if necessary. Extracts any response for
+    /// Calls [`Self::process_feedback()`] if necessary. Extracts any response for
     /// further processing by the caller.
     ///
-    /// On [`ServiceError`] calls the trait impl'd [`set_status`] function
+    /// On [`ServiceError`] calls the trait impl'd [`Self::set_status()`] function
     /// with `InvokerStatus::Aborting` and returns a generated error response
     /// instead of the response from the service.
+    ///
+    /// [`ServiceError`]: domain::net::server::service::ServiceError
     fn process_response_stream_item(
         &mut self,
         stream_item: ServiceResult<Svc::Target>,
@@ -141,14 +149,14 @@ where
 
     //// Acts on [`ServiceFeedback`] received from the [`Service`].
     ///
-    /// Calls the trait impl'd [`reconfigure`] on
+    /// Calls the trait impl'd [`Self::reconfigure`] on
     /// [`ServiceFeedback::Reconfigure`].
     ///
-    /// Calls the trait impl'd [`set_status`] on
+    /// Calls the trait impl'd [`Self::set_status()`] on
     /// [`ServiceFeedback::BeginTransaction`] with
     /// [`InvokerStatus::InTransaction`].
     ///
-    /// Calls the trait impl'd [`set_status`] on
+    /// Calls the trait impl'd [`Self::set_status()`] on
     /// [`ServiceFeedback::EndTransaction`] with [`InvokerStatus::Normal`].
     fn process_feedback(&mut self, feedback: ServiceFeedback) {
         match feedback {

--- a/src/net/server/invoker.rs
+++ b/src/net/server/invoker.rs
@@ -62,17 +62,13 @@ where
     ///
     /// Dispatches the given request to the given [`Service`] impl and
     /// processes the stream of resulting responses, passing them to the trait
-    /// impl'd [`enqueue_response()`] function with the provided metadata
+    /// impl'd [`Self::enqueue_response()`] function with the provided metadata
     /// for writing back to the network. until no more responses exist or the
-    /// trait impl'd [`status()`] function reports that the state is
+    /// trait impl'd [`Self::status()`] function reports that the state is
     /// [`InvokerStatus::Aborting`].
     ///
     /// On [`ServiceFeedback::Reconfigure`] passes the new configuration data
-    /// to the trait impl'd [`reconfigure()`] function.
-    ///
-    /// [`enqueue_response()`]: Self::enqueue_response()
-    /// [`status()`]: Self::status()
-    /// [`reconfigure()`]: Self::reconfigure()
+    /// to the trait impl'd [`Self::reconfigure()`] function.
     fn dispatch(
         &mut self,
         request: Request<RequestOctets, RequestMeta>,
@@ -118,16 +114,14 @@ where
 
     /// Processing a single response stream item.
     ///
-    /// Calls [`process_feedback()`] if necessary. Extracts any response for
-    /// further processing by the caller.
+    /// Calls [`Self::process_feedback()`] if necessary. Extracts any response
+    /// for further processing by the caller.
     ///
-    /// On [`ServiceError`] calls the trait impl'd [`set_status()`] function
-    /// with `InvokerStatus::Aborting` and returns a generated error response
-    /// instead of the response from the service.
+    /// On [`ServiceError`] calls the trait impl'd [`Self::set_status()`]
+    /// function with `InvokerStatus::Aborting` and returns a generated error
+    /// response instead of the response from the service.
     ///
     /// [`ServiceError`]: domain::net::server::service::ServiceError
-    /// [`process_feedback()`]: Self::process_feedback()
-    /// [`set_status()`]: Self::set_status()
     fn process_response_stream_item(
         &mut self,
         stream_item: ServiceResult<Svc::Target>,
@@ -151,18 +145,15 @@ where
 
     //// Acts on [`ServiceFeedback`] received from the [`Service`].
     ///
-    /// Calls the trait impl'd [`reconfigure()`] on
+    /// Calls the trait impl'd [`Self::reconfigure()`] on
     /// [`ServiceFeedback::Reconfigure`].
     ///
-    /// Calls the trait impl'd [`set_status()`] on
+    /// Calls the trait impl'd [`Self::set_status()`] on
     /// [`ServiceFeedback::BeginTransaction`] with
     /// [`InvokerStatus::InTransaction`].
     ///
     /// Calls the trait impl'd [`Self::set_status()`] on
     /// [`ServiceFeedback::EndTransaction`] with [`InvokerStatus::Normal`].
-    ///
-    /// [`reconfigure()`]: Self::reconfigure()
-    /// [`set_status()`]: Self::set_status()
     fn process_feedback(&mut self, feedback: ServiceFeedback) {
         match feedback {
             ServiceFeedback::Reconfigure { idle_timeout } => {

--- a/src/net/server/invoker.rs
+++ b/src/net/server/invoker.rs
@@ -118,14 +118,16 @@ where
 
     /// Processing a single response stream item.
     ///
-    /// Calls [`Self::process_feedback()`] if necessary. Extracts any response for
+    /// Calls [`process_feedback()`] if necessary. Extracts any response for
     /// further processing by the caller.
     ///
-    /// On [`ServiceError`] calls the trait impl'd [`Self::set_status()`] function
+    /// On [`ServiceError`] calls the trait impl'd [`set_status()`] function
     /// with `InvokerStatus::Aborting` and returns a generated error response
     /// instead of the response from the service.
     ///
     /// [`ServiceError`]: domain::net::server::service::ServiceError
+    /// [`process_feedback()`]: Self::process_feedback()
+    /// [`set_status()`]: Self::set_status()
     fn process_response_stream_item(
         &mut self,
         stream_item: ServiceResult<Svc::Target>,
@@ -149,15 +151,18 @@ where
 
     //// Acts on [`ServiceFeedback`] received from the [`Service`].
     ///
-    /// Calls the trait impl'd [`Self::reconfigure`] on
+    /// Calls the trait impl'd [`reconfigure()`] on
     /// [`ServiceFeedback::Reconfigure`].
     ///
-    /// Calls the trait impl'd [`Self::set_status()`] on
+    /// Calls the trait impl'd [`set_status()`] on
     /// [`ServiceFeedback::BeginTransaction`] with
     /// [`InvokerStatus::InTransaction`].
     ///
     /// Calls the trait impl'd [`Self::set_status()`] on
     /// [`ServiceFeedback::EndTransaction`] with [`InvokerStatus::Normal`].
+    ///
+    /// [`reconfigure()`]: Self::reconfigure()
+    /// [`set_status()`]: Self::set_status()
     fn process_feedback(&mut self, feedback: ServiceFeedback) {
         match feedback {
             ServiceFeedback::Reconfigure { idle_timeout } => {

--- a/src/net/server/middleware/stream.rs
+++ b/src/net/server/middleware/stream.rs
@@ -1,7 +1,7 @@
 //! Support for working with response streams needed by all middleware.
 //!
 //! Like application services all middleware implementations implement the
-//! [`Service`] trait and so return a [`futures::stream::Stream`] of
+//! [`Service`] trait and so return a [`futures_util::stream::Stream`] of
 //! responses.
 //!
 //! A middleware [`Service`] may respond immediately, or pass the request to
@@ -23,7 +23,6 @@
 //! this module are intended to simplify and standardize the way that
 //! middleware implementations handle these cases.
 //!
-//! [`futures::stream::Stream`]: futures::stream::Stream
 //! [`Service`]: crate::net::server::service::Service
 use core::future::Future;
 use core::ops::DerefMut;
@@ -40,7 +39,7 @@ use crate::net::server::message::Request;
 
 //------------ MiddlewareStream ----------------------------------------------
 
-/// A [`futures::stream::Stream`] of middleware responses.
+/// A [`futures_util::stream::Stream`] of middleware responses.
 ///
 /// A middleware [`Service`] must be able to respond with different types of
 /// response streams depending on the received request or on post-processing
@@ -51,7 +50,6 @@ use crate::net::server::message::Request;
 /// [`MiddlewareStream`] enum type which is able to represent the different
 /// variants of response stream that may result from middleware processing:
 ///
-/// [`futures::stream::Stream`]: futures::stream::Stream
 /// [`Service`]: crate::net::server::service::Service
 pub enum MiddlewareStream<
     IdentityFuture,
@@ -159,7 +157,7 @@ type PostprocessingStreamCallback<
 
 //------------ PostprocessingStream ------------------------------------------
 
-/// A [`futures::stream::Stream`] that post-processes responses using a
+/// A [`futures_util::stream::Stream`] that post-processes responses using a
 /// provided callback.
 ///
 /// To post-process an upper service response stream one must first resolve
@@ -170,8 +168,6 @@ type PostprocessingStreamCallback<
 /// This type takes care of these details for you so that you can focus on
 /// defining the transformation logic via a user supplied callback function
 /// which will be invoked on each received response stream item.
-///
-/// [`futures::stream::Stream`]: futures::stream::Stream
 pub struct PostprocessingStream<
     RequestOctets,
     Future,

--- a/src/net/server/middleware/xfr/data_provider.rs
+++ b/src/net/server/middleware/xfr/data_provider.rs
@@ -48,7 +48,7 @@ pub struct XfrData<Diff> {
 
     /// Should XFR be done in RFC 5936 backward compatible mode?
     ///
-    /// See: https://www.rfc-editor.org/rfc/rfc5936#section-7
+    /// See: <https://www.rfc-editor.org/rfc/rfc5936#section-7>
     compatibility_mode: bool,
 }
 

--- a/src/net/server/middleware/xfr/mod.rs
+++ b/src/net/server/middleware/xfr/mod.rs
@@ -39,11 +39,10 @@
 //! [RFC 5936]: https://www.rfc-editor.org/info/rfc5936
 //! [RFC 1995]: https://www.rfc-editor.org/info/rfc1995
 //! [`Request::metadata()`]: crate::net::server::message::Request::metadata
-//! [`TsigMiddlewareSvc`]:
-//!     crate::net::server::middleware::tsig::TsigMiddlewareSvc
-//! [`XfrDataProvider`]: super::data_provider::XfrDataProvider
-//! [`Zone`]: crate::net::zonetree::Zone
-//! [`ZoneTree`]: crate::net::zonetree::ZoneTree
+//! [`TsigMiddlewareSvc`]: super::tsig::TsigMiddlewareSvc
+//! [`XfrDataProvider`]: super::xfr::data_provider::XfrDataProvider
+//! [`Zone`]: crate::zonetree::Zone
+//! [`ZoneTree`]: crate::zonetree::ZoneTree
 mod axfr;
 mod batcher;
 mod ixfr;

--- a/src/net/server/service.rs
+++ b/src/net/server/service.rs
@@ -25,7 +25,7 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 /// For an overview of how services fit into the total flow of request and
 /// response handling see the [`net::server`] module documentation.
 ///
-/// Each `Service` implementation defines a [`call`] function which takes a
+/// Each `Service` implementation defines a [`Self::call()`] function which takes a
 /// [`Request`] DNS request as input and returns a future that yields a stream
 /// of one or more items each of which is either a [`CallResult`] or
 /// [`ServiceError`].
@@ -36,7 +36,7 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 /// # Usage
 ///
 /// You can either implement the [`Service`] trait on a struct or use the
-/// helper function [`service_fn`] to turn a function into a [`Service`].
+/// helper function [`service_fn()`] to turn a function into a [`Service`].
 ///
 /// # Implementing the `Service` trait on a `struct`
 ///
@@ -163,8 +163,7 @@ pub type ServiceResult<Target> = Result<CallResult<Target>, ServiceError>;
 /// [`StreamServer`]: crate::net::server::stream::StreamServer
 /// [middleware]: crate::net::server::middleware
 /// [`net::server`]: crate::net::server
-/// [`call`]: Self::call()
-/// [`service_fn`]: crate::net::server::util::service_fn()
+/// [`service_fn()`]: crate::net::server::util::service_fn()
 pub trait Service<
     RequestOctets: AsRef<[u8]> + Send + Sync,
     RequestMeta: Clone + Default,

--- a/src/net/server/stream.rs
+++ b/src/net/server/stream.rs
@@ -422,9 +422,7 @@ where
     ///
     /// # Drop behaviour
     ///
-    /// When dropped [`shutdown`] will be invoked.
-    ///
-    /// [`shutdown`]: Self::shutdown
+    /// When dropped [`Self::shutdown()`] will be invoked.
     pub async fn run(&self)
     where
         Buf: 'static,

--- a/src/new/base/name/compressor.rs
+++ b/src/new/base/name/compressor.rs
@@ -98,8 +98,11 @@ impl NameCompressor {
 
     /// Compress a [`RevName`].
     ///
-    /// This is a low-level function; use [`RevName::build_in_message()`] to
+    /// This is a low-level function; use [`BuildInMessage::build_in_message()`] to
     /// write a [`RevName`] into a DNS message.
+    ///
+    /// [`BuildInMessage::build_in_message()`]:
+    ///     crate::new::base::build::BuildInMessage::build_in_message()
     ///
     /// Given the contents of the DNS message, determine how to compress the
     /// given domain name. If a suitable compression for the name could be
@@ -109,7 +112,7 @@ impl NameCompressor {
     /// The contents slice should begin immediately after the 12-byte message
     /// header. It must end at the position the name will be inserted. It is
     /// assumed that the domain names inserted in these contents still exist
-    /// from previous calls to [`compress_name()`] and related methods. If
+    /// from previous calls to [`Self::compress_name()`] and related methods. If
     /// this is not true, panics or silently invalid results may occur.
     ///
     /// The compressor's state will be updated to assume the provided name was
@@ -251,8 +254,11 @@ impl NameCompressor {
 
     /// Compress a [`Name`].
     ///
-    /// This is a low-level function; use [`Name::build_in_message()`] to
+    /// This is a low-level function; use [`BuildInMessage::build_in_message()`] to
     /// write a [`Name`] into a DNS message.
+    ///
+    /// [`BuildInMessage::build_in_message()`]:
+    ///     domain::new::base::build::BuildInMessage::build_in_message()
     ///
     /// Given the contents of the DNS message, determine how to compress the
     /// given domain name. If a suitable compression for the name could be
@@ -262,7 +268,7 @@ impl NameCompressor {
     /// The contents slice should begin immediately after the 12-byte message
     /// header. It must end at the position the name will be inserted. It is
     /// assumed that the domain names inserted in these contents still exist
-    /// from previous calls to [`compress_name()`] and related methods. If
+    /// from previous calls to [`Self::compress_name()`] and related methods. If
     /// this is not true, panics or silently invalid results may occur.
     ///
     /// The compressor's state will be updated to assume the provided name was

--- a/src/new/base/name/compressor.rs
+++ b/src/new/base/name/compressor.rs
@@ -268,11 +268,13 @@ impl NameCompressor {
     /// The contents slice should begin immediately after the 12-byte message
     /// header. It must end at the position the name will be inserted. It is
     /// assumed that the domain names inserted in these contents still exist
-    /// from previous calls to [`Self::compress_name()`] and related methods. If
-    /// this is not true, panics or silently invalid results may occur.
+    /// from previous calls to [`compress_name()`] and related methods. If this
+    /// is not true, panics or silently invalid results may occur.
     ///
     /// The compressor's state will be updated to assume the provided name was
     /// inserted into the message.
+    ///
+    /// [`compress_name()`]: Self::compress_name()
     pub fn compress_name<'n>(
         &mut self,
         contents: &[u8],

--- a/src/new/base/name/compressor.rs
+++ b/src/new/base/name/compressor.rs
@@ -258,7 +258,7 @@ impl NameCompressor {
     /// write a [`Name`] into a DNS message.
     ///
     /// [`BuildInMessage::build_in_message()`]:
-    ///     domain::new::base::build::BuildInMessage::build_in_message()
+    ///     crate::new::base::build::BuildInMessage::build_in_message()
     ///
     /// Given the contents of the DNS message, determine how to compress the
     /// given domain name. If a suitable compression for the name could be
@@ -268,13 +268,11 @@ impl NameCompressor {
     /// The contents slice should begin immediately after the 12-byte message
     /// header. It must end at the position the name will be inserted. It is
     /// assumed that the domain names inserted in these contents still exist
-    /// from previous calls to [`compress_name()`] and related methods. If this
-    /// is not true, panics or silently invalid results may occur.
+    /// from previous calls to [`Self::compress_name()`] and related methods. If
+    /// this is not true, panics or silently invalid results may occur.
     ///
     /// The compressor's state will be updated to assume the provided name was
     /// inserted into the message.
-    ///
-    /// [`compress_name()`]: Self::compress_name()
     pub fn compress_name<'n>(
         &mut self,
         contents: &[u8],

--- a/src/new/base/name/mod.rs
+++ b/src/new/base/name/mod.rs
@@ -59,14 +59,16 @@
 //! in turn passed on as a [`RevName`].
 //!
 //! ```
-//! let name_buf: new::base::name::NameBuf =
+//! use domain::new::base::name;
+//!
+//! let name_buf: name::NameBuf =
 //!     "www.nlnetlabs.nl".parse().unwrap();
-//! let name_ref: &new::base::name::Name = &name_buf;
+//! let name_ref: &name::Name = &name_buf;
 //!
 //! println!("NameBuf {}, &Name {}", name_buf, name_ref);
 //!
-//! let revname_buf: new::base::name::RevNameBuf = name_buf.into();
-//! let revname_ref: &new::base::name::RevName = &revname_buf;
+//! let revname_buf: name::RevNameBuf = name_buf.into();
+//! let revname_ref: &name::RevName = &revname_buf;
 //!
 //! println!(
 //!     "RevNameBuf {:?}, &RevName {:?}",

--- a/src/new/base/name/mod.rs
+++ b/src/new/base/name/mod.rs
@@ -29,7 +29,13 @@
 //! - [`RevName`] is similar to [`Name`], except that labels are stored in
 //!   _reverse_ order, from outermost to innermost (i.e. `org, example` in
 //!   `example.org.`). It is the right type to use as the owner name of a
-//!   DNS record ([`Record.rname`]).
+//!   DNS record ([`Record`]`.rname`). The [`RevName`] type is introduced to
+//!   improve manipulations done on a Domain Name.
+//!
+//! During serialization with [`BuildBytes`] to wire format both types result
+//! the same byte sequence.
+//!
+//! [`Record`]: domain::new::base::Record
 //!
 //! These types are _dynamically sized_; this means that they cannot be used
 //! by value. The following table illustrates the various container and
@@ -43,6 +49,30 @@
 //! | `NameBuf`      | Yes | Yes | Efficient short-term usage
 //! | `Box<RevName>` | Yes | Yes | Compact, long-term storage
 //! | `RevNameBuf`   | Yes | Yes | Efficient short-term usage
+//!
+//!
+//! ### Usage example
+//!
+//! In the following example a `str` is parsed into a [`NameBuf`] which is the
+//! owner of the data buffer. The [`NameBuf`] is be passed on as a [`Name`]
+//! reference. Later the [`NameBuf`] gets moved into a [`RevNameBuf`] which is
+//! in turn passed on as a [`RevName`].
+//!
+//! ```
+//! let name_buf: new::base::name::NameBuf =
+//!     "www.nlnetlabs.nl".parse().unwrap();
+//! let name_ref: &new::base::name::Name = &name_buf;
+//!
+//! println!("NameBuf {}, &Name {}", name_buf, name_ref);
+//!
+//! let revname_buf: new::base::name::RevNameBuf = name_buf.into();
+//! let revname_ref: &new::base::name::RevName = &revname_buf;
+//!
+//! println!(
+//!     "RevNameBuf {:?}, &RevName {:?}",
+//!     revname_buf, revname_ref
+//! );
+//! ```
 
 use core::cmp::Ordering;
 

--- a/src/new/base/name/mod.rs
+++ b/src/new/base/name/mod.rs
@@ -171,11 +171,10 @@ pub trait CanonicalName: BuildBytes + Ord {
     /// Compare domain names as if they were in the wire format, lowercased.
     ///
     /// This is equivalent to serializing both domain names in the wire format
-    /// using [`build_lowercased_bytes()`] and comparing the resulting byte
-    /// sequences. It is implemented automatically, but it could be overriden
+    /// using [`Self::build_lowercased_bytes()`] and comparing the resulting
+    /// byte sequences. It is implemented automatically, but it could be
+    /// overriden
     /// for performance.
-    ///
-    /// [`build_lowercased_bytes()`]: Self::build_lowercased_bytes()
     fn cmp_lowercase_composed(&self, other: &Self) -> Ordering {
         // Build both names into byte arrays.
 

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -598,9 +598,7 @@ pub trait CanonicalRecordData: BuildBytes {
     /// Compare record data in the canonical form.
     ///
     /// This is equivalent to serializing both record data instances using
-    /// [`build_canonical_bytes()`] and comparing the resulting byte sequences.
-    ///
-    /// [`build_canonical_bytes()`]: Self::build_canonical_bytes()
+    /// [`Self::build_canonical_bytes()`] and comparing the resulting byte sequences.
     fn cmp_canonical(&self, other: &Self) -> Ordering;
 }
 

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -14,6 +14,38 @@ use super::wire::{
 //----------- Record ---------------------------------------------------------
 
 /// A DNS record.
+///
+/// ```
+/// use domain::new::base;
+/// use domain::new::rdata;
+///
+/// // Construct DNS Record with `RevNameBuf` as the `rname` and a `Cname`
+/// // record with a `NameBuf`
+/// let record: base::Record<
+///     base::name::RevNameBuf,
+///     rdata::CName<base::name::NameBuf>,
+/// > = base::Record {
+///     rname: "www.nlnetlabs.nl".parse().unwrap(),
+///     rtype: base::RType::CNAME,
+///     rclass: base::RClass::IN,
+///     ttl: base::TTL::from(3600),
+///     rdata: rdata::CName {
+///         name: "nlnetlabs.nl".parse().unwrap(),
+///     },
+/// };
+///
+/// // Convert the `rname` from `RevNameBuf` into `NameBuf` but keep the
+/// // `rdata` untouched.
+/// let record: base::Record<
+///     base::name::NameBuf,
+///     rdata::CName<base::name::NameBuf>,
+/// > = record.transform(
+///     |name: base::name::RevNameBuf| name.into(),
+///     |data: rdata::CName<base::name::NameBuf>| data,
+/// );
+///
+/// println!("{:?}", record);
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Record<N, D> {
     /// The name of the record.

--- a/src/new/base/wire/parse.rs
+++ b/src/new/base/wire/parse.rs
@@ -235,10 +235,8 @@ pub use domain_macros::SplitBytes;
 /// # Safety
 ///
 /// Every implementation of [`ParseBytesZC`] must satisfy the invariants
-/// documented on [`parse_bytes_by_ref()`]. An incorrect implementation is
+/// documented on [`Self::parse_bytes_by_ref()`]. An incorrect implementation is
 /// considered to cause undefined behaviour.
-///
-/// [`parse_bytes_by_ref()`]: Self::parse_bytes_by_ref()
 ///
 /// Implementing types must also have no alignment (i.e. a valid instance of
 /// [`Self`] can occur at any address). This eliminates the possibility of
@@ -375,10 +373,8 @@ pub use domain_macros::ParseBytesZC;
 /// # Safety
 ///
 /// Every implementation of [`SplitBytesZC`] must satisfy the invariants
-/// documented on [`split_bytes_by_ref()`]. An incorrect implementation is
+/// documented on [`Self::split_bytes_by_ref()`]. An incorrect implementation is
 /// considered to cause undefined behaviour.
-///
-/// [`split_bytes_by_ref()`]: Self::split_bytes_by_ref()
 ///
 /// Note that [`ParseBytesZC`] and [`UnsizedCopy`], required by this trait,
 /// also have several invariants that need to be considered with care.

--- a/src/rdata/dnssec.rs
+++ b/src/rdata/dnssec.rs
@@ -682,7 +682,7 @@ impl Timestamp {
         self.0.into_int()
     }
 
-    /// Returns a [`SytemTime`] close to a reference time.
+    /// Returns a [`SystemTime`] close to a reference time.
     ///
     /// The returned [`SystemTime`] meets the following requirements:
     ///

--- a/src/rdata/nsec3.rs
+++ b/src/rdata/nsec3.rs
@@ -428,13 +428,13 @@ const NSEC3_OPT_OUT_FLAG_MASK: u8 = 0b0000_0001;
     ))
 )]
 pub struct Nsec3param<Octs> {
-    /// https://www.rfc-editor.org/rfc/rfc5155.html#section-3.1.1
+    /// <https://www.rfc-editor.org/rfc/rfc5155.html#section-3.1.1>
     /// 3.1.1.  Hash Algorithm
     ///   "The Hash Algorithm field identifies the cryptographic hash
     ///    algorithm used to construct the hash-value."
     hash_algorithm: Nsec3HashAlgorithm,
 
-    /// https://www.rfc-editor.org/rfc/rfc5155.html#section-3.1.2
+    /// <https://www.rfc-editor.org/rfc/rfc5155.html#section-3.1.2>
     /// 3.1.2.  Flags
     ///   "The Flags field contains 8 one-bit flags that can be used to
     ///   indicate different processing.  All undefined flags must be zero.
@@ -452,7 +452,7 @@ pub struct Nsec3param<Octs> {
     ///    See Section 6 for details about the use of this flag."
     flags: u8,
 
-    /// https://www.rfc-editor.org/rfc/rfc5155.html#section-3.1.3
+    /// <https://www.rfc-editor.org/rfc/rfc5155.html#section-3.1.3>
     /// 3.1.3.  Iterations
     ///   "The Iterations field defines the number of additional times the
     ///    hash function has been performed.  More iterations result in
@@ -461,19 +461,19 @@ pub struct Nsec3param<Octs> {
     ///    resolver.  See Section 5 for details of the use of this field, and
     ///    Section 10.3 for limitations on the value."
     ///
-    /// https://www.rfc-editor.org/rfc/rfc9276.html#section-3.1
+    /// <https://www.rfc-editor.org/rfc/rfc9276.html#section-3.1>
     /// 3.1. Best Practice for Zone Publishers
     ///   "If NSEC3 must be used, then an iterations count of 0 MUST be used
     ///    to alleviate computational burdens."
     iterations: u16,
 
-    /// https://datatracker.ietf.org/doc/html/rfc5155#section-3.1.5
+    /// <https://datatracker.ietf.org/doc/html/rfc5155#section-3.1.5>
     /// 3.1.5.  Salt
     ///   "The Salt field is appended to the original owner name before
     ///    hashing in order to defend against pre-calculated dictionary
     ///    attacks."
     ///
-    /// https://www.rfc-editor.org/rfc/rfc9276.html#section-3.1
+    /// <https://www.rfc-editor.org/rfc/rfc9276.html#section-3.1>
     /// 3.1. Best Practice for Zone Publishers
     ///   "Operators SHOULD NOT use a salt by indicating a zero-length salt
     ///   value instead (represented as a "-" in the presentation format)."

--- a/src/resolv/stub/conf.rs
+++ b/src/resolv/stub/conf.rs
@@ -275,22 +275,18 @@ impl ServerConf {
 /// resolver talks to its upstream resolvers.
 ///
 /// The type follows the builder pattern. After creating a value with
-/// [`ResolvConf::new`] you can manipulate the members. Once you are happy
-/// with them, you call [`finalize`] to make sure the configuration is valid.
-/// It mostly just fixes the `servers`.
+/// [`ResolvConf::new()`] you can manipulate the members. Once you are happy
+/// with them, you call [`Self::finalize()`] to make sure the configuration is
+/// valid. It mostly just fixes the `servers`.
 ///
 /// Additionally, the type can parse a glibc-style configuration file,
-/// commonly known as `/etc/resolv.conf` through the [`parse`] and
-/// [`parse_file`] methods. You still need to call [`finalize`] after
+/// commonly known as `/etc/resolv.conf` through the [`Self::parse()`] and
+/// [`Self::parse_file()`] methods. You still need to call [`Self::finalize()`] after
 /// parsing.
 ///
 /// The easiest way, however, to get the system resolver configuration is
 /// through [`ResolvConf::default`]. This will parse the configuration
 /// file or return a default configuration if that fails.
-///
-/// [`parse`]: Self::parse
-/// [`parse_file`]: Self::parse_file
-/// [`finalize`]: Self::finalize
 #[derive(Clone, Debug)]
 pub struct ResolvConf {
     /// Addresses of servers to query.

--- a/src/resolv/stub/mod.rs
+++ b/src/resolv/stub/mod.rs
@@ -284,10 +284,8 @@ impl StubResolver {
 
     /// Synchronously perform a DNS operation atop a configured resolver.
     ///
-    /// This is like [`run`] but also takes a resolver configuration for
+    /// This is like [`Self::run()`] but also takes a resolver configuration for
     /// tailor-making your own resolver.
-    ///
-    /// [`run`]: Self::run
     pub fn run_with_conf<R, T, E, F>(conf: ResolvConf, op: F) -> R::Output
     where
         R: Future<Output = Result<T, E>> + Send + 'static,

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -52,17 +52,22 @@ pub type ScannedString = Str<Bytes>;
 /// fetching entries by acting as an iterator.
 ///
 /// The type implements the `bytes::BufMut` trait for appending data directly
-/// into the memory buffer. The function [`load`][Self::load] can be used to
-/// create a value directly from a reader.
+/// into the memory buffer. The function [`load()`] can be used to create a
+/// value directly from a reader.
 ///
 /// Once data has been added, you can simply iterate over the value to get
-/// entries. The [`next_entry`][Self::next_entry] method provides an
-/// alternative with a more question mark friendly signature.
+/// entries. The [`next_entry()`] method provides an alternative with a more
+/// question mark friendly signature.
 ///
 /// By default RFC 1035 validity checks are enabled. At present only the first
 /// check is implemented: "1. All RRs in the zonefile should have the same
 /// class". To disable strict validation call [`allow_invalid()`] prior to
 /// calling [`load()`].
+///
+/// [`allow_invalid()`]: Self::allow_invalid
+/// [`load()`]: Self::load
+/// [`next_entry()`]: Self::next_entry
+
 #[derive(Clone, Debug)]
 pub struct Zonefile {
     /// This is where we keep the data of the next entry.

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -51,22 +51,18 @@ pub type ScannedString = Str<Bytes>;
 /// A value of this types holds data to be scanned in memory and allows
 /// fetching entries by acting as an iterator.
 ///
-/// The type implements the `bytes::BufMut` trait for appending data directly
-/// into the memory buffer. The function [`load()`] can be used to create a
-/// value directly from a reader.
+/// The type implements the [`bytes::BufMut`] trait for appending data directly
+/// into the memory buffer. The function [`Self::load()`] can be used to create
+/// a value directly from a reader.
 ///
 /// Once data has been added, you can simply iterate over the value to get
-/// entries. The [`next_entry()`] method provides an alternative with a more
-/// question mark friendly signature.
+/// entries. The [`Self::next_entry()`] method provides an alternative with a
+/// more question mark friendly signature.
 ///
 /// By default RFC 1035 validity checks are enabled. At present only the first
 /// check is implemented: "1. All RRs in the zonefile should have the same
-/// class". To disable strict validation call [`allow_invalid()`] prior to
-/// calling [`load()`].
-///
-/// [`allow_invalid()`]: Self::allow_invalid
-/// [`load()`]: Self::load
-/// [`next_entry()`]: Self::next_entry
+/// class". To disable strict validation call [`Self::allow_invalid()`] prior to
+/// calling [`Self::load()`].
 
 #[derive(Clone, Debug)]
 pub struct Zonefile {

--- a/src/zonetree/answer.rs
+++ b/src/zonetree/answer.rs
@@ -82,7 +82,7 @@ impl Answer {
 
     /// Creates a new [Rcode::REFUSED] answer.
     ///
-    /// This is equivalent to calling [`Answer::new(Rcode::Refused)`].
+    /// This is equivalent to calling `Answer::new(Rcode::REFUSED)`.
     pub fn refused() -> Self {
         Answer::new(Rcode::REFUSED)
     }

--- a/src/zonetree/mod.rs
+++ b/src/zonetree/mod.rs
@@ -96,8 +96,8 @@
 //! [`Rtype`]: crate::base::iana::Rtype
 //! [`Name`]: crate::base::name::Name
 //! [`Message`]: crate::base::Message
-//! [`NoError`]: crate::base::iana::code::Rcode::NOERROR
-//! [`NxDomain`]: crate::base::iana::code::Rcode::NXDOMAIN
+//! [`NoError`]: crate::base::iana::Rcode::NOERROR
+//! [`NxDomain`]: crate::base::iana::Rcode::NXDOMAIN
 //! [`ZoneBuilder`]: in_memory::ZoneBuilder
 //! [`ZoneUpdater`]: update::ZoneUpdater
 

--- a/src/zonetree/traits.rs
+++ b/src/zonetree/traits.rs
@@ -65,6 +65,8 @@ pub trait ZoneStore: Debug + Sync + Send + Any {
     /// This can be used to obtain access to methods on the specific
     /// [`ZoneStore`] implementation. See [`Zone`] for how this can used to
     /// layer functionality on top of a zone.
+    ///
+    /// [`Zone`]: super::Zone
     fn as_any(&self) -> &dyn Any;
 }
 

--- a/src/zonetree/traits.rs
+++ b/src/zonetree/traits.rs
@@ -142,13 +142,12 @@ pub trait WritableZone: Send + Sync {
     ///
     /// If `create_diff` is true the zone backing store is requested to create
     /// an [`InMemoryZoneDiff`] which will accumulate entries as changes are
-    /// made to the zone and will be returned finally when [`commit()`] is
+    /// made to the zone and will be returned finally when [`Self::commit()`] is
     /// invoked.
     ///
     /// Creating a diff is optional. If the backing store doesn't support
-    /// diff creation [`commit()`] will return `None`.
+    /// diff creation [`Self::commit()`] will return `None`.
     ///
-    /// [`commit()`]: Self::commit
     #[allow(clippy::type_complexity)]
     fn open(
         &self,
@@ -163,19 +162,18 @@ pub trait WritableZone: Send + Sync {
 
     /// Complete a write operation for the zone.
     ///
-    /// This function commits the changes accumulated since [`open()`] was
+    /// This function commits the changes accumulated since [`Self::open()`] was
     /// invoked. Clients who obtain a [`ReadableZone`] interface to this zone
     /// _before_ this function has been called will not see any of the changes
     /// made since the last commit. Only clients who obtain a [`ReadableZone`]
     /// _after_ invoking this function will be able to see the changes made
-    /// since [`open()`] was called.
+    /// since [`Self::open()`] was called.
     ///
-    /// If `create_diff` was set to `true` when [`open()`] was invoked then
-    /// this function _may_ return `Some` if a diff was created. `None` may be
-    /// returned if the zone backing store does not support creation of diffs
+    /// If `create_diff` was set to `true` when [`Self::open()`] was invoked
+    /// then this function _may_ return `Some` if a diff was created. `None` may
+    /// be returned if the zone backing store does not support creation of diffs
     /// or was unable to create a diff for some reason.
     ///
-    /// [`open()`]: Self::open
     fn commit(
         &mut self,
         bump_soa_serial: bool,

--- a/src/zonetree/update.rs
+++ b/src/zonetree/update.rs
@@ -347,9 +347,7 @@ where
 
     /// Has zone updating finished?
     ///
-    /// If true, further calls to [`apply()`] will fail.
-    ///
-    /// [`apply()`]: Self::apply
+    /// If true, further calls to [`Self::apply()`] will fail.
     pub fn is_finished(&self) -> bool {
         self.state == ZoneUpdaterState::Finished
     }

--- a/src/zonetree/zone.rs
+++ b/src/zonetree/zone.rs
@@ -23,6 +23,8 @@ use super::{parsed, ReadableZone, ZoneStore};
 /// backed zone) in the same way, and even to store zones with different
 /// backing stores together in the same [`ZoneTree`].
 ///
+/// [`ZoneTree`]: super::ZoneTree
+///
 /// # Layering functionality
 ///
 /// The functionality of [`Zone`]s can be extended by creating a [`ZoneStore`]
@@ -36,11 +38,12 @@ use super::{parsed, ReadableZone, ZoneStore};
 ///
 /// To layer [`ZoneStore`] implementations on top of one another, use
 /// [`Zone::into_inner()`] to obtain backing store implementation of a
-/// [`Zone`] then store that (via [`Arc<dyn ZoneStore`]) in a wrapper type
+/// [`Zone`] then store that (via [`Arc<dyn ZoneStore>`]) in a wrapper type
 /// that itself implements [`ZoneStore`], and then use [`Zone::new()`] to
 /// create a new [`Zone`] based on the outer backing store impl.
 ///
 /// Then to gain access to the additional functionality and state use
+// TODO
 /// [`ZoneStore::as_any()`] and attempt to [`Any::downcast()`] to a
 /// [`ZoneStore`] implementing type that was used earlier.
 #[derive(Clone, Debug)]

--- a/src/zonetree/zone.rs
+++ b/src/zonetree/zone.rs
@@ -43,9 +43,10 @@ use super::{parsed, ReadableZone, ZoneStore};
 /// create a new [`Zone`] based on the outer backing store impl.
 ///
 /// Then to gain access to the additional functionality and state use
-// TODO
-/// [`ZoneStore::as_any()`] and attempt to [`Any::downcast()`] to a
+/// [`ZoneStore::as_any()`] and attempt to [`Any::downcast_ref()`] to a
 /// [`ZoneStore`] implementing type that was used earlier.
+///
+/// [`Any::downcast_ref()`]: std::any::Any
 #[derive(Clone, Debug)]
 pub struct Zone {
     store: Arc<dyn ZoneStore>,


### PR DESCRIPTION
Improve the documentation by including
- [X] a clarification for the `new::base::name::RevName` type.
- [X] an example usage for `new::base::Record` and
- [X] `new::base::name`
- [x] cleanup of documentation warnings and
- [x] a pipeline check
- [x] remove all occurrences of `rg "\[.+\]: Self::"`