### PR TITLE
Fix `SecurityAlgorithm` to parse int and mnemonic

### DIFF
--- a/src/base/iana/secalg.rs
+++ b/src/base/iana/secalg.rs
@@ -116,5 +116,9 @@ int_enum! {
     (PRIVATEOID => 254, "PRIVATEOID")
 }
 
-int_enum_str_with_decimal!(SecurityAlgorithm, u8, "unknown security algorithm");
+int_enum_str_with_decimal!(
+    SecurityAlgorithm,
+    u8,
+    "unknown security algorithm"
+);
 int_enum_zonefile_fmt_decimal!(SecurityAlgorithm, "algorithm");

--- a/src/base/iana/secalg.rs
+++ b/src/base/iana/secalg.rs
@@ -116,5 +116,5 @@ int_enum! {
     (PRIVATEOID => 254, "PRIVATEOID")
 }
 
-int_enum_str_decimal!(SecurityAlgorithm, u8);
+int_enum_str_with_decimal!(SecurityAlgorithm, u8, "unknown security algorithm");
 int_enum_zonefile_fmt_decimal!(SecurityAlgorithm, "algorithm");

--- a/src/zonefile/inplace.rs
+++ b/src/zonefile/inplace.rs
@@ -1981,4 +1981,11 @@ mod test {
             "../../test-data/zonefiles/rfc_1035_ttl_class_type_rdata.yaml"
         ))
     }
+
+    #[test]
+    fn test_security_algorithm_as_int_and_str_in_cds_rrsig_dnskey() {
+        TestCase::test(include_str!(
+            "../../test-data/zonefiles/security_algorithm_as_int_and_str_in_cds_rrsig_dnskey.yaml"
+        ))
+    }
 }

