### PR TITLE
[doc] `name` redirected to `Name` type instead of module

### DIFF
--- a/src/new/base/mod.rs
+++ b/src/new/base/mod.rs
@@ -34,6 +34,7 @@
 //! <code>Box&lt;[Name]&gt;</code> respectively. There are more efficient
 //! alternatives in some cases; see [`name`].
 //!
+//! [`name`]: domain::new::base::name
 //! [Name]: name::Name
 //! [RevName]: name::RevName
 //! [`NameBuf`]: name::NameBuf


### PR DESCRIPTION
The links in the documentation of the submodules for `domain::new` redirected links to `name` to the `Name` type instead of the `name` module.