### PR TITLE
Add catalog zone support behind unstable-catalog feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ zonefile    = ["bytes", "serde", "std"]
 
 # Unstable features
 unstable-new = []
+unstable-catalog = ["unstable-zonetree"]
 unstable-client-cache = ["unstable-client-transport", "moka"]
 unstable-client-transport = ["net", "tracing"]
 unstable-crypto = ["bytes", "std"]

--- a/src/catalog/build.rs
+++ b/src/catalog/build.rs
@@ -1,0 +1,143 @@
+//! Generating a catalog zone from its membership.
+
+use std::collections::HashMap;
+use std::vec::Vec;
+
+use bytes::Bytes;
+
+use crate::base::Ttl;
+use crate::base::iana::{Class, Rtype};
+use crate::base::name::NameBuilder;
+use crate::base::record::Record;
+use crate::rdata::{Ns, Ptr, Soa, Txt, ZoneRecordData};
+use crate::zonetree::types::{
+    Rrset, StoredName, StoredRecord, StoredRecordData,
+};
+use crate::zonetree::{Zone, ZoneBuilder};
+
+use super::types::{BuildCatalogError, Catalog};
+
+/// The schema version emitted in generated catalog zones.
+const SUPPORTED_SCHEMA_VERSION: &[u8] = b"2";
+
+/// The label introducing the member zone collection (`<id>.zones.<apex>`).
+const ZONES_LABEL: &[u8] = b"zones";
+
+/// The label carrying the catalog zone schema version.
+const VERSION_LABEL: &[u8] = b"version";
+
+/// The per-member property label carrying the group of a member zone.
+const GROUP_LABEL: &[u8] = b"group";
+
+impl Catalog {
+    /// Generates the records of a catalog zone from this catalog.
+    ///
+    /// The generated zone consists of the apex SOA and NS records, the schema
+    /// version record at `version.<apex>` and, for each member, a PTR record
+    /// at `<id>.zones.<apex>` plus an optional `group` property record. All
+    /// records use the given `ttl`.
+    pub fn to_records(
+        &self,
+        soa: Soa<StoredName>,
+        ns: &[StoredName],
+        ttl: Ttl,
+    ) -> Result<Vec<StoredRecord>, BuildCatalogError> {
+        let apex = self.apex();
+        let mut records = Vec::new();
+
+        records.push(record(apex.clone(), ttl, ZoneRecordData::Soa(soa)));
+
+        for nsdname in ns {
+            records.push(record(
+                apex.clone(),
+                ttl,
+                ZoneRecordData::Ns(Ns::new(nsdname.clone())),
+            ));
+        }
+
+        let version_name = make_name(&[VERSION_LABEL], apex)?;
+        let version = txt(SUPPORTED_SCHEMA_VERSION)?;
+        records.push(record(version_name, ttl, version));
+
+        for member in self.members() {
+            let member_name = make_name(&[member.id(), ZONES_LABEL], apex)?;
+            records.push(record(
+                member_name,
+                ttl,
+                ZoneRecordData::Ptr(Ptr::new(member.name().clone())),
+            ));
+
+            if let Some(group) = member.group() {
+                let labels = [GROUP_LABEL, member.id(), ZONES_LABEL];
+                let group_name = make_name(&labels, apex)?;
+                records.push(record(group_name, ttl, txt(group)?));
+            }
+        }
+
+        Ok(records)
+    }
+
+    /// Generates a catalog [`Zone`] from this catalog.
+    ///
+    /// See [`Catalog::to_records`] for the records that make up the zone.
+    pub fn to_zone(
+        &self,
+        soa: Soa<StoredName>,
+        ns: &[StoredName],
+        ttl: Ttl,
+    ) -> Result<Zone, BuildCatalogError> {
+        let records = self.to_records(soa, ns, ttl)?;
+
+        let mut rrsets: HashMap<(StoredName, Rtype), Rrset> = HashMap::new();
+        for record in records {
+            let key = (record.owner().clone(), record.rtype());
+            rrsets
+                .entry(key)
+                .or_insert_with(|| Rrset::new(record.rtype(), record.ttl()))
+                .push_data(record.into_data());
+        }
+
+        let mut builder = ZoneBuilder::new(self.apex().clone(), Class::IN);
+        for ((owner, _rtype), rrset) in rrsets {
+            builder
+                .insert_rrset(&owner, rrset.into_shared())
+                .map_err(|_| BuildCatalogError::BadName)?;
+        }
+
+        Ok(builder.build())
+    }
+}
+
+//------------ Helper functions ----------------------------------------------
+
+/// Creates a stored record with the given owner, TTL and data.
+fn record(
+    owner: StoredName,
+    ttl: Ttl,
+    data: StoredRecordData,
+) -> StoredRecord {
+    Record::new(owner, Class::IN, ttl, data)
+}
+
+/// Builds TXT record data from a single octets slice.
+fn txt(value: &[u8]) -> Result<StoredRecordData, BuildCatalogError> {
+    Txt::<Bytes>::build_from_slice(value)
+        .map(ZoneRecordData::Txt)
+        .map_err(|_| BuildCatalogError::BadValue)
+}
+
+/// Builds an owner name by prepending the given labels to `apex`.
+fn make_name(
+    labels: &[&[u8]],
+    apex: &StoredName,
+) -> Result<StoredName, BuildCatalogError> {
+    let mut builder = NameBuilder::new_bytes();
+    for label in labels {
+        builder
+            .append_label(label)
+            .map_err(|_| BuildCatalogError::BadName)?;
+    }
+    builder
+        .append_origin(apex)
+        .map_err(|_| BuildCatalogError::BadName)
+}

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1,0 +1,179 @@
+#![cfg(feature = "unstable-catalog")]
+#![cfg_attr(docsrs, doc(cfg(feature = "unstable-catalog")))]
+#![warn(missing_docs)]
+//! Reading and writing of catalog zones.
+//!
+//! A catalog zone, as defined by [RFC 9432], is an ordinary DNS zone whose
+//! contents describe a collection of _member zones_. Catalog zones provide a
+//! means of provisioning zones onto secondary name servers without per-zone
+//! configuration: a _catalog producer_ publishes a catalog zone listing its
+//! member zones, and a _catalog consumer_ transfers the catalog and adds or
+//! removes the member zones automatically.
+//!
+//! This module provides the building blocks for both roles. The central type
+//! is [`Catalog`], which captures the apex of a catalog zone together with
+//! its [member zones][CatalogMember].
+//!
+//! # Consuming a catalog zone
+//!
+//! Given a catalog zone as a [`Zone`] (or a sequence of records), the
+//! membership can be extracted with [`Catalog::parse_zone`] (or
+//! [`Catalog::parse_records`]):
+//!
+//! ```no_run
+//! use domain::catalog::Catalog;
+//! use domain::zonetree::Zone;
+//!
+//! # fn example(zone: &Zone) -> Result<(), Box<dyn std::error::Error>> {
+//! let catalog = Catalog::parse_zone(zone)?;
+//! for member in catalog.members() {
+//!     println!("member zone {}", member.name());
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Producing a catalog zone
+//!
+//! Conversely, a [`Catalog`] can be turned into a [`Zone`] with
+//! [`Catalog::to_zone`] or into a sequence of records with
+//! [`Catalog::to_records`], ready to be served to catalog consumers.
+//!
+//! # Schema version and properties
+//!
+//! Only schema version 2 as defined by [RFC 9432] is supported. The
+//! per-member `group` property (as used by, e.g., BIND) is recognised and
+//! preserved; other properties are tolerated but ignored.
+//!
+//! [RFC 9432]: https://datatracker.ietf.org/doc/html/rfc9432
+//! [`Zone`]: crate::zonetree::Zone
+
+mod build;
+mod parse;
+mod types;
+
+pub use self::types::{
+    BuildCatalogError, Catalog, CatalogMember, ParseCatalogError,
+};
+
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+
+    use crate::base::iana::Class;
+    use crate::base::name::Name;
+    use crate::base::{Serial, Ttl};
+    use crate::rdata::Soa;
+
+    use super::{Catalog, CatalogMember, ParseCatalogError};
+
+    /// Returns a catalog apex name for use in tests.
+    fn apex() -> Name<Bytes> {
+        Name::bytes_from_str("catalog.example.").unwrap()
+    }
+
+    /// Returns a member zone name for use in tests.
+    fn member_name(label: &str) -> Name<Bytes> {
+        Name::bytes_from_str(&format!("{label}.example.")).unwrap()
+    }
+
+    /// Returns an SOA record suitable for a generated catalog zone.
+    fn soa(serial: u32) -> Soa<Name<Bytes>> {
+        Soa::new(
+            Name::bytes_from_str("invalid.").unwrap(),
+            Name::bytes_from_str("invalid.").unwrap(),
+            Serial(serial),
+            Ttl::from_secs(3600),
+            Ttl::from_secs(600),
+            Ttl::from_secs(86400),
+            Ttl::from_secs(3600),
+        )
+    }
+
+    /// Builds a sample catalog with two members, one of which has a group.
+    fn sample_catalog() -> Catalog {
+        let mut catalog = Catalog::new(apex());
+        catalog.push_member(CatalogMember::new(
+            Bytes::from_static(b"id1"),
+            member_name("one"),
+        ));
+        let mut member = CatalogMember::new(
+            Bytes::from_static(b"id2"),
+            member_name("two"),
+        );
+        member.set_group(Bytes::from_static(b"production"));
+        catalog.push_member(member);
+        catalog
+    }
+
+    #[test]
+    fn build_then_parse_round_trips() {
+        let original = sample_catalog();
+        let ns = [Name::bytes_from_str("invalid.").unwrap()];
+        let zone = original.to_zone(soa(1), &ns, Ttl::from_secs(0)).unwrap();
+
+        let parsed = Catalog::parse_zone(&zone).unwrap();
+
+        assert_eq!(parsed.apex(), original.apex());
+        assert_eq!(parsed.serial(), Some(Serial(1)));
+        assert_eq!(parsed.members(), original.members());
+    }
+
+    #[test]
+    fn parse_records_collects_members_and_group() {
+        let ns = [Name::bytes_from_str("invalid.").unwrap()];
+        let records = sample_catalog()
+            .to_records(soa(7), &ns, Ttl::from_secs(0))
+            .unwrap();
+
+        let catalog = Catalog::parse_records(apex(), records).unwrap();
+
+        assert_eq!(catalog.members().len(), 2);
+        assert_eq!(catalog.members()[0].id(), b"id1");
+        assert_eq!(catalog.members()[0].name(), &member_name("one"));
+        assert_eq!(catalog.members()[0].group(), None);
+        assert_eq!(catalog.members()[1].id(), b"id2");
+        let group = catalog.members()[1].group();
+        assert_eq!(group, Some(b"production".as_ref()));
+    }
+
+    #[test]
+    fn missing_version_is_rejected() {
+        // A catalog with no version record at all.
+        let apex = apex();
+        let records = std::vec::Vec::new();
+        assert_eq!(
+            Catalog::parse_records(apex, records),
+            Err(ParseCatalogError::MissingSchemaVersion),
+        );
+    }
+
+    #[test]
+    fn unsupported_version_is_rejected() {
+        let ns = [Name::bytes_from_str("invalid.").unwrap()];
+        let mut records = sample_catalog()
+            .to_records(soa(1), &ns, Ttl::from_secs(0))
+            .unwrap();
+
+        // Replace the version TXT value with an unsupported version.
+        use crate::base::name::NameBuilder;
+        use crate::base::record::Record;
+        use crate::rdata::{Txt, ZoneRecordData};
+        let mut builder = NameBuilder::new_bytes();
+        builder.append_label(b"version").unwrap();
+        let version_name = builder.append_origin(&apex()).unwrap();
+        records.retain(|record| record.owner() != &version_name);
+        let bad_version = Txt::<Bytes>::build_from_slice(b"99").unwrap();
+        records.push(Record::new(
+            version_name,
+            Class::IN,
+            Ttl::from_secs(0),
+            ZoneRecordData::Txt(bad_version),
+        ));
+
+        assert_eq!(
+            Catalog::parse_records(apex(), records),
+            Err(ParseCatalogError::UnsupportedSchemaVersion),
+        );
+    }
+}

