### PR TITLE
Panic when trying to create an RRset with records that have diffferent TTLs.

### DIFF
--- a/src/dnssec/sign/error.rs
+++ b/src/dnssec/sign/error.rs
@@ -21,6 +21,9 @@ pub enum SigningError {
     /// Cannot create an Rrset from an empty slice.
     EmptyRecordSlice,
 
+    /// Multiple TTL values in RRset.
+    MultipleTtlValues,
+
     // TODO
     Nsec3HashingError(Nsec3HashError),
 
@@ -51,6 +54,9 @@ impl Display for SigningError {
             }
 	    SigningError::EmptyRecordSlice => {
                 f.write_str("Empty slice of Record")
+	    }
+	    SigningError::MultipleTtlValues => {
+                f.write_str("Muultiple TTL values in RRset")
 	    }
             SigningError::Nsec3HashingError(err) => {
                 f.write_fmt(format_args!("NSEC3 hashing error: {err}"))

--- a/src/dnssec/sign/records.rs
+++ b/src/dnssec/sign/records.rs
@@ -429,7 +429,10 @@ pub struct Rrset<'a, N, D> {
     slice: SliceRefsOrOwned<'a, Record<N, D>>,
 }
 
-impl<'a, N, D> Rrset<'a, N, D> {
+impl<'a, N, D> Rrset<'a, N, D>
+where
+    D: RecordData,
+{
     pub fn new(
         slice: SliceRefsOrOwned<'a, Record<N, D>>,
     ) -> Result<Self, SigningError> {
@@ -514,7 +517,14 @@ impl<'a, N, D> Rrset<'a, N, D> {
     fn check_ttls(
         slice: &SliceRefsOrOwned<'a, Record<N, D>>,
     ) -> Result<(), SigningError> {
-        let first_ttl = slice.first().expect("slice is not empty").ttl();
+        let first = slice.first().expect("slice is not empty");
+        if first.rtype() == Rtype::RRSIG {
+            // RRSIG records should not be grouped into RRsets. However,
+            // code may still try do that and ignore the RRSIG records later.
+            // Allow RRSIG records to have different TTLs.
+            return Ok(());
+        }
+        let first_ttl = first.ttl();
         if slice.iter().any(|r| r.ttl() != first_ttl) {
             return Err(SigningError::MultipleTtlValues);
         }

--- a/src/dnssec/sign/records.rs
+++ b/src/dnssec/sign/records.rs
@@ -436,6 +436,9 @@ impl<'a, N, D> Rrset<'a, N, D> {
         if slice.is_empty() {
             Err(SigningError::EmptyRecordSlice)
         } else {
+            // This should not panic but return an error if check_ttl
+            // fails. However, other code cannot handle errors.
+            Rrset::check_ttls(&slice).expect("TTLs should be the same");
             Ok(Rrset { slice })
         }
     }
@@ -446,9 +449,13 @@ impl<'a, N, D> Rrset<'a, N, D> {
         if slice.is_empty() {
             Err(SigningError::EmptyRecordSlice)
         } else {
-            Ok(Rrset {
-                slice: SliceRefsOrOwned::new_from_refs(slice),
-            })
+            let slice = SliceRefsOrOwned::new_from_refs(slice);
+
+            // This should not panic but return an error if check_ttl
+            // fails. However, other code cannot handle errors.
+            Rrset::check_ttls(&slice).expect("TTLs should be the same");
+
+            Ok(Rrset { slice })
         }
     }
 
@@ -458,9 +465,13 @@ impl<'a, N, D> Rrset<'a, N, D> {
         if slice.is_empty() {
             Err(SigningError::EmptyRecordSlice)
         } else {
-            Ok(Rrset {
-                slice: SliceRefsOrOwned::new_from_owned(slice),
-            })
+            let slice = SliceRefsOrOwned::new_from_owned(slice);
+
+            // This should not panic but return an error if check_ttl
+            // fails. However, other code cannot handle errors.
+            Rrset::check_ttls(&slice).expect("TTLs should be the same");
+
+            Ok(Rrset { slice })
         }
     }
 
@@ -498,6 +509,16 @@ impl<'a, N, D> Rrset<'a, N, D> {
 
     pub fn into_inner(self) -> SliceRefsOrOwned<'a, Record<N, D>> {
         self.slice
+    }
+
+    fn check_ttls(
+        slice: &SliceRefsOrOwned<'a, Record<N, D>>,
+    ) -> Result<(), SigningError> {
+        let first_ttl = slice.first().expect("slice is not empty").ttl();
+        if slice.iter().any(|r| r.ttl() != first_ttl) {
+            return Err(SigningError::MultipleTtlValues);
+        }
+        Ok(())
     }
 }
 
@@ -602,9 +623,7 @@ where
         }
         let (res, slice) = self.slice.split_at(end);
         self.slice = slice;
-        Some(
-            Rrset::new(res).expect("res is not empty so new should not fail"),
-        )
+        Some(Rrset::new(res).expect("Rrset::new should not fail"))
     }
 }
 


### PR DESCRIPTION
This is not ideal, but the best we can do in short time. It should be fixed by propagating the error up. 