### PR TITLE
Add `Name` conversion and mnemonic Display for `new::base`

### DIFF
--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -882,6 +882,12 @@ impl fmt::Display for NameParseError {
 
 // -- Convert from old Name to new::base::NameBuf ----------------------------
 
+/// Upgrade a [`crate::base::Name`] into a
+/// [`crate::new::base::name::absolute::NameBuf`].
+///
+/// # Panics
+///
+/// The [`crate::base::Name`] slice has to contain a valid domain.
 #[allow(unused)]
 pub fn upgrade_name<Octs>(value: &crate::base::Name<Octs>) -> NameBuf
 where
@@ -901,7 +907,7 @@ mod tests {
             crate::base::Name::from_slice(b"\x07example\x03com\x00")
                 .expect("Invalid name");
 
-        let new_name: NameBuf = upgrade_name(&old_name);
+        let new_name: NameBuf = upgrade_name(old_name);
         assert_eq!(old_name.as_slice(), new_name.as_bytes())
     }
 }

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::{
     CanonicalName, Label, LabelBuf, LabelIter, LabelParseError,
-    NameCompressor,
+    NameCompressor, RevNameBuf,
 };
 
 //----------- Name -----------------------------------------------------------
@@ -99,6 +99,11 @@ impl Name {
     pub const fn labels(&self) -> LabelIter<'_> {
         // SAFETY: A 'Name' always contains valid encoded labels.
         unsafe { LabelIter::new_unchecked(self.as_bytes()) }
+    }
+
+    /// Covert &[`Name`] into [`RevNameBuf`]
+    pub fn to_revname(&self) -> RevNameBuf {
+        NameBuf::copy_from(self).into()
     }
 }
 
@@ -909,5 +914,14 @@ mod tests {
 
         let new_name: NameBuf = upgrade_name(old_name);
         assert_eq!(old_name.as_slice(), new_name.as_bytes())
+    }
+
+    #[test]
+    fn test_to_revname() {
+        let namebuf: NameBuf = "example.com".parse().unwrap();
+        assert_eq!(
+            (&namebuf).to_revname().as_bytes(),
+            b"\x00\x03com\x07example",
+        );
     }
 }

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -888,18 +888,19 @@ impl fmt::Display for NameParseError {
 // -- Convert from old Name to new::base::NameBuf ----------------------------
 
 /// Upgrade a [`crate::base::Name`] into a
-/// [`crate::new::base::name::absolute::NameBuf`].
+/// [`crate::new::base::name::NameBuf`].
 ///
 /// # Panics
 ///
 /// The [`crate::base::Name`] slice has to contain a valid domain.
-#[allow(unused)]
-pub fn upgrade_name<Octs>(value: &crate::base::Name<Octs>) -> NameBuf
+impl<Octs> From<&crate::base::Name<Octs>> for NameBuf
 where
     Octs: AsRef<[u8]> + ?Sized,
 {
-    NameBuf::parse_bytes(value.as_slice())
-        .expect("Tried to upgrade invalid name")
+    fn from(value: &crate::base::Name<Octs>) -> Self {
+        NameBuf::parse_bytes(value.as_slice())
+            .expect("Tried to upgrade invalid name")
+    }
 }
 
 #[cfg(test)]
@@ -912,7 +913,7 @@ mod tests {
             crate::base::Name::from_slice(b"\x07example\x03com\x00")
                 .expect("Invalid name");
 
-        let new_name: NameBuf = upgrade_name(old_name);
+        let new_name: NameBuf = old_name.into();
         assert_eq!(old_name.as_slice(), new_name.as_bytes())
     }
 

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -920,7 +920,7 @@ mod tests {
     fn test_to_revname() {
         let namebuf: NameBuf = "example.com".parse().unwrap();
         assert_eq!(
-            (&namebuf).to_revname().as_bytes(),
+            namebuf.to_revname().as_bytes(),
             b"\x00\x03com\x07example",
         );
     }

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -889,10 +889,6 @@ impl fmt::Display for NameParseError {
 
 /// Upgrade a [`crate::base::Name`] into a
 /// [`crate::new::base::name::NameBuf`].
-///
-/// # Panics
-///
-/// The [`crate::base::Name`] slice has to contain a valid domain.
 impl<Octs> From<&crate::base::Name<Octs>> for NameBuf
 where
     Octs: AsRef<[u8]> + ?Sized,

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -879,3 +879,29 @@ impl fmt::Display for NameParseError {
         })
     }
 }