--- a/src/catalog/parse.rs
+++ b/src/catalog/parse.rs
@@ -1,0 +1,219 @@
+//! Parsing the membership of a catalog zone.
+
+use std::boxed::Box;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::vec::Vec;
+
+use bytes::Bytes;
+
+use crate::base::iana::Class;
+use crate::base::name::Label;
+use crate::base::record::Record;
+use crate::rdata::ZoneRecordData;
+use crate::zonetree::Zone;
+use crate::zonetree::types::{StoredName, StoredRecord};
+
+use super::types::{Catalog, CatalogMember, ParseCatalogError};
+
+/// The catalog zone schema version supported by this crate.
+const SUPPORTED_SCHEMA_VERSION: &[u8] = b"2";
+
+/// The label introducing the member zone collection (`<id>.zones.<apex>`).
+const ZONES_LABEL: &[u8] = b"zones";
+
+/// The label carrying the catalog zone schema version.
+const VERSION_LABEL: &[u8] = b"version";
+
+/// The per-member property label carrying the group of a member zone.
+const GROUP_LABEL: &[u8] = b"group";
+
+impl Catalog {
+    /// Parses the membership of a catalog zone from a [`Zone`].
+    ///
+    /// This walks the entire zone, interpreting its records according to
+    /// RFC 9432. The catalog's apex is taken from the zone.
+    ///
+    /// Returns an error if the zone does not declare a supported schema
+    /// version. Member entries that cannot be interpreted are ignored.
+    pub fn parse_zone(zone: &Zone) -> Result<Self, ParseCatalogError> {
+        let apex = zone.apex_name().clone();
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let collector = records.clone();
+        zone.read()
+            .walk(Box::new(move |owner, rrset, _at_zone_cut| {
+                let mut records = collector.lock().unwrap();
+                for data in rrset.data() {
+                    records.push(Record::new(
+                        owner.clone(),
+                        Class::IN,
+                        rrset.ttl(),
+                        data.clone(),
+                    ));
+                }
+            }));
+
+        // The walk has completed, so we are the only remaining reference.
+        let records = Arc::try_unwrap(records)
+            .map(|mutex| mutex.into_inner().unwrap())
+            .unwrap_or_default();
+
+        Self::parse_records(apex, records)
+    }
+
+    /// Parses the membership of a catalog zone from its records.
+    ///
+    /// The `apex` is the apex name of the catalog zone. The records may be
+    /// supplied in any order.
+    ///
+    /// Returns an error if the records do not declare a supported schema
+    /// version. Member entries that cannot be interpreted are ignored.
+    pub fn parse_records<I>(
+        apex: StoredName,
+        records: I,
+    ) -> Result<Self, ParseCatalogError>
+    where
+        I: IntoIterator<Item = StoredRecord>,
+    {
+        let mut version = Version::Missing;
+        let mut serial = None;
+        let mut members: HashMap<Bytes, PartialMember> = HashMap::new();
+
+        for record in records {
+            let owner = record.owner();
+            let Some(prefix) = relative_labels(owner, &apex) else {
+                continue;
+            };
+
+            match prefix.as_slice() {
+                // The apex SOA gives us the catalog serial.
+                [] => {
+                    if let ZoneRecordData::Soa(soa) = record.data() {
+                        serial = Some(soa.serial());
+                    }
+                }
+
+                // `version.<apex>` carries the schema version.
+                [label] if label_eq(label, VERSION_LABEL) => {
+                    if let ZoneRecordData::Txt(txt) = record.data() {
+                        let value = txt.text::<Vec<u8>>();
+                        version = if value == SUPPORTED_SCHEMA_VERSION {
+                            Version::Supported
+                        } else {
+                            Version::Unsupported
+                        };
+                    }
+                }
+
+                // `<id>.zones.<apex>` PTR points to a member zone.
+                [id, zones] if label_eq(zones, ZONES_LABEL) => {
+                    if let ZoneRecordData::Ptr(ptr) = record.data() {
+                        let entry =
+                            members.entry(label_bytes(id)).or_default();
+                        entry.name = Some(ptr.ptrdname().clone());
+                    }
+                }
+
+                // `<property>.<id>.zones.<apex>` carries a member property.
+                [property, id, zones]
+                    if label_eq(zones, ZONES_LABEL)
+                        && label_eq(property, GROUP_LABEL) =>
+                {
+                    if let ZoneRecordData::Txt(txt) = record.data() {
+                        let entry =
+                            members.entry(label_bytes(id)).or_default();
+                        entry.group =
+                            Some(Bytes::from(txt.text::<Vec<u8>>()));
+                    }
+                }
+
+                _ => {}
+            }
+        }
+
+        match version {
+            Version::Missing => {
+                return Err(ParseCatalogError::MissingSchemaVersion);
+            }
+            Version::Unsupported => {
+                return Err(ParseCatalogError::UnsupportedSchemaVersion);
+            }
+            Version::Supported => {}
+        }
+
+        let mut catalog = Catalog::new(apex);
+        if let Some(serial) = serial {
+            catalog.set_serial(serial);
+        }
+
+        // Only entries with a PTR record are valid members. Sort by
+        // identifier to give callers a deterministic ordering.
+        let mut entries: Vec<(Bytes, PartialMember)> =
+            members.into_iter().collect();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        for (id, entry) in entries {
+            if let Some(name) = entry.name {
+                let mut member = CatalogMember::new(id, name);
+                if let Some(group) = entry.group {
+                    member.set_group(group);
+                }
+                catalog.push_member(member);
+            }
+        }
+
+        Ok(catalog)
+    }
+}
+
+//------------ Version -------------------------------------------------------
+
+/// The schema version state observed while parsing.
+enum Version {
+    /// No version record has been seen.
+    Missing,
+
+    /// A supported version record has been seen.
+    Supported,
+
+    /// A version record with an unsupported value has been seen.
+    Unsupported,
+}
+
+//------------ PartialMember -------------------------------------------------
+
+/// A member zone being assembled from several records.
+#[derive(Default)]
+struct PartialMember {
+    /// The member zone name from its PTR record.
+    name: Option<StoredName>,
+
+    /// The value of the member's `group` property, if seen.
+    group: Option<Bytes>,
+}
+
+//------------ Helper functions ----------------------------------------------
+
+/// Returns the labels of `owner` that precede `apex`, if `owner` is in zone.
+///
+/// For an owner name of `<id>.zones.<apex>` this returns the labels `id` and
+/// `zones`. Returns `None` if `owner` is not contained within `apex`.
+fn relative_labels<'a>(
+    owner: &'a StoredName,
+    apex: &StoredName,
+) -> Option<Vec<&'a Label>> {
+    if !owner.ends_with(apex) {
+        return None;
+    }
+    let prefix_len = owner.label_count().checked_sub(apex.label_count())?;
+    Some(owner.iter().take(prefix_len).collect())
+}
+
+/// Compares a label against a byte slice, ignoring ASCII case.
+fn label_eq(label: &Label, text: &[u8]) -> bool {
+    label.as_slice().eq_ignore_ascii_case(text)
+}
+
+/// Copies the content of a label into a [`Bytes`].
+fn label_bytes(label: &Label) -> Bytes {
+    Bytes::copy_from_slice(label.as_slice())
+}

