### PR TITLE
Fix deserialize and add testing for the `base::iana` enums

### DIFF
--- a/src/base/iana/mod.rs
+++ b/src/base/iana/mod.rs
@@ -57,3 +57,493 @@ pub mod sshfp;
 pub mod svcb;
 pub mod tlsa;
 pub mod zonemd;
+
+#[cfg(feature = "serde")]
+#[cfg(test)]
+mod test {
+    use crate::base::iana::class::Class;
+    use crate::base::iana::digestalg::DigestAlgorithm;
+    // use crate::base::iana::exterr::ExtendedErrorCode;
+    use crate::base::iana::ipseckey::IpseckeyAlgorithm;
+    use crate::base::iana::ipseckey::IpseckeyGatewayType;
+    use crate::base::iana::nsec3::Nsec3HashAlgorithm;
+    use crate::base::iana::opcode::Opcode;
+    use crate::base::iana::opt::OptionCode;
+    // use crate::base::iana::rcode::OptRcode;
+    // use crate::base::iana::rcode::Rcode;
+    use crate::base::iana::rcode::TsigRcode;
+    use crate::base::iana::rtype::Rtype;
+    use crate::base::iana::secalg::SecurityAlgorithm;
+    use crate::base::iana::sshfp::SshfpAlgorithm;
+    use crate::base::iana::sshfp::SshfpType;
+    use crate::base::iana::svcb::SvcParamKey;
+    use crate::base::iana::tlsa::TlsaCertificateUsage;
+    use crate::base::iana::tlsa::TlsaMatchingType;
+    use crate::base::iana::tlsa::TlsaSelector;
+    use crate::base::iana::zonemd::ZonemdAlgorithm;
+    use crate::base::iana::zonemd::ZonemdScheme;
+
+    use core::fmt::Debug;
+    use core::fmt::Display;
+    use core::str::FromStr;
+    use std::string::String;
+
+    use crate::base::zonefile_fmt::DisplayKind;
+    use crate::base::zonefile_fmt::ZonefileFmt;
+
+    #[track_caller]
+    fn validate_generic_representation<T>(
+        test_value: T,              // This value is used as desired value
+        display_repr: String,       // Display MUST result in this String
+        debug_repr: String,         // Debug MUST result in this String
+        fromstr_list: &[&str], // `&[&str]` `FromStr`s MUST result in `test_value`
+        zonefile_fmt_value: String, // ZonefileFmt MUST result in this String
+        serde_serialize_value: String, // ZonefileFmt MUST result in this String
+    ) where
+        T: Display
+            + Debug
+            + FromStr
+            + PartialEq
+            + ZonefileFmt
+            + for<'a> serde::Deserialize<'a>
+            + serde::Serialize,
+        <T as core::str::FromStr>::Err: core::fmt::Debug,
+    {
+        // Display
+        println!("assert fmt::Display");
+        assert_eq!(
+            display_repr,
+            format!("{test_value}"),
+            "Display representation"
+        );
+
+        // Debug
+        println!("assert fmt::Debug");
+        assert_eq!(
+            debug_repr,
+            format!("{test_value:?}"),
+            "Debug representation"
+        );
+
+        for value in fromstr_list {
+            // FromStr mnemonic
+            println!("assert FromStr with {}", value);
+            assert_eq!(
+                value.parse::<T>().unwrap_or_else(|_| panic!(
+                    "FromStr failed with {value}"
+                )),
+                test_value,
+                "FromStr representation"
+            );
+        }
+
+        // ZonefileFmt
+        println!("assert ZonefileFmt");
+        let display_zonefile =
+            test_value.display_zonefile(DisplayKind::Simple);
+        assert_eq!(
+            zonefile_fmt_value,
+            format!("{display_zonefile}"),
+            "ZonefileFmt representation"
+        );
+
+        // serde::Serialize
+        println!("assert Serialize");
+        assert_eq!(
+            serde_serialize_value,
+            serde_json::to_string(&test_value).unwrap(),
+            "serde_json::to_string(&test_value)"
+        );
+
+        // serde::Deserialize
+        let value_as_json_string =
+            serde_json::to_string(&test_value).unwrap();
+
+        println!("assert Deserialize from #{}#", value_as_json_string);
+        assert_eq!(
+            test_value,
+            serde_json::from_str(&value_as_json_string).unwrap(),
+            "serde_json::from_str(&value_as_json_string)"
+        );
+
+        // TODO: Missing is the non-human-readable testing of serde!
+    }
+
+    #[test]
+    fn validate_class_representation() {
+        validate_generic_representation(
+            Class::IN,
+            "IN".into(),
+            "Class::IN".into(),
+            &["IN", "CLASS1"],
+            "IN".into(),
+            r#""IN""#.into(),
+        );
+        validate_generic_representation(
+            Class::from_int(42),
+            "CLASS42".into(),
+            "Class(42)".into(),
+            &["CLASS42"],
+            "CLASS42".into(),
+            r#""CLASS42""#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_digest_algorithm_representation() {
+        validate_generic_representation(
+            DigestAlgorithm::SHA256,
+            "2".into(),
+            "DigestAlgorithm::SHA-256".into(),
+            &["2"],
+            "2".into(),
+            r#"2"#.into(),
+        );
+        validate_generic_representation(
+            DigestAlgorithm::from_int(42),
+            "42".into(),
+            "DigestAlgorithm(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn validate_extended_error_code_representation() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_ipseckey_algorithm_representation() {
+        validate_generic_representation(
+            IpseckeyAlgorithm::ECDSA,
+            "3".into(),
+            "IpseckeyAlgorithm::ECDSA".into(),
+            &["3"], // not "ECDSA"
+            "3".into(),
+            r#"3"#.into(),
+        );
+        validate_generic_representation(
+            IpseckeyAlgorithm::from_int(42),
+            "42".into(),
+            "IpseckeyAlgorithm(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_ipseckey_gateway_type_representation() {
+        validate_generic_representation(
+            IpseckeyGatewayType::NONE,
+            "0".into(),
+            "IpseckeyGatewayType::NONE".into(),
+            &["0"], // not "NONE"
+            "0".into(),
+            r#"0"#.into(),
+        );
+        validate_generic_representation(
+            IpseckeyGatewayType::from_int(42),
+            "42".into(),
+            "IpseckeyGatewayType(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_nsec3_hash_algorithm_representation() {
+        validate_generic_representation(
+            Nsec3HashAlgorithm::SHA1,
+            "1".into(),
+            "Nsec3HashAlgorithm::SHA-1".into(),
+            &["1"], // "SHA-1"
+            "1".into(),
+            r#"1"#.into(),
+        );
+        validate_generic_representation(
+            Nsec3HashAlgorithm::from_int(42),
+            "42".into(),
+            "Nsec3HashAlgorithm(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_opcode_representation() {
+        validate_generic_representation(
+            Opcode::QUERY,
+            "QUERY(0)".into(),
+            "Opcode::QUERY".into(),
+            &["QUERY", "0"],
+            "QUERY".into(),
+            r#""QUERY""#.into(),
+        );
+        validate_generic_representation(
+            Opcode::from_int(42),
+            "42".into(),
+            "Opcode(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_option_code_representation() {
+        validate_generic_representation(
+            OptionCode::COOKIE,
+            "COOKIE(10)".into(),
+            "OptionCode::COOKIE".into(),
+            &["COOKIE", "10"],
+            "COOKIE".into(),
+            r#""COOKIE""#.into(),
+        );
+        validate_generic_representation(
+            OptionCode::from_int(42),
+            "42".into(),
+            "OptionCode(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn validate_opt_rcode_representation() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn validate_rcode_representation() {
+        todo!()
+    }
+
+    #[test]
+    fn validate_tsig_rcode_representation() {
+        validate_generic_representation(
+            TsigRcode::BADCOOKIE,
+            "BADCOOKIE(23)".into(),
+            "TsigRcode::BADCOOKIE".into(),
+            &["23", "BADCOOKIE"],
+            "BADCOOKIE".into(),
+            r#""BADCOOKIE""#.into(),
+        );
+        validate_generic_representation(
+            TsigRcode::from_int(42),
+            "42".into(),
+            "TsigRcode(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_rtype_representation() {
+        validate_generic_representation(
+            Rtype::MX,
+            "MX".into(),
+            "Rtype::MX".into(),
+            &["MX", "TYPE15"],
+            "MX".into(),
+            r#""MX""#.into(),
+        );
+        validate_generic_representation(
+            Rtype::from_int(842),
+            "TYPE842".into(),
+            "Rtype(842)".into(),
+            &["TYPE842"],
+            "TYPE842".into(),
+            r#""TYPE842""#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_security_algorithm_representation() {
+        validate_generic_representation(
+            SecurityAlgorithm::DELETE,
+            "0".into(),
+            "SecurityAlgorithm::DELETE".into(),
+            &["0"], // not "DELETE"
+            "0".into(),
+            r#"0"#.into(),
+        );
+        validate_generic_representation(
+            SecurityAlgorithm::from_int(42),
+            "42".into(),
+            "SecurityAlgorithm(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_sshfp_algorithm_representation() {
+        validate_generic_representation(
+            SshfpAlgorithm::ED25519,
+            "4".into(),
+            "SshfpAlgorithm::Ed25519".into(),
+            &["4"],
+            "4".into(),
+            r#"4"#.into(),
+        );
+        validate_generic_representation(
+            SshfpAlgorithm::from_int(42),
+            "42".into(),
+            "SshfpAlgorithm(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_sshfp_type_representation() {
+        validate_generic_representation(
+            SshfpType::SHA256,
+            "2".into(),
+            "SshfpType::SHA-256".into(),
+            &["2"],
+            "2".into(),
+            r#"2"#.into(),
+        );
+        validate_generic_representation(
+            SshfpType::from_int(42),
+            "42".into(),
+            "SshfpType(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_svc_param_key_representation() {
+        validate_generic_representation(
+            SvcParamKey::ALPN,
+            "alpn".into(),
+            "SvcParamKey::alpn".into(),
+            &["alpn", "KEY1"],
+            "alpn".into(),
+            r#""alpn""#.into(),
+        );
+        validate_generic_representation(
+            SvcParamKey::from_int(42),
+            "key42".into(),
+            "SvcParamKey(42)".into(),
+            &["KEY42"],
+            "key42".into(),
+            r#""key42""#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_tlsa_certificate_usage_representation() {
+        validate_generic_representation(
+            TlsaCertificateUsage::DANE_EE,
+            "3".into(),
+            "TlsaCertificateUsage::DANE-EE".into(),
+            &["3"],
+            "3".into(),
+            r#"3"#.into(),
+        );
+        validate_generic_representation(
+            TlsaCertificateUsage::from_int(42),
+            "42".into(),
+            "TlsaCertificateUsage(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_tlsa_matching_type_representation() {
+        validate_generic_representation(
+            TlsaMatchingType::FULL,
+            "0".into(),
+            "TlsaMatchingType::Full".into(),
+            &["0"],
+            "0".into(),
+            r#"0"#.into(),
+        );
+        validate_generic_representation(
+            TlsaMatchingType::from_int(42),
+            "42".into(),
+            "TlsaMatchingType(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_tlsa_selector_representation() {
+        validate_generic_representation(
+            TlsaSelector::CERT,
+            "0".into(),
+            "TlsaSelector::Cert".into(),
+            &["0"],
+            "0".into(),
+            r#"0"#.into(),
+        );
+        validate_generic_representation(
+            TlsaSelector::from_int(42),
+            "42".into(),
+            "TlsaSelector(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_zonemd_algorithm_representation() {
+        validate_generic_representation(
+            ZonemdAlgorithm::SHA512,
+            "2".into(),
+            "ZonemdAlgorithm::SHA512".into(),
+            &["2"],
+            "2".into(),
+            "2".into(),
+        );
+        validate_generic_representation(
+            ZonemdAlgorithm::from_int(42),
+            "42".into(),
+            "ZonemdAlgorithm(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+
+    #[test]
+    fn validate_zonemd_scheme_representation() {
+        validate_generic_representation(
+            ZonemdScheme::SIMPLE,
+            "1".into(),
+            "ZonemdScheme::SIMPLE".into(),
+            &["1"],
+            "1".into(),
+            "1".into(),
+        );
+        validate_generic_representation(
+            ZonemdScheme::from_int(42),
+            "42".into(),
+            "ZonemdScheme(42)".into(),
+            &["42"],
+            "42".into(),
+            r#"42"#.into(),
+        );
+    }
+}

--- a/src/base/iana/mod.rs
+++ b/src/base/iana/mod.rs
@@ -86,19 +86,24 @@ mod test {
     use core::fmt::Debug;
     use core::fmt::Display;
     use core::str::FromStr;
-    use std::string::String;
 
     use crate::base::zonefile_fmt::DisplayKind;
     use crate::base::zonefile_fmt::ZonefileFmt;
 
+    /// `test_value`: T - This is used as the desired value
+    /// `display_repr`: &str - Display MUST result in this string
+    /// `debug_repr`: &str - Debug MUST result in this string
+    /// `fromstr_list`: &[&str] - `FromStr` MUST result in `test_value`
+    /// `zonefile_fmt_value`: &str - ZonefileFmt MUST result in this string
+    /// `serde_serialize_value`: &str - Serialize MUST result in this string
     #[track_caller]
     fn validate_generic_representation<T>(
-        test_value: T,              // This value is used as desired value
-        display_repr: String,       // Display MUST result in this String
-        debug_repr: String,         // Debug MUST result in this String
-        fromstr_list: &[&str], // `&[&str]` `FromStr`s MUST result in `test_value`
-        zonefile_fmt_value: String, // ZonefileFmt MUST result in this String
-        serde_serialize_value: String, // ZonefileFmt MUST result in this String
+        test_value: T,
+        display_repr: &str,
+        debug_repr: &str,
+        fromstr_list: &[&str],
+        zonefile_fmt_value: &str,
+        serde_serialize_value: &str,
     ) where
         T: Display
             + Debug
@@ -178,19 +183,19 @@ mod test {
     fn validate_class_representation() {
         validate_generic_representation(
             Class::IN,
-            "IN".into(),
-            "Class::IN".into(),
+            "IN",
+            "Class::IN",
             &["IN", "CLASS1"],
-            "IN".into(),
-            r#""IN""#.into(),
+            "IN",
+            r#""IN""#,
         );
         validate_generic_representation(
             Class::from_int(42),
-            "CLASS42".into(),
-            "Class(42)".into(),
+            "CLASS42",
+            "Class(42)",
             &["CLASS42"],
-            "CLASS42".into(),
-            r#""CLASS42""#.into(),
+            "CLASS42",
+            r#""CLASS42""#,
         );
     }
 
@@ -198,19 +203,19 @@ mod test {
     fn validate_digest_algorithm_representation() {
         validate_generic_representation(
             DigestAlgorithm::SHA256,
-            "2".into(),
-            "DigestAlgorithm::SHA-256".into(),
+            "2",
+            "DigestAlgorithm::SHA-256",
             &["2"],
-            "2".into(),
-            r#"2"#.into(),
+            "2",
+            r#"2"#,
         );
         validate_generic_representation(
             DigestAlgorithm::from_int(42),
-            "42".into(),
-            "DigestAlgorithm(42)".into(),
+            "42",
+            "DigestAlgorithm(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -224,19 +229,19 @@ mod test {
     fn validate_ipseckey_algorithm_representation() {
         validate_generic_representation(
             IpseckeyAlgorithm::ECDSA,
-            "3".into(),
-            "IpseckeyAlgorithm::ECDSA".into(),
+            "3",
+            "IpseckeyAlgorithm::ECDSA",
             &["3"], // not "ECDSA"
-            "3".into(),
-            r#"3"#.into(),
+            "3",
+            r#"3"#,
         );
         validate_generic_representation(
             IpseckeyAlgorithm::from_int(42),
-            "42".into(),
-            "IpseckeyAlgorithm(42)".into(),
+            "42",
+            "IpseckeyAlgorithm(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -244,19 +249,19 @@ mod test {
     fn validate_ipseckey_gateway_type_representation() {
         validate_generic_representation(
             IpseckeyGatewayType::NONE,
-            "0".into(),
-            "IpseckeyGatewayType::NONE".into(),
+            "0",
+            "IpseckeyGatewayType::NONE",
             &["0"], // not "NONE"
-            "0".into(),
-            r#"0"#.into(),
+            "0",
+            r#"0"#,
         );
         validate_generic_representation(
             IpseckeyGatewayType::from_int(42),
-            "42".into(),
-            "IpseckeyGatewayType(42)".into(),
+            "42",
+            "IpseckeyGatewayType(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -264,19 +269,19 @@ mod test {
     fn validate_nsec3_hash_algorithm_representation() {
         validate_generic_representation(
             Nsec3HashAlgorithm::SHA1,
-            "1".into(),
-            "Nsec3HashAlgorithm::SHA-1".into(),
+            "1",
+            "Nsec3HashAlgorithm::SHA-1",
             &["1"], // "SHA-1"
-            "1".into(),
-            r#"1"#.into(),
+            "1",
+            r#"1"#,
         );
         validate_generic_representation(
             Nsec3HashAlgorithm::from_int(42),
-            "42".into(),
-            "Nsec3HashAlgorithm(42)".into(),
+            "42",
+            "Nsec3HashAlgorithm(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -284,19 +289,19 @@ mod test {
     fn validate_opcode_representation() {
         validate_generic_representation(
             Opcode::QUERY,
-            "QUERY(0)".into(),
-            "Opcode::QUERY".into(),
+            "QUERY(0)",
+            "Opcode::QUERY",
             &["QUERY", "0"],
-            "QUERY".into(),
-            r#""QUERY""#.into(),
+            "QUERY",
+            r#""QUERY""#,
         );
         validate_generic_representation(
             Opcode::from_int(42),
-            "42".into(),
-            "Opcode(42)".into(),
+            "42",
+            "Opcode(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -304,19 +309,19 @@ mod test {
     fn validate_option_code_representation() {
         validate_generic_representation(
             OptionCode::COOKIE,
-            "COOKIE(10)".into(),
-            "OptionCode::COOKIE".into(),
+            "COOKIE(10)",
+            "OptionCode::COOKIE",
             &["COOKIE", "10"],
-            "COOKIE".into(),
-            r#""COOKIE""#.into(),
+            "COOKIE",
+            r#""COOKIE""#,
         );
         validate_generic_representation(
             OptionCode::from_int(42),
-            "42".into(),
-            "OptionCode(42)".into(),
+            "42",
+            "OptionCode(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -336,19 +341,19 @@ mod test {
     fn validate_tsig_rcode_representation() {
         validate_generic_representation(
             TsigRcode::BADCOOKIE,
-            "BADCOOKIE(23)".into(),
-            "TsigRcode::BADCOOKIE".into(),
+            "BADCOOKIE(23)",
+            "TsigRcode::BADCOOKIE",
             &["23", "BADCOOKIE"],
-            "BADCOOKIE".into(),
-            r#""BADCOOKIE""#.into(),
+            "BADCOOKIE",
+            r#""BADCOOKIE""#,
         );
         validate_generic_representation(
             TsigRcode::from_int(42),
-            "42".into(),
-            "TsigRcode(42)".into(),
+            "42",
+            "TsigRcode(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -356,19 +361,19 @@ mod test {
     fn validate_rtype_representation() {
         validate_generic_representation(
             Rtype::MX,
-            "MX".into(),
-            "Rtype::MX".into(),
+            "MX",
+            "Rtype::MX",
             &["MX", "TYPE15"],
-            "MX".into(),
-            r#""MX""#.into(),
+            "MX",
+            r#""MX""#,
         );
         validate_generic_representation(
             Rtype::from_int(842),
-            "TYPE842".into(),
-            "Rtype(842)".into(),
+            "TYPE842",
+            "Rtype(842)",
             &["TYPE842"],
-            "TYPE842".into(),
-            r#""TYPE842""#.into(),
+            "TYPE842",
+            r#""TYPE842""#,
         );
     }
 
@@ -376,19 +381,19 @@ mod test {
     fn validate_security_algorithm_representation() {
         validate_generic_representation(
             SecurityAlgorithm::DELETE,
-            "0".into(),
-            "SecurityAlgorithm::DELETE".into(),
+            "0",
+            "SecurityAlgorithm::DELETE",
             &["0"], // not "DELETE"
-            "0".into(),
-            r#"0"#.into(),
+            "0",
+            r#"0"#,
         );
         validate_generic_representation(
             SecurityAlgorithm::from_int(42),
-            "42".into(),
-            "SecurityAlgorithm(42)".into(),
+            "42",
+            "SecurityAlgorithm(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -396,19 +401,19 @@ mod test {
     fn validate_sshfp_algorithm_representation() {
         validate_generic_representation(
             SshfpAlgorithm::ED25519,
-            "4".into(),
-            "SshfpAlgorithm::Ed25519".into(),
+            "4",
+            "SshfpAlgorithm::Ed25519",
             &["4"],
-            "4".into(),
-            r#"4"#.into(),
+            "4",
+            r#"4"#,
         );
         validate_generic_representation(
             SshfpAlgorithm::from_int(42),
-            "42".into(),
-            "SshfpAlgorithm(42)".into(),
+            "42",
+            "SshfpAlgorithm(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -416,19 +421,19 @@ mod test {
     fn validate_sshfp_type_representation() {
         validate_generic_representation(
             SshfpType::SHA256,
-            "2".into(),
-            "SshfpType::SHA-256".into(),
+            "2",
+            "SshfpType::SHA-256",
             &["2"],
-            "2".into(),
-            r#"2"#.into(),
+            "2",
+            r#"2"#,
         );
         validate_generic_representation(
             SshfpType::from_int(42),
-            "42".into(),
-            "SshfpType(42)".into(),
+            "42",
+            "SshfpType(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -436,19 +441,19 @@ mod test {
     fn validate_svc_param_key_representation() {
         validate_generic_representation(
             SvcParamKey::ALPN,
-            "alpn".into(),
-            "SvcParamKey::alpn".into(),
+            "alpn",
+            "SvcParamKey::alpn",
             &["alpn", "KEY1"],
-            "alpn".into(),
-            r#""alpn""#.into(),
+            "alpn",
+            r#""alpn""#,
         );
         validate_generic_representation(
             SvcParamKey::from_int(42),
-            "key42".into(),
-            "SvcParamKey(42)".into(),
+            "key42",
+            "SvcParamKey(42)",
             &["KEY42"],
-            "key42".into(),
-            r#""key42""#.into(),
+            "key42",
+            r#""key42""#,
         );
     }
 
@@ -456,19 +461,19 @@ mod test {
     fn validate_tlsa_certificate_usage_representation() {
         validate_generic_representation(
             TlsaCertificateUsage::DANE_EE,
-            "3".into(),
-            "TlsaCertificateUsage::DANE-EE".into(),
+            "3",
+            "TlsaCertificateUsage::DANE-EE",
             &["3"],
-            "3".into(),
-            r#"3"#.into(),
+            "3",
+            r#"3"#,
         );
         validate_generic_representation(
             TlsaCertificateUsage::from_int(42),
-            "42".into(),
-            "TlsaCertificateUsage(42)".into(),
+            "42",
+            "TlsaCertificateUsage(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -476,19 +481,19 @@ mod test {
     fn validate_tlsa_matching_type_representation() {
         validate_generic_representation(
             TlsaMatchingType::FULL,
-            "0".into(),
-            "TlsaMatchingType::Full".into(),
+            "0",
+            "TlsaMatchingType::Full",
             &["0"],
-            "0".into(),
-            r#"0"#.into(),
+            "0",
+            r#"0"#,
         );
         validate_generic_representation(
             TlsaMatchingType::from_int(42),
-            "42".into(),
-            "TlsaMatchingType(42)".into(),
+            "42",
+            "TlsaMatchingType(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -496,19 +501,19 @@ mod test {
     fn validate_tlsa_selector_representation() {
         validate_generic_representation(
             TlsaSelector::CERT,
-            "0".into(),
-            "TlsaSelector::Cert".into(),
+            "0",
+            "TlsaSelector::Cert",
             &["0"],
-            "0".into(),
-            r#"0"#.into(),
+            "0",
+            r#"0"#,
         );
         validate_generic_representation(
             TlsaSelector::from_int(42),
-            "42".into(),
-            "TlsaSelector(42)".into(),
+            "42",
+            "TlsaSelector(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -516,19 +521,19 @@ mod test {
     fn validate_zonemd_algorithm_representation() {
         validate_generic_representation(
             ZonemdAlgorithm::SHA512,
-            "2".into(),
-            "ZonemdAlgorithm::SHA512".into(),
+            "2",
+            "ZonemdAlgorithm::SHA512",
             &["2"],
-            "2".into(),
-            "2".into(),
+            "2",
+            "2",
         );
         validate_generic_representation(
             ZonemdAlgorithm::from_int(42),
-            "42".into(),
-            "ZonemdAlgorithm(42)".into(),
+            "42",
+            "ZonemdAlgorithm(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 
@@ -536,19 +541,19 @@ mod test {
     fn validate_zonemd_scheme_representation() {
         validate_generic_representation(
             ZonemdScheme::SIMPLE,
-            "1".into(),
-            "ZonemdScheme::SIMPLE".into(),
+            "1",
+            "ZonemdScheme::SIMPLE",
             &["1"],
-            "1".into(),
-            "1".into(),
+            "1",
+            "1",
         );
         validate_generic_representation(
             ZonemdScheme::from_int(42),
-            "42".into(),
-            "ZonemdScheme(42)".into(),
+            "42",
+            "ZonemdScheme(42)",
             &["42"],
-            "42".into(),
-            r#"42"#.into(),
+            "42",
+            r#"42"#,
         );
     }
 }

--- a/src/base/iana/mod.rs
+++ b/src/base/iana/mod.rs
@@ -110,7 +110,6 @@ mod test {
         <T as core::str::FromStr>::Err: core::fmt::Debug,
     {
         // Display
-        println!("assert fmt::Display");
         assert_eq!(
             display_repr,
             format!("{test_value}"),
@@ -118,7 +117,6 @@ mod test {
         );
 
         // Debug
-        println!("assert fmt::Debug");
         assert_eq!(
             debug_repr,
             format!("{test_value:?}"),
@@ -127,7 +125,6 @@ mod test {
 
         for value in fromstr_list {
             // FromStr mnemonic
-            println!("assert FromStr with {}", value);
             assert_eq!(
                 value.parse::<T>().unwrap_or_else(|_| panic!(
                     "FromStr failed with {value}"
@@ -138,7 +135,6 @@ mod test {
         }
 
         // ZonefileFmt
-        println!("assert ZonefileFmt");
         let display_zonefile =
             test_value.display_zonefile(DisplayKind::Simple);
         assert_eq!(
@@ -148,7 +144,6 @@ mod test {
         );
 
         // serde::Serialize
-        println!("assert Serialize");
         assert_eq!(
             serde_serialize_value,
             serde_json::to_string(&test_value).unwrap(),
@@ -159,14 +154,24 @@ mod test {
         let value_as_json_string =
             serde_json::to_string(&test_value).unwrap();
 
-        println!("assert Deserialize from #{}#", value_as_json_string);
         assert_eq!(
             test_value,
-            serde_json::from_str(&value_as_json_string).unwrap(),
-            "serde_json::from_str(&value_as_json_string)"
+            serde_json::from_str(&value_as_json_string).unwrap_or_else(|_|
+                panic!("serde_json::from_str() failed with {value_as_json_string}")
+            ),
+            "serde_json::from_str(&{value_as_json_string})"
         );
 
-        // TODO: Missing is the non-human-readable testing of serde!
+        let big_number_error: Result<T, serde_json::Error> =
+            serde_json::from_str(&format!("{}", u32::MAX));
+        assert!(
+            big_number_error.is_err(),
+            "Make sure too big integer (u32::MAX) throw an error {big_number_error:?}"
+        );
+
+        // NOTE: Currently there is no testing for `is_human_reable()` = false
+        // option in this function.
+        // https://docs.rs/serde/latest/serde/trait.Serializer.html#method.is_human_readable
     }
 
     #[test]

--- a/src/base/serde.rs
+++ b/src/base/serde.rs
@@ -43,20 +43,15 @@ where
                 write!(f, "a u8 or string")
             }
 
-            fn visit_u8<E: serde::de::Error>(self, v: u8) -> Result<T, E> {
-                Ok(T::from(v))
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<T, E> {
+                Ok(T::from(v as u8))
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<T, E> {
                 T::from_str(v).map_err(E::custom)
             }
         }
-
-        if deserializer.is_human_readable() {
-            deserializer.deserialize_str(Visitor(PhantomData))
-        } else {
-            deserializer.deserialize_u8(Visitor(PhantomData))
-        }
+        deserializer.deserialize_any(Visitor(PhantomData))
     }
 }
 
@@ -81,20 +76,15 @@ where
                 write!(f, "a u16 or string")
             }
 
-            fn visit_u16<E: serde::de::Error>(self, v: u16) -> Result<T, E> {
-                Ok(T::from(v))
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<T, E> {
+                Ok(T::from(v as u16))
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<T, E> {
                 T::from_str(v).map_err(E::custom)
             }
         }
-
-        if deserializer.is_human_readable() {
-            deserializer.deserialize_str(Visitor(PhantomData))
-        } else {
-            deserializer.deserialize_u16(Visitor(PhantomData))
-        }
+        deserializer.deserialize_any(Visitor(PhantomData))
     }
 }
 
@@ -119,19 +109,14 @@ where
                 write!(f, "a u32 or string")
             }
 
-            fn visit_u32<E: serde::de::Error>(self, v: u32) -> Result<T, E> {
-                Ok(T::from(v))
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<T, E> {
+                Ok(T::from(v as u32))
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<T, E> {
                 T::from_str(v).map_err(E::custom)
             }
         }
-
-        if deserializer.is_human_readable() {
-            deserializer.deserialize_str(Visitor(PhantomData))
-        } else {
-            deserializer.deserialize_u32(Visitor(PhantomData))
-        }
+        deserializer.deserialize_any(Visitor(PhantomData))
     }
 }

--- a/src/base/serde.rs
+++ b/src/base/serde.rs
@@ -44,7 +44,12 @@ where
             }
 
             fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<T, E> {
-                Ok(T::from(v as u8))
+                match v.try_into() {
+                    Ok(u8_value) => Ok(T::from(u8_value)),
+                    Err(e) => Err(E::custom(format!(
+                        "value too big, expected u8: {e}"
+                    ))),
+                }
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<T, E> {
@@ -77,7 +82,12 @@ where
             }
 
             fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<T, E> {
-                Ok(T::from(v as u16))
+                match v.try_into() {
+                    Ok(u16_value) => Ok(T::from(u16_value)),
+                    Err(e) => Err(E::custom(format!(
+                        "value too big, expected u16: {e}"
+                    ))),
+                }
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<T, E> {
@@ -110,7 +120,12 @@ where
             }
 
             fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<T, E> {
-                Ok(T::from(v as u32))
+                match v.try_into() {
+                    Ok(u32_value) => Ok(T::from(u32_value)),
+                    Err(e) => Err(E::custom(format!(
+                        "value too big, expected u32: {e}"
+                    ))),
+                }
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<T, E> {


### PR DESCRIPTION
`serde_json::from_str()` was unable to parse enum values in a JSON if they are represented as an integer instead of a string.

Modifying the `serde::de::Visitor` Trait for the deserialization solved this issue by calling `deserializer.deserialize_any(Visitor(PhantomData))` which calls the appropriate deserializer for the JSON value. In JSON the default is [u64] AFAIK. Thus the function `visit_u64` is implemented which in turn tries to convert the number into the enum associated integer type.

[u64]: https://users.rust-lang.org/t/deserialize-a-number-that-may-be-inside-a-string-serde-json/27318/3