--- a/test-data/zonefiles/security_algorithm_as_int_and_str_in_cds_rrsig_dnskey.yaml
+++ b/test-data/zonefiles/security_algorithm_as_int_and_str_in_cds_rrsig_dnskey.yaml
@@ -1,0 +1,107 @@
+origin: example.com.
+zonefile: |
+    v01.example.com. 3600 IN CDS 0 0 0 00
+    v02.example.com. 3600 IN CDS 0 DELETE 0 00
+
+    v03.example.com. 3600 IN RRSIG A 5       3 3600 20060825081644 20060728081644 44537 Example.com. ONq5uFbBsvt6XRZdGA7TdZkRy9DcV3ZXS1CXL1AMZ78+MaS+YufBes9wUo/8rBJPoGrBx1u6HRiLOUjc+7LpLJa0NSGCCwPsispbAgNwBKNBYBHd2ftxWImchh1qp5OfFvjkSp9jftr4DlQOW3Sjz8/kvzNU3b+Cr+ERF6vlJks=
+    v04.example.com. 3600 IN RRSIG A RSASHA1 3 3600 20060825081644 20060728081644 44537 Example.com. ONq5uFbBsvt6XRZdGA7TdZkRy9DcV3ZXS1CXL1AMZ78+MaS+YufBes9wUo/8rBJPoGrBx1u6HRiLOUjc+7LpLJa0NSGCCwPsispbAgNwBKNBYBHd2ftxWImchh1qp5OfFvjkSp9jftr4DlQOW3Sjz8/kvzNU3b+Cr+ERF6vlJks=
+
+    v05.example.com. 3600 IN DNSKEY 257 3 8         AQO5v4qLMhH88u+O2rSXA349FO48DlVX8cCQCW3P8edee/4moLd3wLwGm4SoUwX/TyP9HLoyMjCw1gGJPyvlR6IA4u1NAE7Ik2Vpj8NtA9y1evpOd6AYBYlRKon0SAsl5x7QqcN0lKaE2zklXh3lUdQTKrh94xAyXu+SsiSdaaVy+w==
+    v06.example.com. 3600 IN DNSKEY 257 3 RSASHA256 AQO5v4qLMhH88u+O2rSXA349FO48DlVX8cCQCW3P8edee/4moLd3wLwGm4SoUwX/TyP9HLoyMjCw1gGJPyvlR6IA4u1NAE7Ik2Vpj8NtA9y1evpOd6AYBYlRKon0SAsl5x7QqcN0lKaE2zklXh3lUdQTKrh94xAyXu+SsiSdaaVy+w==
+
+    v07.example.com. 3600 IN DNSKEY 257 3 10        AQO5v4qLMhH88u+O2rSXA349FO48DlVX8cCQCW3P8edee/4moLd3wLwGm4SoUwX/TyP9HLoyMjCw1gGJPyvlR6IA4u1NAE7Ik2Vpj8NtA9y1evpOd6AYBYlRKon0SAsl5x7QqcN0lKaE2zklXh3lUdQTKrh94xAyXu+SsiSdaaVy+w==
+    v08.example.com. 3600 IN DNSKEY 257 3 RSASHA512 AQO5v4qLMhH88u+O2rSXA349FO48DlVX8cCQCW3P8edee/4moLd3wLwGm4SoUwX/TyP9HLoyMjCw1gGJPyvlR6IA4u1NAE7Ik2Vpj8NtA9y1evpOd6AYBYlRKon0SAsl5x7QqcN0lKaE2zklXh3lUdQTKrh94xAyXu+SsiSdaaVy+w==
+result:
+
+  # --- Code 0 / DELETE
+  # https://datatracker.ietf.org/doc/html/rfc8078#section-4
+  - owner: v01.example.com.
+    class: IN
+    ttl: 3600
+    data: !Cds
+      rtype: Ds
+      key_tag: 0
+      algorithm: 0
+      digest_type: 0
+      digest: AA== # 0 in Base64
+
+  # https://datatracker.ietf.org/doc/html/rfc8078#section-4
+  - owner: v02.example.com.
+    class: IN
+    ttl: 3600
+    data: !Cds
+      rtype: Ds
+      key_tag: 0
+      algorithm: 0
+      digest_type: 0
+      digest: AA== # 0 in Base64
+
+  - owner: v03.example.com.
+    class: IN
+    ttl: 3600
+    data: !Rrsig
+      rtype: Rrsig
+      type_covered: A
+      algorithm: 5 # RSA/SHA-1 [RSASHA1] https://datatracker.ietf.org/doc/html/rfc4034#appendix-A.1
+      labels: 3
+      original_ttl: 3600
+      expiration: 1156493804
+      inception: 1154074604
+      key_tag: 44537
+      signer_name: example.com.
+      signature: ONq5uFbBsvt6XRZdGA7TdZkRy9DcV3ZXS1CXL1AMZ78+MaS+YufBes9wUo/8rBJPoGrBx1u6HRiLOUjc+7LpLJa0NSGCCwPsispbAgNwBKNBYBHd2ftxWImchh1qp5OfFvjkSp9jftr4DlQOW3Sjz8/kvzNU3b+Cr+ERF6vlJks=
+
+  - owner: v04.example.com.
+    class: IN
+    ttl: 3600
+    data: !Rrsig
+      rtype: Rrsig
+      type_covered: A
+      algorithm: 5 # RSA/SHA-1 [RSASHA1] https://datatracker.ietf.org/doc/html/rfc4034#appendix-A.1
+      labels: 3
+      original_ttl: 3600
+      expiration: 1156493804
+      inception: 1154074604
+      key_tag: 44537
+      signer_name: example.com.
+      signature: ONq5uFbBsvt6XRZdGA7TdZkRy9DcV3ZXS1CXL1AMZ78+MaS+YufBes9wUo/8rBJPoGrBx1u6HRiLOUjc+7LpLJa0NSGCCwPsispbAgNwBKNBYBHd2ftxWImchh1qp5OfFvjkSp9jftr4DlQOW3Sjz8/kvzNU3b+Cr+ERF6vlJks=
+
+  - owner: v05.example.com.
+    class: IN
+    ttl: 3600
+    data: !Dnskey
+      rtype: Dnskey
+      flags: 257
+      protocol: 3
+      algorithm: 8 # RSA/SHA-256 [RSASHA256] https://datatracker.ietf.org/doc/html/rfc5702#section-7
+      public_key: AQO5v4qLMhH88u+O2rSXA349FO48DlVX8cCQCW3P8edee/4moLd3wLwGm4SoUwX/TyP9HLoyMjCw1gGJPyvlR6IA4u1NAE7Ik2Vpj8NtA9y1evpOd6AYBYlRKon0SAsl5x7QqcN0lKaE2zklXh3lUdQTKrh94xAyXu+SsiSdaaVy+w==
+
+  - owner: v06.example.com.
+    class: IN
+    ttl: 3600
+    data: !Dnskey
+      rtype: Dnskey
+      flags: 257
+      protocol: 3
+      algorithm: 8 # RSA/SHA-256 [RSASHA256] https://datatracker.ietf.org/doc/html/rfc5702#section-7
+      public_key: AQO5v4qLMhH88u+O2rSXA349FO48DlVX8cCQCW3P8edee/4moLd3wLwGm4SoUwX/TyP9HLoyMjCw1gGJPyvlR6IA4u1NAE7Ik2Vpj8NtA9y1evpOd6AYBYlRKon0SAsl5x7QqcN0lKaE2zklXh3lUdQTKrh94xAyXu+SsiSdaaVy+w==
+
+  - owner: v07.example.com.
+    class: IN
+    ttl: 3600
+    data: !Dnskey
+      rtype: Dnskey
+      flags: 257
+      protocol: 3
+      algorithm: 10 # RSA/SHA-512 [RSASHA512] https://datatracker.ietf.org/doc/html/rfc5702#section-7
+      public_key: AQO5v4qLMhH88u+O2rSXA349FO48DlVX8cCQCW3P8edee/4moLd3wLwGm4SoUwX/TyP9HLoyMjCw1gGJPyvlR6IA4u1NAE7Ik2Vpj8NtA9y1evpOd6AYBYlRKon0SAsl5x7QqcN0lKaE2zklXh3lUdQTKrh94xAyXu+SsiSdaaVy+w==
+
+  - owner: v08.example.com.
+    class: IN
+    ttl: 3600
+    data: !Dnskey
+      rtype: Dnskey
+      flags: 257
+      protocol: 3
+      algorithm: 10 # RSA/SHA-512 [RSASHA512] https://datatracker.ietf.org/doc/html/rfc5702#section-7
+      public_key: AQO5v4qLMhH88u+O2rSXA349FO48DlVX8cCQCW3P8edee/4moLd3wLwGm4SoUwX/TyP9HLoyMjCw1gGJPyvlR6IA4u1NAE7Ik2Vpj8NtA9y1evpOd6AYBYlRKon0SAsl5x7QqcN0lKaE2zklXh3lUdQTKrh94xAyXu+SsiSdaaVy+w==