+
+// -- Convert from old Name to new::base::NameBuf ----------------------------
+
+#[allow(unused)]
+pub fn upgrade_name<Octs>(value: &crate::base::Name<Octs>) -> NameBuf
+where
+    Octs: AsRef<[u8]> + ?Sized,
+{
+    NameBuf::parse_bytes(value.as_slice())
+        .expect("Tried to upgrade invalid name")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upgrade_name_to_namebuf() {
+        let old_name =
+            crate::base::Name::from_slice(b"\x07example\x03com\x00")
+                .expect("Invalid name");
+
+        let new_name: NameBuf = upgrade_name(&old_name);
+        assert_eq!(old_name.as_slice(), new_name.as_bytes())
+    }
+}

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -680,13 +680,14 @@ impl<'a> serde::Deserialize<'a> for std::boxed::Box<RevName> {
 /// # Panics
 ///
 /// The [`crate::base::Name`] slice has to contain a valid domain.
-#[allow(unused)]
-pub fn upgrade_name<Octs>(value: &crate::base::Name<Octs>) -> RevNameBuf
+impl<Octs> From<&crate::base::Name<Octs>> for RevNameBuf
 where
     Octs: AsRef<[u8]> + ?Sized,
 {
-    RevNameBuf::parse_bytes(value.as_slice())
-        .expect("Tried to upgrade invalid name")
+    fn from(value: &crate::base::Name<Octs>) -> Self {
+        RevNameBuf::parse_bytes(value.as_slice())
+            .expect("Tried to upgrade invalid name")
+    }
 }
 
 #[cfg(test)]
@@ -699,7 +700,7 @@ mod tests {
             crate::base::Name::from_slice(b"\x07example\x03com\x00")
                 .expect("Invalid name");
 
-        let new_name: RevNameBuf = upgrade_name(old_name);
+        let new_name: RevNameBuf = old_name.into();
         let mut buf = vec![0; new_name.built_bytes_size()];
         new_name.build_bytes(&mut buf).unwrap();
         assert_eq!(old_name.as_slice(), buf);

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -669,6 +669,12 @@ impl<'a> serde::Deserialize<'a> for std::boxed::Box<RevName> {
 
 // -- Convert from old Name to new::base::RevNameBuf -------------------------
 
+/// Upgrade a [`crate::base::Name`] into a
+/// [`crate::new::base::name::reversed::RevNameBuf`].
+///
+/// # Panics
+///
+/// The [`crate::base::Name`] slice has to contain a valid domain.
 #[allow(unused)]
 pub fn upgrade_name<Octs>(value: &crate::base::Name<Octs>) -> RevNameBuf
 where
@@ -688,7 +694,7 @@ mod tests {
             crate::base::Name::from_slice(b"\x07example\x03com\x00")
                 .expect("Invalid name");
 
-        let new_name: RevNameBuf = upgrade_name(&old_name);
+        let new_name: RevNameBuf = upgrade_name(old_name);
         assert_eq!(old_name.as_slice(), new_name.as_bytes())
     }
 }

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -666,3 +666,29 @@ impl<'a> serde::Deserialize<'a> for std::boxed::Box<RevName> {
             .map(|this| this.unsized_copy_into())
     }
 }
+
+// -- Convert from old Name to new::base::RevNameBuf -------------------------
+
+#[allow(unused)]
+pub fn upgrade_name<Octs>(value: &crate::base::Name<Octs>) -> RevNameBuf
+where
+    Octs: AsRef<[u8]> + ?Sized,
+{
+    RevNameBuf::parse_bytes(value.as_slice())
+        .expect("Tried to upgrade invalid name")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upgrade_revnamebuf() {
+        let old_name =
+            crate::base::Name::from_slice(b"\x07example\x03com\x00")
+                .expect("Invalid name");
+
+        let new_name: RevNameBuf = upgrade_name(&old_name);
+        assert_eq!(old_name.as_slice(), new_name.as_bytes())
+    }
+}

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -695,13 +695,14 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn test_upgrade_revnamebuf() {
         let old_name =
             crate::base::Name::from_slice(b"\x07example\x03com\x00")
                 .expect("Invalid name");
 
         let new_name: RevNameBuf = old_name.into();
-        let mut buf = vec![0; new_name.built_bytes_size()];
+        let mut buf = alloc::vec![0; new_name.built_bytes_size()];
         new_name.build_bytes(&mut buf).unwrap();
         assert_eq!(old_name.as_slice(), buf);
     }

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -709,7 +709,7 @@ mod tests {
     fn test_to_name() {
         let revnamebuf: RevNameBuf = "example.com".parse().unwrap();
         assert_eq!(
-            (&revnamebuf).to_name().as_bytes(),
+            revnamebuf.to_name().as_bytes(),
             b"\x07example\x03com\x00",
         );
     }

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -110,6 +110,11 @@ impl RevName {
         // SAFETY: A 'RevName' always contains valid encoded labels.
         unsafe { LabelIter::new_unchecked(self.as_bytes()) }
     }
+
+    /// Covert &[`RevName`] into [`NameBuf`]
+    pub fn to_name(&self) -> NameBuf {
+        RevNameBuf::copy_from(self).into()
+    }
 }
 
 //--- Building in DNS messages
@@ -698,5 +703,14 @@ mod tests {
         let mut buf = vec![0; new_name.built_bytes_size()];
         new_name.build_bytes(&mut buf).unwrap();
         assert_eq!(old_name.as_slice(), buf);
+    }
+
+    #[test]
+    fn test_to_name() {
+        let revnamebuf: RevNameBuf = "example.com".parse().unwrap();
+        assert_eq!(
+            (&revnamebuf).to_name().as_bytes(),
+            b"\x07example\x03com\x00",
+        );
     }
 }

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -695,6 +695,8 @@ mod tests {
                 .expect("Invalid name");
 
         let new_name: RevNameBuf = upgrade_name(old_name);
-        assert_eq!(old_name.as_slice(), new_name.as_bytes())
+        let mut buf = vec![0; new_name.built_bytes_size()];
+        new_name.build_bytes(&mut buf).unwrap();
+        assert_eq!(old_name.as_slice(), buf);
     }
 }

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -447,11 +447,20 @@ impl fmt::Debug for RType {
     }
 }
 
-/// Return the associated name of [`RType`]. If [`RType`] is unknown,
-/// then the returned string contains the type in the unknown format as
-/// defined in Section 5 in [RFC3597].
+/// Format an [`RType`] in a human-readable way
 ///
-/// The names are consolidated by [IANA].
+/// Return the mnemonic of [`RType`]. If [`RType`] is unknown, then the
+/// returned string contains the type in the unknown format as defined in
+/// Section 5 in [RFC3597].
+///
+/// The mnemonics are consolidated by [IANA].
+///
+/// ```
+/// // Known RType with mnemonic
+/// assert_eq!("A", format!("{}", RType::A));
+/// // Unknown RType
+/// assert_eq!("TYPE265", format!("{}", RType::from(265)));
+/// ```
 ///
 /// [RFC3597]: https://datatracker.ietf.org/doc/html/rfc3597#section-5
 /// [IANA]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
@@ -555,11 +564,20 @@ impl fmt::Debug for RClass {
     }
 }
 
-/// Return the associated name of [`RClass`]. If [`RClass`] is unknown,
-/// then the returned string contains the class in the unknown format as
-/// defined in Section 5 in [RFC3597].
+/// Format an [`RClass`] in a human-readable way
 ///
-/// The names are consolidated by [IANA].
+/// Return the mnemonic of [`RClass`]. If [`RClass`] is unknown, then the
+/// returned string contains the class in the unknown format as defined in
+/// Section 5 in [RFC3597].
+///
+/// The mnemonics are consolidated by [IANA].
+///
+/// ```
+/// // Known RClass with mnemonic
+/// assert_eq!("IN", format!("{}", RClass::IN));
+/// // Unknown RClass
+/// assert_eq!("CLASS42", format!("{}", RClass::from(42)));
+/// ```
 ///
 /// [RFC3597]: https://datatracker.ietf.org/doc/html/rfc3597#section-5
 /// [IANA]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -527,6 +527,22 @@ impl RClass {
     pub const CH: Self = Self::new(3);
 }
 
+//--- Conversion to and from 'u16'
+
+impl From<u16> for RClass {
+    fn from(value: u16) -> Self {
+        Self {
+            code: U16::new(value),
+        }
+    }
+}
+
+impl From<RClass> for u16 {
+    fn from(value: RClass) -> Self {
+        value.code.get()
+    }
+}
+
 //--- Formatting
 
 impl fmt::Debug for RClass {
@@ -816,9 +832,28 @@ mod test {
     }
 
     #[test]
+    fn test_rclass_from() {
+        let rclass: RClass = 1.into();
+        assert_eq!(rclass, RClass::IN);
+
+        let number: u16 = rclass.into();
+        assert_eq!(number, 1);
+    }
+
+    #[test]
+    fn test_rtype_from() {
+        let rtype: RType = 6.into();
+        assert_eq!(rtype, RType::SOA);
+
+        let number: u16 = rtype.into();
+        assert_eq!(number, 6);
+    }
+
+    #[test]
     fn test_rclass_display() {
         assert_eq!("IN", format!("{}", RClass::IN));
         assert_eq!("CH", format!("{}", RClass::CH));
+        assert_eq!("CLASS42", format!("{}", RClass::from(42)));
     }
 
     #[test]

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -447,6 +447,44 @@ impl fmt::Debug for RType {
     }
 }
 