--- a/src/catalog/types.rs
+++ b/src/catalog/types.rs
@@ -1,0 +1,207 @@
+//! Core types for representing catalog zones.
+
+use core::fmt;
+
+use std::vec::Vec;
+
+use bytes::Bytes;
+
+use crate::base::Serial;
+use crate::zonetree::types::StoredName;
+
+//------------ Catalog -------------------------------------------------------
+
+/// The membership information held in an RFC 9432 catalog zone.
+///
+/// A catalog zone is an ordinary DNS zone whose contents describe a set of
+/// _member zones_. This type captures the information that a catalog consumer
+/// or producer cares about: the catalog's own apex, its SOA serial (if known)
+/// and the list of member zones together with their properties.
+///
+/// Use [`Catalog::parse_zone`] or [`Catalog::parse_records`] to extract this
+/// information from a catalog zone, and [`Catalog::to_zone`] or
+/// [`Catalog::to_records`] to generate a catalog zone from it.
+///
+/// [`Catalog::parse_zone`]: Catalog::parse_zone
+/// [`Catalog::parse_records`]: Catalog::parse_records
+/// [`Catalog::to_zone`]: Catalog::to_zone
+/// [`Catalog::to_records`]: Catalog::to_records
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Catalog {
+    /// The apex name of the catalog zone.
+    apex: StoredName,
+
+    /// The serial of the catalog zone, if it was determined while parsing.
+    serial: Option<Serial>,
+
+    /// The member zones described by the catalog.
+    members: Vec<CatalogMember>,
+}
+
+impl Catalog {
+    /// Creates a new, empty catalog with the given apex name.
+    #[must_use]
+    pub fn new(apex: StoredName) -> Self {
+        Self {
+            apex,
+            serial: None,
+            members: Vec::new(),
+        }
+    }
+
+    /// Returns the apex name of the catalog zone.
+    pub fn apex(&self) -> &StoredName {
+        &self.apex
+    }
+
+    /// Returns the SOA serial of the catalog zone, if known.
+    ///
+    /// This is populated when the catalog is parsed from a zone that contains
+    /// an apex SOA record. It is `None` for catalogs created via
+    /// [`Catalog::new`].
+    pub fn serial(&self) -> Option<Serial> {
+        self.serial
+    }
+
+    /// Sets the SOA serial of the catalog zone.
+    pub fn set_serial(&mut self, serial: Serial) {
+        self.serial = Some(serial);
+    }
+
+    /// Returns the member zones described by the catalog.
+    pub fn members(&self) -> &[CatalogMember] {
+        &self.members
+    }
+
+    /// Adds a member zone to the catalog.
+    pub fn push_member(&mut self, member: CatalogMember) {
+        self.members.push(member);
+    }
+}
+
+//------------ CatalogMember -------------------------------------------------
+
+/// A single member zone described by a catalog zone.
+///
+/// Each member is identified within the catalog by a unique label and points
+/// to a member zone name via a PTR record at `<id>.zones.<catalog-apex>`. A
+/// member may additionally carry a `group` property which a consumer can use
+/// to select differing configuration for the member.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CatalogMember {
+    /// The unique identifier label of the member within the catalog.
+    ///
+    /// This is the single label found immediately before the `zones` label
+    /// in the member's owner name. It carries no semantics beyond uniquely
+    /// identifying the member within the catalog.
+    id: Bytes,
+
+    /// The name of the member zone.
+    name: StoredName,
+
+    /// The value of the member's `group` property, if present.
+    group: Option<Bytes>,
+}
+
+impl CatalogMember {
+    /// Creates a new member with the given identifier and zone name.
+    #[must_use]
+    pub fn new(id: Bytes, name: StoredName) -> Self {
+        Self {
+            id,
+            name,
+            group: None,
+        }
+    }
+
+    /// Returns the unique identifier label of the member.
+    pub fn id(&self) -> &[u8] {
+        self.id.as_ref()
+    }
+
+    /// Returns the name of the member zone.
+    pub fn name(&self) -> &StoredName {
+        &self.name
+    }
+
+    /// Returns the value of the member's `group` property, if present.
+    pub fn group(&self) -> Option<&[u8]> {
+        self.group.as_ref().map(|group| group.as_ref())
+    }
+
+    /// Sets the value of the member's `group` property.
+    pub fn set_group(&mut self, group: Bytes) {
+        self.group = Some(group);
+    }
+}
+
+//============ Error types ===================================================
+
+//------------ ParseCatalogError ---------------------------------------------
+
+/// An error that occurred while parsing a catalog zone.
+///
+/// Only catalog-wide problems are reported as errors. Individual member
+/// entries that cannot be interpreted are silently ignored, in keeping with
+/// the leniency expected of catalog consumers by RFC 9432.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ParseCatalogError {
+    /// The catalog zone did not contain a schema version record.
+    ///
+    /// RFC 9432 requires a TXT record at `version.<catalog-apex>`.
+    MissingSchemaVersion,
+
+    /// The catalog zone declared a schema version that is not supported.
+    ///
+    /// This crate supports schema version 2 as defined by RFC 9432.
+    UnsupportedSchemaVersion,
+}
+
+//--- Display and Error
+
+impl fmt::Display for ParseCatalogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseCatalogError::MissingSchemaVersion => {
+                f.write_str("missing catalog zone schema version")
+            }
+            ParseCatalogError::UnsupportedSchemaVersion => {
+                f.write_str("unsupported catalog zone schema version")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParseCatalogError {}
+
+//------------ BuildCatalogError ---------------------------------------------
+
+/// An error that occurred while generating a catalog zone.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BuildCatalogError {
+    /// A constructed owner name was not a valid domain name.
+    ///
+    /// This happens if a member identifier is not a valid label or if the
+    /// resulting owner name would exceed the maximum domain name length.
+    BadName,
+
+    /// A property value could not be encoded as TXT record data.
+    BadValue,
+}
+
+//--- Display and Error
+
+impl fmt::Display for BuildCatalogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BuildCatalogError::BadName => {
+                f.write_str("invalid catalog member owner name")
+            }
+            BuildCatalogError::BadValue => {
+                f.write_str("invalid catalog property value")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BuildCatalogError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,8 @@
 //!
 //! Currently, the following unstable features exist:
 //!
+//! * `unstable-catalog`: reading and writing of catalog zones (RFC 9432);
+//!   primarily the `catalog` module.
 //! * `unstable-client-transport`: sending and receiving DNS messages from
 //!   a client perspective; primarily the `net::client` module.
 //! * `unstable-server-transport`: receiving and sending DNS messages from
@@ -206,6 +208,7 @@ extern crate self as domain;
 pub use core as __core;
 
 pub mod base;
+pub mod catalog;
 pub mod crypto;
 pub mod dep;
 pub mod dnssec;


### PR DESCRIPTION
This is WORK IN PROGRESS, and is TOTALLY UNTESTED outside for some synthetic unit tests and the bare minimum support for my Cascade testing. Both this and the Cascade feature need considerably more work.

Introduce a new `catalog` module implementing RFC 9432 catalog zones, gated behind the `unstable-catalog` feature (which enables `unstable-zonetree`).

This is used by https://github.com/NLnetLabs/cascade/pull/827 to implement catalog zone support in Cascade.