### PR DESCRIPTION
Loading a zone that includes a `SecurityAlgorithm` as mnemonic value (e.g. `RSASHA1`) instead of an integer fails. See [example.com.txt] for an example Zonefile containing such records.

Parsing fails with the following message:
```
EntryError { msg: "expected SecurityAlgorithm", context: None }
```

Example to trigger the error.

```rust
// in file src/zonetree/zone.rs
#[cfg(test)]
mod test {
    #[test]
    fn load_zone() {
        use crate::base::zonefile_fmt::{DisplayKind, ZonefileFmt};
        use crate::zonetree::zone::inplace::{Entry, Zonefile};
        use std::io::BufReader;

        let zone_bytes =
            include_bytes!("../../test-data/zonefiles/example.com.txt");
        let mut zone_bytes = BufReader::new(&zone_bytes[..]);

        let mut reader = Zonefile::load(&mut zone_bytes).unwrap();
        while let Some(entry) = reader.next_entry().unwrap() {
            match entry {
                Entry::Record(record) => {
                    println!(
                        "{}",
                        record.display_zonefile(DisplayKind::Simple)
                    );
                }
                _ => continue,
            }
        }
    }
}
```

---

**RFC:**

[RFC 4034] states in [Section 2.2], [Section 3.2] and [Section 5.2] that the Algorithm value `MUST be represented either as an unsigned decimal integer or as an algorithm mnemonic`. A list of all Algorithms and mnemonics can be found at the Iana Assignmnet [Domain Name System Security (DNSSEC) Algorithm Numbers]

---

**FIX:**

To fix the implementation of the `SecurityAlgorithm` the traits need to be generated by the macro called `int_enum_str_with_decimal` instead of `int_enum_str_decimal`.

The `ZonefileFmt` implementation is not affected by this change, therefore the Zonefile representation will not change. But the `Display` implementation will change. It will display the algorithm using the mnemonic name if possible.

`int_enum_str_decimal` (current macro)
```
/// For `FromStr`, recognizes only the decimal values. For `Display`, it will
/// only print the decimal values.
```

`int_enum_str_with_decimal` (desired macro)
```
/// For `FromStr`, recognizes all mnemonics case-insensitively as well as a
/// decimal number representing any value.
///
/// For `Display`, it will display a decimal number for values without
/// mnemonic.
```
---

**Test:**

This PR includes also a new test which parses a Zonefile with both unsigned integer and mnemonic values for different rtypes.

---

🏆 Thanks @partim for helping me understand the issue and fixing it.

[RFC 4034]: https://datatracker.ietf.org/doc/html/rfc4034
[Section 2.2]: https://datatracker.ietf.org/doc/html/rfc4034#section-2.2
[Section 3.2]: https://datatracker.ietf.org/doc/html/rfc4034#section-3.2
[Section 5.2]: https://datatracker.ietf.org/doc/html/rfc4034#section-5.2
[example.com.txt]: https://github.com/NLnetLabs/domain/blob/main/test-data/zonefiles/example.com.txt
[Domain Name System Security (DNSSEC) Algorithm Numbers]: https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml