### PR TITLE
Update EDNS(0) Update Lease comment to reflect new standard

### DIFF
--- a/src/base/iana/opt.rs
+++ b/src/base/iana/opt.rs
@@ -31,11 +31,12 @@ int_enum! {
 
     /// Update lease (UL, 2).
     ///
-    /// This option was proposed in a draft as a way to state lease times for
-    /// registrations made via DNS UPDATE. Its draft, [draft-sekar-dns-ul],
-    /// has since expired. The code is considered ‘on hold.’
+    /// This option is used to request lease times for registrations made via
+    /// DNS UPDATE. DNS lease expiration is used in the DNS-SD Service
+    /// Registration Protocol [RFC 9665]. The option is defined in [RFC 9664].
     ///
-    /// [draft-sekar-dns-ul]: http://files.dns-sd.org/draft-sekar-dns-ul.txt
+    /// [RFC 9664]: https://datatracker.ietf.org/doc/html/rfc9664
+    /// [RFC 9665]: https://datatracker.ietf.org/doc/html/rfc9665
     (UL => 2, "UL")
 
     /// Name server identifier (NSID, 3).


### PR DESCRIPTION
The doc-comment on the Update Lease option mentioned a previous draft standard that had since expired. RFC 9664 has been standardized and now gives official meaning to EDNS(0) option, and the comment is now updated to reflect that.