+/// Return the associated name of [`RType`]. If [`RType`] is unknown,
+/// then the returned string contains the type in the unknown format as
+/// defined in Section 5 in [RFC3597].
+///
+/// The names are consolidated by [IANA].
+///
+/// [RFC3597]: https://datatracker.ietf.org/doc/html/rfc3597#section-5
+/// [IANA]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
+impl fmt::Display for RType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match *self {
+            Self::A => "A",
+            Self::NS => "NS",
+            Self::CNAME => "CNAME",
+            Self::SOA => "SOA",
+            Self::PTR => "PTR",
+            Self::HINFO => "HINFO",
+            Self::MX => "MX",
+            Self::TXT => "TXT",
+            Self::RP => "RP",
+            Self::AAAA => "AAAA",
+            Self::DNAME => "DNAME",
+            Self::OPT => "OPT",
+            Self::DS => "DS",
+            Self::RRSIG => "RRSIG",
+            Self::NSEC => "NSEC",
+            Self::DNSKEY => "DNSKEY",
+            Self::NSEC3 => "NSEC3",
+            Self::NSEC3PARAM => "NSEC3PARAM",
+            Self::CDS => "CDS",
+            Self::CDNSKEY => "CDNSKEY",
+            Self::ZONEMD => "ZONEMD",
+            Self::TSIG => "TSIG",
+            _ => return write!(f, "TYPE{}", self.code),
+        })
+    }
+}
+
 //----------- RClass ---------------------------------------------------------
 
 /// The class of a record.
@@ -497,6 +535,24 @@ impl fmt::Debug for RClass {
             Self::IN => "RClass::IN",
             Self::CH => "RClass::CH",
             _ => return write!(f, "RClass({})", self.code),
+        })
+    }
+}
+
+/// Return the associated name of [`RClass`]. If [`RClass`] is unknown,
+/// then the returned string contains the class in the unknown format as
+/// defined in Section 5 in [RFC3597].
+///
+/// The names are consolidated by [IANA].
+///
+/// [RFC3597]: https://datatracker.ietf.org/doc/html/rfc3597#section-5
+/// [IANA]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
+impl fmt::Display for RClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match *self {
+            Self::IN => "IN",
+            Self::CH => "CH",
+            _ => return write!(f, "CLASS{}", self.code),
         })
     }
 }
@@ -757,5 +813,18 @@ mod test {
         let mut buffer = [0u8; 15];
         assert_eq!(record.build_bytes(&mut buffer), Ok(&mut [] as &mut [u8]));
         assert_eq!(buffer, &bytes[..15]);
+    }
+
+    #[test]
+    fn test_rclass_display() {
+        assert_eq!("IN", format!("{}", RClass::IN));
+        assert_eq!("CH", format!("{}", RClass::CH));
+    }
+
+    #[test]
+    fn test_rtype_display() {
+        assert_eq!("A", format!("{}", RType::A));
+        assert_eq!("MX", format!("{}", RType::MX));
+        assert_eq!("TYPE265", format!("{}", RType::from(265)));
     }
 }

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -456,6 +456,7 @@ impl fmt::Debug for RType {
 /// The mnemonics are consolidated by [IANA].
 ///
 /// ```
+/// # use domain::new::base::RType;
 /// // Known RType with mnemonic
 /// assert_eq!("A", format!("{}", RType::A));
 /// // Unknown RType
@@ -573,6 +574,7 @@ impl fmt::Debug for RClass {
 /// The mnemonics are consolidated by [IANA].
 ///
 /// ```
+/// # use domain::new::base::RClass;
 /// // Known RClass with mnemonic
 /// assert_eq!("IN", format!("{}", RClass::IN));
 /// // Unknown RClass


### PR DESCRIPTION
This PR adds `From<>` implementations to work with `domain::base` `Name` types. Additionally easier conversion between `RevNameBuf` and `NameBuf`. And `fmt::Display`for `RType` and `RClass`.