### PR TITLE
Overhaul `new/base/name/label.rs`

### DIFF
--- a/src/new/base/build/message.rs
+++ b/src/new/base/build/message.rs
@@ -371,7 +371,7 @@ mod test {
         );
 
         let question = Question::<RevNameBuf> {
-            qname: "www.example.org".parse().unwrap(),
+            qname: "www.example.org.".parse().unwrap(),
             qtype: QType::A,
             qclass: QClass::IN,
         };
@@ -393,7 +393,7 @@ mod test {
         );
 
         let record = Record::<RevNameBuf, _> {
-            rname: "www.example.org".parse().unwrap(),
+            rname: "www.example.org.".parse().unwrap(),
             rtype: RType::A,
             rclass: RClass::IN,
             ttl: TTL::from(42),

--- a/src/new/base/build/mod.rs
+++ b/src/new/base/build/mod.rs
@@ -36,14 +36,14 @@
 //!
 //! // Add a question for an A record.
 //! builder.push_question(&Question {
-//!     qname: "www.example.org".parse::<RevNameBuf>().unwrap(),
+//!     qname: "www.example.org.".parse::<RevNameBuf>().unwrap(),
 //!     qtype: QType::A,
 //!     qclass: QClass::IN,
 //! }).unwrap();
 //!
 //! // Add an answer.
 //! builder.push_answer(&Record {
-//!     rname: "www.example.org".parse::<RevNameBuf>().unwrap(),
+//!     rname: "www.example.org.".parse::<RevNameBuf>().unwrap(),
 //!     rtype: RType::A,
 //!     rclass: RClass::IN,
 //!     ttl: 3600.into(),

--- a/src/new/base/mod.rs
+++ b/src/new/base/mod.rs
@@ -134,7 +134,7 @@
 //!
 //! // Add a question for an A record.
 //! builder.push_question(&Question {
-//!     qname: "www.example.org".parse::<RevNameBuf>().unwrap(),
+//!     qname: "www.example.org.".parse::<RevNameBuf>().unwrap(),
 //!     qtype: QType::A,
 //!     qclass: QClass::IN,
 //! }).unwrap();

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -12,6 +12,7 @@ use core::{
 use crate::{
     new::base::{
         build::BuildInMessage,
+        name::LabelSplitError,
         parse::{ParseMessageBytes, SplitMessageBytes},
         wire::{
             AsBytes, BuildBytes, ParseBytes, ParseError, SplitBytes,
@@ -576,7 +577,7 @@ impl NameBuf {
     ///
     /// This is an internal convenience function used while building buffers.
     fn append_label(&mut self, label: &Label) {
-        self.append_bytes(label.as_bytes());
+        self.append_bytes(label.encoding());
     }
 }
 
@@ -667,30 +668,136 @@ impl fmt::Debug for NameBuf {
 //--- Parsing from strings
 
 impl NameBuf {
-    /// Parse a domain name from the zonefile format.
-    pub fn parse_str(mut s: &[u8]) -> Result<(Self, &[u8]), NameParseError> {
+    /// Parse a printed domain name.
+    ///
+    /// This will parse a domain name from the format used by [`impl Display
+    /// for Name`]. This is a subset of the syntax of the zone file format.
+    /// See the examples here to understand how this implementation works.
+    ///
+    /// This function is a direct inverse of [`impl Display for NameBuf`],
+    /// but it cannot be used to parse a domain name embedded within a larger
+    /// string. For that, see [`NameBuf::split_str()`].
+    //
+    // TODO: Doc tests
+    pub fn parse_str(mut s: &[u8]) -> Result<Self, NameParseError> {
         // The buffer we'll fill into.
         let mut this = Self::empty();
 
         // Parse label by label.
-        loop {
-            let (label, rest) = LabelBuf::parse_str(s)?;
+        let absolute = loop {
+            let (label, rest) = match LabelBuf::split_str(s) {
+                Ok((label, rest)) => (label, rest),
+                Err(LabelSplitError::Overlong) => {
+                    return Err(NameParseError::Overlong);
+                }
+                Err(LabelSplitError::InvalidChar) => {
+                    return Err(NameParseError::InvalidChar);
+                }
+                Err(LabelSplitError::InvalidEscape) => {
+                    return Err(NameParseError::InvalidEscape);
+                }
+                Err(LabelSplitError::ShortInput) => {
+                    // Parsing the label reached the end of the input;
+                    // Re-parse with the knowledge that this is the complete
+                    // input.
+                    (LabelBuf::parse_str(s)?, &[] as _)
+                }
+            };
 
-            if 255 - this.size < 1 + label.as_bytes().len() as u8 {
+            if 255 - this.size < label.encoding().len() as u8 {
                 return Err(NameParseError::Overlong);
             }
             this.append_label(&label);
 
-            match *rest {
-                [b' ' | b'\n' | b'\r' | b'\t', ..] | [] => {
-                    s = rest;
-                    break;
+            // Try continuing.
+            let [b'.', ref rest @ ..] = *rest else {
+                if !rest.is_empty() {
+                    // `rest` contained a character that was not valid for
+                    // `Label`, and was also not a `.`.
+                    return Err(NameParseError::InvalidChar);
                 }
-                [b'.', ref rest @ ..] => s = rest,
-                _ => return Err(NameParseError::InvalidChar),
+
+                break label.is_root();
+            };
+
+            if label.is_root() {
+                // `.` after the root label.
+                return Err(NameParseError::EmptyLabel);
             }
+
+            s = rest;
+            continue;
+        };
+
+        // TODO: If we require `absolute`, this function can only be used
+        // with `.`-suffixed domain names. If we don't, this function stops
+        // parsing a proper subset of the zone file format (since unsuffixed
+        // names would be processed differently in the zone file format).
+        //
+        // For now, we require `absolute`. It's the conservative choice.
+        if !absolute {
+            return Err(NameParseError::Relative);
         }
-        this.append_label(Label::ROOT);
+
+        Ok(this)
+    }
+
+    /// Parse a printed domain name from a larger string.
+    ///
+    /// This will parse a domain name from the format used by [`impl Display
+    /// for Name`]. This is a subset of the syntax of the zone file format.
+    /// See the examples here to understand how this implementation works.
+    ///
+    /// This function is designed for use when parsing domain names embedded
+    /// within some larger string (e.g. a zone file). The string may be
+    /// buffered, so only a part of it is provided; the string is considered
+    /// to be infinitely long. A domain name is only parsed successfully once
+    /// a delimiting byte (one that lies _after_ it) is found. As such, this
+    /// function is **not** a perfect inverse of [`impl Display for NameBuf`].
+    /// For such an inverse, see [`NameBuf::parse_str()`].
+    //
+    // TODO: Doc tests
+    pub fn split_str(mut s: &[u8]) -> Result<(Self, &[u8]), NameSplitError> {
+        // The buffer we'll fill into.
+        let mut this = Self::empty();
+
+        // Parse label by label.
+        let absolute = loop {
+            let (label, rest) = LabelBuf::split_str(s)?;
+
+            if 255 - this.size < label.encoding().len() as u8 {
+                return Err(NameSplitError::Overlong);
+            }
+            this.append_label(&label);
+
+            // Try continuing.
+            let [b'.', ref rest @ ..] = *rest else {
+                debug_assert!(
+                    !rest.is_empty(),
+                    "`LabelBuf::split_str()` fails without a delimiting character"
+                );
+
+                break label.is_root();
+            };
+
+            if label.is_root() {
+                // `.` after the root label.
+                return Err(NameSplitError::EmptyLabel);
+            }
+
+            s = rest;
+            continue;
+        };
+
+        // TODO: If we require `absolute`, this function can only be used
+        // with `.`-suffixed domain names. If we don't, this function stops
+        // parsing a proper subset of the zone file format (since unsuffixed
+        // names would be processed differently in the zone file format).
+        //
+        // For now, we require `absolute`. It's the conservative choice.
+        if !absolute {
+            return Err(NameSplitError::Relative);
+        }
 
         Ok((this, s))
     }
@@ -699,13 +806,11 @@ impl NameBuf {
 impl FromStr for NameBuf {
     type Err = NameParseError;
 
-    /// Parse a name from a string.
+    /// Parse a printed domain name.
+    ///
+    /// See [`NameBuf::parse_str()`].
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match Self::parse_str(s.as_bytes()) {
-            Ok((this, &[])) => Ok(this),
-            Ok(_) => Err(NameParseError::InvalidChar),
-            Err(err) => Err(err),
-        }
+        Self::parse_str(s.as_bytes())
     }
 }
 
@@ -836,14 +941,35 @@ impl<'a> serde::Deserialize<'a> for alloc::boxed::Box<Name> {
 
 /// An error in parsing a [`Name`] from a string.
 ///
-/// This can be returned by [`NameBuf::from_str()`]. It is not used when
-/// parsing names from the zonefile format, which uses a different mechanism.
+/// This can be returned by [`NameBuf::parse_str()`] and
+/// [`NameBuf::from_str()`]. It is not used when parsing names from the
+/// zonefile format, which uses a different mechanism.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NameParseError {
     /// The name was too large.
     ///
     /// Valid names are between 1 and 255 bytes, inclusive.
     Overlong,
+
+    /// The name was relative.
+    ///
+    /// The name did not end with a `.`, making it unclear whether it is an
+    /// absolute domain name or a relative one. Domain names that do not end
+    /// with a `.` are interpreted differently within zone files, and hence
+    /// they are not allowed here.
+    Relative,
+
+    /// An empty label was discovered.
+    ///
+    /// The name contained two consecutive `.`s, which would imply an empty
+    /// label followed by more content. This is not allowed; empty labels are
+    /// interpreted as root labels, and they must terminate domain names.
+    EmptyLabel,
+
+    /// A label in the name was too large.
+    ///
+    /// Valid labels are between 1 and 63 bytes, inclusive.
+    OverlongLabel,
 
     /// The name contained an invalid character.
     ///
@@ -854,13 +980,29 @@ pub enum NameParseError {
     /// - Correctly escaped characters
     InvalidChar,
 
-    /// A label in the name could not be parsed.
-    Label(LabelParseError),
+    /// A partial escape was used.
+    ///
+    /// An escape must be `\\DDD`, where `DDD` are 3 ASCII decimal digits
+    /// representing an unsigned 8-bit integer; or `\\X`, where `X` is a
+    /// graphical, non-digit ASCII character.
+    PartialEscape,
+
+    /// An invalid escape was used.
+    ///
+    /// An escape must be `\\DDD`, where `DDD` are 3 ASCII decimal digits
+    /// representing an unsigned 8-bit integer; or `\\X`, where `X` is a
+    /// graphical, non-digit ASCII character.
+    InvalidEscape,
 }
 
 impl From<LabelParseError> for NameParseError {
-    fn from(value: LabelParseError) -> Self {
-        Self::Label(value)
+    fn from(error: LabelParseError) -> Self {
+        match error {
+            LabelParseError::Overlong => Self::OverlongLabel,
+            LabelParseError::InvalidChar => Self::InvalidChar,
+            LabelParseError::PartialEscape => Self::PartialEscape,
+            LabelParseError::InvalidEscape => Self::InvalidEscape,
+        }
     }
 }
 
@@ -870,16 +1012,106 @@ impl fmt::Display for NameParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Self::Overlong => "the domain name was too long",
-            Self::InvalidChar | Self::Label(LabelParseError::InvalidChar) => {
+            Self::Relative => "the domain name did not end with `.`",
+            Self::EmptyLabel => "the domain name contained an empty label",
+            Self::OverlongLabel => "a label in the domain name was too long",
+            Self::InvalidChar => {
                 "the domain name contained an invalid character"
             }
-            Self::Label(LabelParseError::Overlong) => "a label was too long",
-            Self::Label(LabelParseError::Empty) => "a label was empty",
-            Self::Label(LabelParseError::PartialEscape) => {
-                "a label contained an incomplete escape"
+            Self::PartialEscape => {
+                "the domain name contained an incomplete escape"
             }
-            Self::Label(LabelParseError::InvalidEscape) => {
-                "a label contained an invalid escape"
+            Self::InvalidEscape => {
+                "the domain name contained an invalid escape"
+            }
+        })
+    }
+}
+
+//------------ NameSplitError ------------------------------------------------
+
+/// An error in parsing a [`Name`] from a larger string.
+///
+/// This can be returned by [`NameBuf::split_str()`]. It is not used when
+/// parsing names from the zonefile format, which uses a different mechanism.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NameSplitError {
+    /// The name was too large.
+    ///
+    /// Valid names are between 1 and 255 bytes, inclusive.
+    Overlong,
+
+    /// The name was relative.
+    ///
+    /// The name did not end with a `.`, making it unclear whether it is an
+    /// absolute domain name or a relative one. Domain names that do not end
+    /// with a `.` are interpreted differently within zone files, and hence
+    /// they are not allowed here.
+    Relative,
+
+    /// An empty label was discovered.
+    ///
+    /// The name contained two consecutive `.`s, which would imply an empty
+    /// label followed by more content. This is not allowed; empty labels are
+    /// interpreted as root labels, and they must terminate domain names.
+    EmptyLabel,
+
+    /// A label in the name was too large.
+    ///
+    /// Valid labels are between 1 and 63 bytes, inclusive.
+    OverlongLabel,
+
+    /// The name contained an invalid character.
+    ///
+    /// Valid names contain any of the following characters:
+    /// - ASCII alphanumeric characters
+    /// - `-`, `_`, `*` (within labels)
+    /// - `.` (between labels)
+    /// - Correctly escaped characters
+    InvalidChar,
+
+    /// An invalid escape was used.
+    ///
+    /// An escape must be `\\DDD`, where `DDD` are 3 ASCII decimal digits
+    /// representing an unsigned 8-bit integer; or `\\X`, where `X` is a
+    /// graphical, non-digit ASCII character.
+    InvalidEscape,
+
+    /// The input was too short to parse the domain name.
+    ///
+    /// The input did not sufficiently delimit the domain name. More input (if
+    /// any) needs to be collected to correctly parse the entire domain name.
+    ShortInput,
+}
+
+impl From<LabelSplitError> for NameSplitError {
+    fn from(error: LabelSplitError) -> Self {
+        match error {
+            LabelSplitError::Overlong => Self::Overlong,
+            LabelSplitError::InvalidChar => Self::InvalidChar,
+            LabelSplitError::InvalidEscape => Self::InvalidEscape,
+            LabelSplitError::ShortInput => Self::ShortInput,
+        }
+    }
+}
+
+impl core::error::Error for NameSplitError {}
+
+impl fmt::Display for NameSplitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Overlong => "the domain name was too long",
+            Self::Relative => "the domain name did not end with `.`",
+            Self::EmptyLabel => "the domain name contained an empty label",
+            Self::OverlongLabel => "a label in the domain name was too long",
+            Self::InvalidChar => {
+                "the domain name contained an invalid character"
+            }
+            Self::InvalidEscape => {
+                "the domain name contained an invalid escape"
+            }
+            Self::ShortInput => {
+                "the input was too short to parse the domain name"
             }
         })
     }

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -577,7 +577,7 @@ impl NameBuf {
     ///
     /// This is an internal convenience function used while building buffers.
     fn append_label(&mut self, label: &Label) {
-        self.append_bytes(label.encoding());
+        self.append_bytes(label.as_wire());
     }
 }
 
@@ -704,7 +704,7 @@ impl NameBuf {
                 }
             };
 
-            if 255 - this.size < label.encoding().len() as u8 {
+            if 255 - this.size < label.as_wire().len() as u8 {
                 return Err(NameParseError::Overlong);
             }
             this.append_label(&label);
@@ -765,7 +765,7 @@ impl NameBuf {
         let absolute = loop {
             let (label, rest) = LabelBuf::split_str(s)?;
 
-            if 255 - this.size < label.encoding().len() as u8 {
+            if 255 - this.size < label.as_wire().len() as u8 {
                 return Err(NameSplitError::Overlong);
             }
             this.append_label(&label);

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -1147,7 +1147,7 @@ mod tests {
 
     #[test]
     fn test_to_revname() {
-        let namebuf: NameBuf = "example.com".parse().unwrap();
+        let namebuf: NameBuf = "example.com.".parse().unwrap();
         assert_eq!(
             namebuf.to_revname().as_bytes(),
             b"\x00\x03com\x07example",

--- a/src/new/base/name/compressor.rs
+++ b/src/new/base/name/compressor.rs
@@ -223,22 +223,22 @@ impl NameCompressor {
             // chance that we aren't consistent with label boundaries.
 
             // TODO(1.80): Use 'slice::split_at_checked()'.
-            if entry.len() < first.as_bytes().len()
-                || !entry[entry.len() - first.as_bytes().len()..]
-                    .eq_ignore_ascii_case(first.as_bytes())
+            if entry.len() < first.encoding().len()
+                || !entry[entry.len() - first.encoding().len()..]
+                    .eq_ignore_ascii_case(first.encoding())
             {
                 continue;
             }
-            entry = &entry[..entry.len() - first.as_bytes().len()];
+            entry = &entry[..entry.len() - first.encoding().len()];
 
             for label in name_labels.clone() {
-                if entry.len() < label.as_bytes().len()
-                    || !entry[entry.len() - label.as_bytes().len()..]
-                        .eq_ignore_ascii_case(label.as_bytes())
+                if entry.len() < label.encoding().len()
+                    || !entry[entry.len() - label.encoding().len()..]
+                        .eq_ignore_ascii_case(label.encoding())
                 {
                     break;
                 }
-                entry = &entry[..entry.len() - label.as_bytes().len()];
+                entry = &entry[..entry.len() - label.encoding().len()];
             }
 
             // Suffixes from 'entry' that were also in 'name' have been
@@ -550,7 +550,7 @@ impl NameCompressor {
         const SEED2: u64 = 0x13198a2e03707344;
         const M: u64 = 0xa4093822299f31d0;
 
-        let bytes = label.as_bytes();
+        let bytes = label.encoding();
         let len = bytes.len();
         let mut s = (SEED1, SEED2);
 

--- a/src/new/base/name/compressor.rs
+++ b/src/new/base/name/compressor.rs
@@ -631,8 +631,8 @@ mod tests {
         let mut compressor = NameCompressor::new();
 
         // The TLD is different, so they cannot be compressed together.
-        let a: NameBuf = "example.org".parse().unwrap();
-        let b: NameBuf = "example.com".parse().unwrap();
+        let a: NameBuf = "example.org.".parse().unwrap();
+        let b: NameBuf = "example.com.".parse().unwrap();
 
         let mut off = 0;
         off = a
@@ -657,8 +657,8 @@ mod tests {
         let mut compressor = NameCompressor::new();
 
         // Only the TLD will be shared.
-        let a: NameBuf = "example.org".parse().unwrap();
-        let b: NameBuf = "unequal.org".parse().unwrap();
+        let a: NameBuf = "example.org.".parse().unwrap();
+        let b: NameBuf = "unequal.org.".parse().unwrap();
 
         let mut off = 0;
         off = a
@@ -683,8 +683,8 @@ mod tests {
         let mut compressor = NameCompressor::new();
 
         // The TLD should be shared, even if it differs in case.
-        let a: NameBuf = "example.org".parse().unwrap();
-        let b: NameBuf = "unequal.ORG".parse().unwrap();
+        let a: NameBuf = "example.org.".parse().unwrap();
+        let b: NameBuf = "unequal.ORG.".parse().unwrap();
 
         let mut off = 0;
         off = a

--- a/src/new/base/name/compressor.rs
+++ b/src/new/base/name/compressor.rs
@@ -223,22 +223,22 @@ impl NameCompressor {
             // chance that we aren't consistent with label boundaries.
 
             // TODO(1.80): Use 'slice::split_at_checked()'.
-            if entry.len() < first.encoding().len()
-                || !entry[entry.len() - first.encoding().len()..]
-                    .eq_ignore_ascii_case(first.encoding())
+            if entry.len() < first.as_wire().len()
+                || !entry[entry.len() - first.as_wire().len()..]
+                    .eq_ignore_ascii_case(first.as_wire())
             {
                 continue;
             }
-            entry = &entry[..entry.len() - first.encoding().len()];
+            entry = &entry[..entry.len() - first.as_wire().len()];
 
             for label in name_labels.clone() {
-                if entry.len() < label.encoding().len()
-                    || !entry[entry.len() - label.encoding().len()..]
-                        .eq_ignore_ascii_case(label.encoding())
+                if entry.len() < label.as_wire().len()
+                    || !entry[entry.len() - label.as_wire().len()..]
+                        .eq_ignore_ascii_case(label.as_wire())
                 {
                     break;
                 }
-                entry = &entry[..entry.len() - label.encoding().len()];
+                entry = &entry[..entry.len() - label.as_wire().len()];
             }
 
             // Suffixes from 'entry' that were also in 'name' have been
@@ -550,7 +550,7 @@ impl NameCompressor {
         const SEED2: u64 = 0x13198a2e03707344;
         const M: u64 = 0xa4093822299f31d0;
 
-        let bytes = label.encoding();
+        let bytes = label.as_wire();
         let len = bytes.len();
         let mut s = (SEED1, SEED2);
 

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -350,23 +350,6 @@ impl Label {
         matches!(self.0, [1, b'*'])
     }
 
-    /// Whether the label is "empty" (i.e. the root label).
-    ///
-    /// This is an alias for [`Self::is_root()`], offered for uniformity with
-    /// other types that implement `len()`.
-    #[must_use]
-    pub const fn is_empty(&self) -> bool {
-        self.is_root()
-    }
-
-    /// The length of the label.
-    ///
-    /// This count does not include the length octet.
-    #[must_use]
-    pub const fn len(&self) -> usize {
-        self.0[0] as usize
-    }
-
     /// The encoding of the label in the DNS wire format.
     ///
     /// This includes the length octet. It is also accessible via

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -138,6 +138,16 @@ impl Label {
         // SAFETY: This is a correctly encoded label.
         unsafe { Self::from_bytes_unchecked(&[1, b'*']) }
     };
+
+    /// Printable ASCII characters that can appear in labels printed in zone
+    /// files without escaping.
+    ///
+    /// Rationale is described in [`Label#zone-file-formatting`].
+    const UNESCAPED_ZONEFILE_CHARS: &[u8] = b"\
+        ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+        abcdefghijklmnopqrstuvwxyz\
+        0123456789\
+        !#$%&'*+,-^_`{|}~";
 }
 
 //--- Construction
@@ -601,9 +611,7 @@ impl fmt::Display for Label {
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.contents().iter().try_for_each(|&byte| {
-            if byte.is_ascii_alphanumeric()
-                || b"!#$%&'*+,-^_`{|}~".contains(&byte)
-            {
+            if Label::UNESCAPED_ZONEFILE_CHARS.contains(&byte) {
                 write!(f, "{}", byte as char)
             } else if byte.is_ascii_graphic() {
                 write!(f, "\\{}", byte as char)
@@ -1096,8 +1104,7 @@ impl LabelBuf {
                 return Ok(this);
             };
             s = rest;
-            if b.is_ascii_alphanumeric() || b"!#$%&'*+,-^_`{|}~".contains(&b)
-            {
+            if Label::UNESCAPED_ZONEFILE_CHARS.contains(&b) {
                 // A regular label character.
                 this.push(b).map_err(|_| LabelParseError::Overlong)?;
             } else if b == b'\\' {
@@ -1174,8 +1181,7 @@ impl LabelBuf {
                 return Err(LabelSplitError::ShortInput);
             };
             s = rest;
-            if b.is_ascii_alphanumeric() || b"!#$%&'*+,-^_`{|}~".contains(&b)
-            {
+            if Label::UNESCAPED_ZONEFILE_CHARS.contains(&b) {
                 // A regular label character.
                 this.push(b).map_err(|_| LabelSplitError::Overlong)?;
             } else if b == b'\\' {

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -45,6 +45,9 @@ use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 /// label) or [`<&Label>::parse_bytes()`] (when the input ends right after
 /// the label).
 ///
+/// [`<&Label>::split_bytes()`]: #method.split_bytes
+/// [`<&Label>::parse_bytes()`]: #method.parse_bytes
+///
 /// The [`label`] macro is helpful for writing tests, and it shows up in many
 /// of the tests and examples here. It constructs a label from a hard-coded
 /// (byte) string literal.
@@ -108,6 +111,8 @@ use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 /// to access the underlying bytes, because it is unclear whether the
 /// implementation should include the length octet with those bytes.
 ///
+/// [`AsRef<[u8]>`]: core::convert::AsRef
+///
 /// The preferred ways to access the bytes are [`Self::encoding()`] (which
 /// explicitly includes the length octet) and [`Self::contents()`] (which
 /// explicitly does not).
@@ -143,7 +148,9 @@ impl Label {
     /// This can be used to cast a label encoded in the wire format into the
     /// [`Label`] type without copying.
     ///
-    /// For a checked, safe version, use [`Label::parse_bytes()`].
+    /// For a checked, safe version, use [`<&Label>::parse_bytes()`].
+    ///
+    /// [`<&Label>::parse_bytes()`]: #method.parse_bytes
     ///
     /// ```
     /// # use domain::new::base::name::Label;
@@ -207,6 +214,8 @@ impl Label {
     }
 
     /// Copy the label into a [`Box<Label>`].
+    ///
+    /// [`Box<Label>`]: https://doc.rust-lang.org/stable/std/boxed/struct.Box.html
     ///
     /// This is a concrete, inherent version of [`Self::unsized_copy_into()`].
     #[must_use]
@@ -465,7 +474,7 @@ impl Eq for Label {}
 impl PartialOrd for Label {
     /// Determine the order between two labels.
     ///
-    /// See [`impl Ord for Label`].
+    /// See [`Label::cmp()`].
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -543,8 +552,8 @@ impl fmt::Display for Label {
     /// clear how they should be formatted on their own. See the examples
     /// here to understand how this implementation works.
     ///
-    /// To parse a label _from_ this format, see [`impl FromStr for
-    /// LabelBuf`]. [`Label`] cannot implement [`FromStr`] itself.
+    /// To parse a label _from_ this format, see [`LabelBuf::from_str()`].
+    /// [`Label`] cannot implement [`FromStr`] itself.
     ///
     /// The root label is printed as an empty string. Labels are usually
     /// delimited by `.`s when printing domain names, so this should be
@@ -637,14 +646,19 @@ impl serde::Serialize for Label {
     /// understanding of the terms here.
     ///
     /// Labels are serialized as `newtype_struct`s of name `Label`. For
-    /// human-readable formats (e.g. JSON and TOML), they are serialized as
-    /// per [`impl Display for Label`]. For compact formats (e.g. Postcard),
-    /// they are serialized as byte slices (specifically [`Self::contents()`],
-    /// excluding the length octet).
+    /// human-readable formats (e.g. JSON and TOML), they are serialized
+    /// as per [`<Label as Display>::fmt()`]. For compact formats (e.g.
+    /// Postcard), they are serialized as byte slices (specifically
+    /// [`Self::contents()`], excluding the length octet).
     ///
-    /// To deserialize a label, see [`impl Deserialize for LabelBuf`] or
-    /// [`impl Deserialize for Box<Label>`]. They use exactly the same format.
-    /// [`Label`] cannot implement [`Deserialize`] itself.
+    /// [`<Label as Display>::fmt()`]: #method.fmt
+    ///
+    /// To deserialize a label, see [`LabelBuf::deserialize()`] or
+    /// [`<Box<Label>>::deserialize()`]. They use exactly the same format.
+    /// [`Label`] cannot implement [`serde::Deserialize`] itself.
+    ///
+    /// [`LabelBuf::deserialize()`]: struct.LabelBuf.html#method.deserialize
+    /// [`<Box<Label>>::deserialize()`]: #method.deserialize
     ///
     /// ```
     /// # use serde_test::{Configure, Token, assert_ser_tokens};
@@ -1048,6 +1062,7 @@ impl AsMut<Label> for LabelBuf {
 //--- Forwarding equality, comparison, and hashing
 
 impl PartialEq for LabelBuf {
+    /// See [`Label::eq()`].
     fn eq(&self, that: &Self) -> bool {
         **self == **that
     }
@@ -1056,18 +1071,21 @@ impl PartialEq for LabelBuf {
 impl Eq for LabelBuf {}
 
 impl PartialOrd for LabelBuf {
+    /// See [`Label::partial_cmp()`].
     fn partial_cmp(&self, that: &Self) -> Option<Ordering> {
         Some(self.cmp(that))
     }
 }
 
 impl Ord for LabelBuf {
+    /// See [`Label::cmp()`].
     fn cmp(&self, that: &Self) -> Ordering {
         (**self).cmp(&**that)
     }
 }
 
 impl Hash for LabelBuf {
+    /// See [`Label::hash()`].
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state)
     }
@@ -1076,7 +1094,9 @@ impl Hash for LabelBuf {
 //--- Forwarding formatting
 
 impl fmt::Display for LabelBuf {
-    /// See [`impl Display for Label`].
+    /// See [`<Label as Display>::fmt()`].
+    ///
+    /// [`<Label as Display>::fmt()`]: struct.Label.html#method.fmt
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
@@ -1097,12 +1117,14 @@ impl fmt::Debug for LabelBuf {
 impl LabelBuf {
     /// Parse a printed label.
     ///
-    /// This will parse a label from the format used by [`impl Display for
-    /// Label`]. Labels are usually parsed as part of a domain name, and it
-    /// is not entirely clear how they should be parsed on their own. See the
-    /// examples here to understand how this implementation works.
+    /// This will parse a label from the format used by [`<Label as
+    /// Display>::fmt()`]. Labels are usually parsed as part of a domain name,
+    /// and it is not entirely clear how they should be parsed on their own.
+    /// See the examples here to understand how this implementation works.
     ///
-    /// This function is a direct inverse of [`impl Display for LabelBuf`],
+    /// [`<Label as Display>::fmt()`]: struct.Label.html#method.fmt
+    ///
+    /// This function is a direct inverse of [`<Label as Display>::fmt()`],
     /// but it cannot be used to parse a label embedded within a larger
     /// string. For that, see [`LabelBuf::split_str()`].
     ///
@@ -1167,18 +1189,20 @@ impl LabelBuf {
 
     /// Parse a printed label from a larger string.
     ///
-    /// This will parse a label from the format used by [`impl Display for
-    /// Label`]. Labels are usually parsed as part of a domain name, and it
-    /// is not entirely clear how they should be parsed on their own. See the
-    /// examples here to understand how this implementation works.
+    /// This will parse a label from the format used by [`<Label as
+    /// Display>::fmt()`]. Labels are usually parsed as part of a domain name,
+    /// and it is not entirely clear how they should be parsed on their own.
+    /// See the examples here to understand how this implementation works.
+    ///
+    /// [`<Label as Display>::fmt()`]: struct.Label.html#method.fmt
     ///
     /// This function is designed for use when parsing labels embedded within
     /// some larger string (e.g. a zone file). The string may be buffered,
     /// so only a part of it is provided; the string is considered to be
     /// infinitely long. A label is only parsed successfully once a delimiting
     /// byte (one that lies _after_ it) is found. As such, this function is
-    /// **not** a perfect inverse of [`impl Display for Label`]. For such an
-    /// inverse, see [`LabelBuf::parse_str()`].
+    /// **not** a perfect inverse of [`<Label as Display>::fmt()`]. For such
+    /// an inverse, see [`LabelBuf::parse_str()`].
     ///
     /// ```
     /// # use domain::new::base::name::{LabelBuf, LabelSplitError, label_buf};
@@ -1257,7 +1281,9 @@ impl FromStr for LabelBuf {
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for LabelBuf {
-    /// See [`impl Serialize for Label`].
+    /// See [`Label::serialize()`].
+    ///
+    /// [`Label::serialize()`]: struct.Label.html#method.serialize
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -1374,7 +1400,9 @@ impl<'a> serde::Deserialize<'a> for LabelBuf {
 impl<'a> serde::Deserialize<'a> for alloc::boxed::Box<Label> {
     /// Deserialize a label and allocate it on the heap.
     ///
-    /// See [`impl Deserialize for LabelBuf`].
+    /// See [`LabelBuf::deserialize()`].
+    ///
+    /// [`LabelBuf::deserialize()`]: struct.LabelBuf.html#method.deserialize
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'a>,

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -69,9 +69,9 @@ use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 /// let input = b"\x07example";
 /// let label: &Label = <&Label>::parse_bytes(input)?;
 /// assert_eq!(label.contents(), b"example");
-/// assert_eq!(label.encoding(), b"\x07example");
+/// assert_eq!(label.as_wire(), b"\x07example");
 /// // `label` is not a copy of the input; it refers to the same address.
-/// assert_eq!(label.encoding().as_ptr(), input.as_ptr());
+/// assert_eq!(label.as_wire().as_ptr(), input.as_ptr());
 ///
 /// // You may see `label!` used in examples here.
 /// // It generates a `&'static Label` for hard-coded labels.
@@ -113,7 +113,7 @@ use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 ///
 /// [`AsRef<[u8]>`]: core::convert::AsRef
 ///
-/// The preferred ways to access the bytes are [`Self::encoding()`] (which
+/// The preferred ways to access the bytes are [`Self::as_wire()`] (which
 /// explicitly includes the length octet) and [`Self::contents()`] (which
 /// explicitly does not).
 ///
@@ -273,7 +273,7 @@ impl BuildInMessage for Label {
         start: usize,
         _compressor: &mut NameCompressor,
     ) -> Result<usize, TruncationError> {
-        let bytes = self.encoding();
+        let bytes = self.as_wire();
         let end = start + bytes.len();
         contents
             .get_mut(start..end)
@@ -313,7 +313,7 @@ impl<'a> ParseBytes<'a> for &'a Label {
 
 /// Serializing a [`Label`] as bytes.
 ///
-/// Labels are serialized exactly as [`Label::encoding()`], their encoding in
+/// Labels are serialized exactly as [`Label::as_wire()`], their encoding in
 /// the DNS wire format: a one-byte length octet (between 0 and 63, inclusive)
 /// followed by that many bytes.
 impl BuildBytes for Label {
@@ -321,11 +321,11 @@ impl BuildBytes for Label {
         &self,
         bytes: &'b mut [u8],
     ) -> Result<&'b mut [u8], TruncationError> {
-        self.encoding().build_bytes(bytes)
+        self.as_wire().build_bytes(bytes)
     }
 
     fn built_bytes_size(&self) -> usize {
-        self.encoding().len()
+        self.as_wire().len()
     }
 }
 
@@ -377,18 +377,18 @@ impl Label {
     /// # use domain::new::base::name::label;
     /// #
     /// let label = label!("example");
-    /// assert_eq!(label.encoding(), b"\x07example");
+    /// assert_eq!(label.as_wire(), b"\x07example");
     /// assert_eq!(label.contents(), b"example");
     /// ```
     #[must_use]
-    pub const fn encoding(&self) -> &[u8] {
+    pub const fn as_wire(&self) -> &[u8] {
         &self.0
     }
 
     /// The contents of the label.
     ///
     /// This does not include the length octet. If you need the length octet,
-    /// use [`Self::encoding()`]. Use [`Self::contents_mut()`] for a mutable
+    /// use [`Self::as_wire()`]. Use [`Self::contents_mut()`] for a mutable
     /// view.
     ///
     /// ```
@@ -396,7 +396,7 @@ impl Label {
     /// #
     /// let label = label!("example");
     /// assert_eq!(label.contents(), b"example");
-    /// assert_eq!(label.encoding(), b"\x07example");
+    /// assert_eq!(label.as_wire(), b"\x07example");
     /// ```
     #[must_use]
     pub const fn contents(&self) -> &[u8] {
@@ -443,7 +443,7 @@ impl PartialEq for Label {
     ///
     /// Labels are compared ASCII-case-insensitively, as is conventional for
     /// DNS. For a case-sensitive comparison, you can compare the byte slices
-    /// (from [`Self::contents()`], not [`Self::encoding()`]!) manually.
+    /// (from [`Self::contents()`], not [`Self::as_wire()`]!) manually.
     ///
     /// ```
     /// # use domain::new::base::name::label;
@@ -463,7 +463,7 @@ impl PartialEq for Label {
         // We don't need to include it, because the lengths of the slices will
         // be checked already. But it is probably more efficient this way.
         // Maybe we'll benchmark it one day and find out.
-        self.encoding().eq_ignore_ascii_case(other.encoding())
+        self.as_wire().eq_ignore_ascii_case(other.as_wire())
     }
 }
 
@@ -490,8 +490,8 @@ impl Ord for Label {
     /// label is a prefix of the other (i.e. all their corresponding bytes are
     /// equal, but one has fewer bytes), it is considered less than the other.
     ///
-    /// For a case-sensitive comparison, you can compare the byte slices
-    /// (from [`Self::contents()`], not [`Self::encoding()`]!) manually.
+    /// For a case-sensitive comparison, you can compare the byte slices (from
+    /// [`Self::contents()`], not [`Self::as_wire()`]!) manually.
     ///
     /// ```
     /// # use domain::new::base::name::label;
@@ -536,7 +536,7 @@ impl Hash for Label {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // NOTE: The length octet is unaffected by `to_ascii_lowercase()`
         // because it is strictly less than 64.
-        for &byte in self.encoding() {
+        for &byte in self.as_wire() {
             state.write_u8(byte.to_ascii_lowercase())
         }
     }
@@ -733,11 +733,11 @@ impl LabelBuf {
     /// # use domain::new::base::wire::ParseBytes;
     /// #
     /// let buffer: LabelBuf = LabelBuf::copy_from(label!("example"));
-    /// assert_eq!(buffer.encoding(), b"\x07example");
+    /// assert_eq!(buffer.as_wire(), b"\x07example");
     /// ```
     #[must_use]
     pub const fn copy_from(label: &Label) -> Self {
-        let bytes = label.encoding();
+        let bytes = label.as_wire();
         let mut data = [0u8; 64];
         // TODO: `for` loops and slicing aren't `const` yet.
         let mut index = 0usize;
@@ -776,7 +776,7 @@ impl LabelBuf {
     /// let mut buffer = LabelBuf::new();
     /// buffer.append(b"hello").unwrap();
     /// buffer.append(b"world").unwrap();
-    /// assert_eq!(buffer.encoding(), b"\x0Ahelloworld");
+    /// assert_eq!(buffer.as_wire(), b"\x0Ahelloworld");
     /// ```
     ///
     /// # Errors
@@ -828,7 +828,7 @@ impl LabelBuf {
     /// buffer.append(b"hello").unwrap();
     /// buffer.push(b'4').unwrap();
     /// buffer.push(b'2').unwrap();
-    /// assert_eq!(buffer.encoding(), b"\x07hello42");
+    /// assert_eq!(buffer.as_wire(), b"\x07hello42");
     /// ```
     ///
     /// # Errors
@@ -855,9 +855,9 @@ impl LabelBuf {
     /// #
     /// let mut buffer = LabelBuf::new();
     /// buffer.append(b"example");
-    /// assert_eq!(buffer.encoding(), b"\x07example");
+    /// assert_eq!(buffer.as_wire(), b"\x07example");
     /// buffer.truncate(4);
-    /// assert_eq!(buffer.encoding(), b"\x04exam");
+    /// assert_eq!(buffer.as_wire(), b"\x04exam");
     /// ```
     ///
     /// # Panics
@@ -1450,17 +1450,17 @@ impl fmt::Debug for LabelIter<'_> {
 /// # use domain::new::base::name::{Label, label};
 /// #
 /// let foo: &'static Label = label!("example");
-/// assert_eq!(foo.encoding(), b"\x07example");
+/// assert_eq!(foo.as_wire(), b"\x07example");
 ///
 /// // Escapes in the label are not processed.
 /// let foo: &'static Label = label!("ex\x0Amp\\e");
-/// assert_eq!(foo.encoding(), b"\x07ex\x0Amp\\e");
+/// assert_eq!(foo.as_wire(), b"\x07ex\x0Amp\\e");
 ///
 /// // You can use byte strings to avoid UTF-8 validity.
 /// // Due to macro limitations, you need to disambiguate this from
 /// // a regular string literal by prepending a `b` token.
 /// let foo: &'static Label = label!(b b"ex\xFFmple");
-/// assert_eq!(foo.encoding(), b"\x07ex\xFFmple");
+/// assert_eq!(foo.as_wire(), b"\x07ex\xFFmple");
 /// ```
 #[doc(hidden)]
 #[macro_export]
@@ -1497,17 +1497,17 @@ pub use crate::new_base_name_label as label;
 /// # use domain::new::base::name::{LabelBuf, label_buf};
 /// #
 /// let foo: LabelBuf = label_buf!("example");
-/// assert_eq!(foo.encoding(), b"\x07example");
+/// assert_eq!(foo.as_wire(), b"\x07example");
 ///
 /// // Escapes in the label are not processed.
 /// let foo: LabelBuf = label_buf!("ex\x0Amp\\e");
-/// assert_eq!(foo.encoding(), b"\x07ex\x0Amp\\e");
+/// assert_eq!(foo.as_wire(), b"\x07ex\x0Amp\\e");
 ///
 /// // You can use byte strings to avoid UTF-8 validity.
 /// // Due to macro limitations, you need to disambiguate this from
 /// // a regular string literal by prepending a `b` token.
 /// let foo: LabelBuf = label_buf!(b b"ex\xFFmple");
-/// assert_eq!(foo.encoding(), b"\x07ex\xFFmple");
+/// assert_eq!(foo.as_wire(), b"\x07ex\xFFmple");
 /// ```
 #[doc(hidden)]
 #[macro_export]
@@ -1648,9 +1648,9 @@ mod tests {
             let expected_len = input[0] as usize + 1;
             assert_eq!(<&Label>::parse_bytes(input), Err(ParseError));
             let (actual, rest) = <&Label>::split_bytes(input).unwrap();
-            assert_eq!(actual.encoding().len(), expected_len);
-            assert_eq!(actual.encoding().as_ptr(), input.as_ptr());
-            assert_eq!(actual.encoding().len() + rest.len(), input.len());
+            assert_eq!(actual.as_wire().len(), expected_len);
+            assert_eq!(actual.as_wire().as_ptr(), input.as_ptr());
+            assert_eq!(actual.as_wire().len() + rest.len(), input.len());
             assert_eq!(
                 rest.as_ptr(),
                 input.as_ptr().wrapping_add(expected_len)
@@ -1659,12 +1659,12 @@ mod tests {
             // Try parsing input that _only_ contains a label.
             let min_input = &input[..expected_len];
             let (actual, rest) = <&Label>::split_bytes(min_input).unwrap();
-            assert_eq!(actual.encoding().as_ptr(), min_input.as_ptr());
-            assert_eq!(actual.encoding().len(), min_input.len());
+            assert_eq!(actual.as_wire().as_ptr(), min_input.as_ptr());
+            assert_eq!(actual.as_wire().len(), min_input.len());
             assert_eq!(rest, &[] as &[u8]);
             let actual = <&Label>::parse_bytes(min_input).unwrap();
-            assert_eq!(actual.encoding().as_ptr(), min_input.as_ptr());
-            assert_eq!(actual.encoding().len(), min_input.len());
+            assert_eq!(actual.as_wire().as_ptr(), min_input.as_ptr());
+            assert_eq!(actual.as_wire().len(), min_input.len());
 
             // Try parsing input that's a byte too short.
             let short_input = &input[..expected_len - 1];

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -770,8 +770,6 @@ impl LabelBuf {
     ///
     /// The length octet will be adjusted automatically.
     ///
-    /// For more complex use cases, consider [`Self::spare_capacity_mut()`].
-    ///
     /// ```
     /// # use domain::new::base::name::LabelBuf;
     /// #
@@ -821,8 +819,7 @@ impl LabelBuf {
     ///
     /// The length octet will be adjusted automatically.
     ///
-    /// Also see [`Self::append()`]. For more complex use cases, consider
-    /// [`Self::spare_capacity_mut()`].
+    /// Also see [`Self::append()`].
     ///
     /// ```
     /// # use domain::new::base::name::LabelBuf;
@@ -872,51 +869,6 @@ impl LabelBuf {
         let len = self.data[0] as usize;
         assert!(new_len <= len, "Label is shorter than desired length");
         self.data[0] = new_len as u8;
-    }
-
-    /// Access the uninitialized portion of the buffer.
-    ///
-    /// The bytes _after_ the encoded label are returned. These can be
-    /// modified and then included in the label using [`Self::set_len()`].
-    /// This is analogous to [`Vec::spare_capacity_mut()`].
-    ///
-    /// [`Vec::spare_capacity_mut()`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.spare_capacity_mut
-    ///
-    /// ```
-    /// # use domain::new::base::name::LabelBuf;
-    /// # use domain::new::base::wire::ParseBytes;
-    /// #
-    /// let mut buffer = LabelBuf::new();
-    /// buffer.spare_capacity_mut()[..7].copy_from_slice(b"example");
-    /// buffer.set_len(7);
-    /// assert_eq!(buffer.encoding(), b"\x07example");
-    /// ```
-    #[must_use]
-    pub const fn spare_capacity_mut(&mut self) -> &mut [u8] {
-        let size = self.data[0];
-        // TODO: direct slicing is not possible in `const` yet.
-        // SAFETY: `size < 64` so `1 + size` fits within `self.data`.
-        unsafe { self.data.split_at_mut_unchecked(1 + size as usize).1 }
-    }
-
-    /// Set the length of the buffer.
-    ///
-    /// This should be used in conjunction with
-    /// [`Self::spare_capacity_mut()`]; see its documentation. This is
-    /// analogous to [`Vec::set_len()`].
-    ///
-    /// [`Vec::set_len()`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.set_len
-    ///
-    /// Prefer [`Self::truncate()`] for truncating the label.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `len >= 64`.
-    pub const fn set_len(&mut self, len: usize) {
-        // TODO: Include `len` in the assert message once it is `const`-safe
-        // to do so.
-        assert!(len < 64, "Invalid length for label");
-        self.data[0] = len as u8;
     }
 }
 

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -1251,6 +1251,25 @@ impl serde::Serialize for LabelBuf {
 
 #[cfg(feature = "serde")]
 impl<'a> serde::Deserialize<'a> for LabelBuf {
+    /// Deserialize a label.
+    ///
+    /// See [`Label::serialize()`] for a discussion of the format.
+    ///
+    /// [`Label::serialize()`]: struct.Label.html#method.serialize
+    ///
+    /// ```
+    /// # use serde_test::{Configure, Token, assert_tokens};
+    /// # use domain::new::base::name::label_buf;
+    /// #
+    /// assert_tokens(&label_buf!(b"example\x7Fabc").readable(), &[
+    ///     Token::NewtypeStruct { name: "Label" },
+    ///     Token::String("example\\127abc"),
+    /// ]);
+    /// assert_tokens(&label_buf!(b"example\x7Fabc").compact(), &[
+    ///     Token::NewtypeStruct { name: "Label" },
+    ///     Token::Bytes(b"example\x7Fabc"),
+    /// ]);
+    /// ```
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'a>,
@@ -1310,18 +1329,20 @@ impl<'a> serde::Deserialize<'a> for LabelBuf {
                     &self,
                     f: &mut fmt::Formatter<'_>,
                 ) -> fmt::Result {
-                    f.write_str("a label, in the DNS wire format")
+                    f.write_str("the contents of a DNS label")
                 }
 
                 fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
                 where
                     E: serde::de::Error,
                 {
-                    LabelBuf::parse_bytes(v).map_err(|_| {
+                    let mut buf = LabelBuf::new();
+                    buf.append(v).map_err(|_| {
                         E::custom(
                             "misformatted label for the DNS wire format",
                         )
-                    })
+                    })?;
+                    Ok(buf)
                 }
             }
 

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -75,7 +75,7 @@ use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 ///
 /// // You may see `label!` used in examples here.
 /// // It generates a `&'static Label` for hard-coded labels.
-/// assert_eq!(label, label!("example"));
+/// assert_eq!(label, label!(b"example"));
 /// #
 /// # Ok::<(), ParseError>(())
 /// ```
@@ -91,7 +91,7 @@ use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 /// # use domain::new::base::wire::ParseBytes;
 /// # use domain::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 /// #
-/// let label: &Label = label!("example");
+/// let label: &Label = label!(b"example");
 ///
 /// // Copy into a fixed-size buffer (ideal for modification):
 /// let buffer: LabelBuf = label.to_buf();
@@ -241,7 +241,7 @@ impl Label {
     /// ```
     /// # use domain::new::base::name::label_buf;
     /// #
-    /// let mut buffer = label_buf!("eXAMpLE");
+    /// let mut buffer = label_buf!(b"eXAMpLE");
     /// buffer.make_lowercase();
     /// assert_eq!(buffer.contents(), b"example");
     /// ```
@@ -369,7 +369,7 @@ impl Label {
     /// ```
     /// # use domain::new::base::name::label;
     /// #
-    /// let label = label!("example");
+    /// let label = label!(b"example");
     /// assert_eq!(label.as_wire(), b"\x07example");
     /// assert_eq!(label.contents(), b"example");
     /// ```
@@ -387,7 +387,7 @@ impl Label {
     /// ```
     /// # use domain::new::base::name::label;
     /// #
-    /// let label = label!("example");
+    /// let label = label!(b"example");
     /// assert_eq!(label.contents(), b"example");
     /// assert_eq!(label.as_wire(), b"\x07example");
     /// ```
@@ -408,7 +408,7 @@ impl Label {
     /// # use domain::new::base::name::{Label, label_buf};
     /// # use domain::new::base::wire::ParseBytes;
     /// #
-    /// let mut buffer = label_buf!("example");
+    /// let mut buffer = label_buf!(b"example");
     /// let label: &mut Label = buffer.as_mut_label();
     /// assert_eq!(label.contents_mut(), b"example");
     /// ```
@@ -446,9 +446,9 @@ impl PartialEq for Label {
     /// ```
     /// # use domain::new::base::name::label;
     /// #
-    /// let a = label!("example");
-    /// let b = label!("eXAMpLE");
-    /// let c = label!("unrelated");
+    /// let a = label!(b"example");
+    /// let b = label!(b"eXAMpLE");
+    /// let c = label!(b"unrelated");
     /// assert_eq!(a, b);
     /// assert_ne!(a.contents(), b.contents());
     /// assert_ne!(a, c);
@@ -494,9 +494,9 @@ impl Ord for Label {
     /// ```
     /// # use domain::new::base::name::label;
     /// #
-    /// let a = label!("example");
-    /// let b = label!("example-");
-    /// let c = label!("org");
+    /// let a = label!(b"example");
+    /// let b = label!(b"example-");
+    /// let c = label!(b"org");
     /// assert!(a < b);
     /// assert!(a < c);
     /// assert!(b < c);
@@ -525,8 +525,8 @@ impl Hash for Label {
     /// # use domain::new::base::name::label;
     /// #
     /// # let hasher = RandomState::default();
-    /// let a = label!("example");
-    /// let b = label!("eXAMpLE");
+    /// let a = label!(b"example");
+    /// let b = label!(b"eXAMpLE");
     /// assert_eq!(a, b);
     /// assert_ne!(a.contents(), b.contents());
     /// assert_eq!(hasher.hash_one(a), hasher.hash_one(b));
@@ -591,21 +591,21 @@ impl fmt::Display for Label {
     /// # use domain::new::base::name::{Label, label};
     /// #
     /// // The simple case is pretty simple.
-    /// assert_eq!(label!("example").to_string(), "example");
+    /// assert_eq!(label!(b"example").to_string(), "example");
     ///
     /// // Uppercase characters are printed as such.
-    /// assert_eq!(label!("eXAMplE").to_string(), "eXAMplE");
+    /// assert_eq!(label!(b"eXAMplE").to_string(), "eXAMplE");
     ///
     /// // The root label is an empty string.
     /// assert_eq!(Label::ROOT.to_string(), "");
     ///
     /// // Non-ASCII characters are escaped.
-    /// let label = label!(b b"helloworld\xF0\x9F\x8F\xB3\xEF\xB8\x8F\xE2\x80\x8D\xE2\x9A\xA7\xEF\xB8\x8F");
+    /// let label = label!(b"helloworld\xF0\x9F\x8F\xB3\xEF\xB8\x8F\xE2\x80\x8D\xE2\x9A\xA7\xEF\xB8\x8F");
     /// assert_eq!(label.to_string(),
     ///     r"helloworld\240\159\143\179\239\184\143\226\128\141\226\154\167\239\184\143");
     ///
     /// // Uncommon and non-printable ASCII characters are escaped too.
-    /// let label = label!("\x00\x0A!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~\x7F");
+    /// let label = label!(b"\x00\x0A!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~\x7F");
     /// assert_eq!(label.to_string(),
     ///     r##"\000\010!\"#$%&'\(\)*+,-\.\/\:\;\<\=\>\?\@\[\\\]^_`{|}~\127"##);
     /// ```
@@ -660,11 +660,11 @@ impl serde::Serialize for Label {
     /// # use serde_test::{Configure, Token, assert_ser_tokens};
     /// # use domain::new::base::name::label;
     /// #
-    /// assert_ser_tokens(&label!("example\x7Fabc").readable(), &[
+    /// assert_ser_tokens(&label!(b"example\x7Fabc").readable(), &[
     ///     Token::NewtypeStruct { name: "Label" },
     ///     Token::String("example\\127abc"),
     /// ]);
-    /// assert_ser_tokens(&label!("example\x7Fabc").compact(), &[
+    /// assert_ser_tokens(&label!(b"example\x7Fabc").compact(), &[
     ///     Token::NewtypeStruct { name: "Label" },
     ///     Token::Bytes(b"example\x7Fabc"),
     /// ]);
@@ -728,7 +728,7 @@ impl LabelBuf {
     /// # use domain::new::base::name::{LabelBuf, label};
     /// # use domain::new::base::wire::ParseBytes;
     /// #
-    /// let buffer: LabelBuf = LabelBuf::copy_from(label!("example"));
+    /// let buffer: LabelBuf = LabelBuf::copy_from(label!(b"example"));
     /// assert_eq!(buffer.as_wire(), b"\x07example");
     /// ```
     #[must_use]
@@ -1081,11 +1081,11 @@ impl LabelBuf {
     /// #
     /// assert_eq!(
     ///     LabelBuf::parse_str(b"example"),
-    ///     Ok(label_buf!("example")));
+    ///     Ok(label_buf!(b"example")));
     ///
     /// assert_eq!(
     ///     LabelBuf::parse_str(b"foo\\.b\\010r"),
-    ///     Ok(label_buf!("foo.b\x0Ar")));
+    ///     Ok(label_buf!(b"foo.b\x0Ar")));
     ///
     /// // An empty input is parsed as the root label.
     /// assert_eq!(
@@ -1161,11 +1161,11 @@ impl LabelBuf {
     /// #
     /// assert_eq!(
     ///     LabelBuf::split_str(b"example.com."),
-    ///     Ok((label_buf!("example"), &b".com."[..])));
+    ///     Ok((label_buf!(b"example"), &b".com."[..])));
     ///
     /// assert_eq!(
     ///     LabelBuf::split_str(b"foo\\.b\\010r.com."),
-    ///     Ok((label_buf!("foo.b\x0Ar"), &b".com."[..])));
+    ///     Ok((label_buf!(b"foo.b\x0Ar"), &b".com."[..])));
     ///
     /// // Even though this looks like a valid label, there is no delimiting
     /// // byte, so it cannot be parsed successfully.
@@ -1177,7 +1177,7 @@ impl LabelBuf {
     /// // non-ASCII character can serve as the delimiting byte.
     /// assert_eq!(
     ///     LabelBuf::split_str(b"com:22"),
-    ///     Ok((label_buf!("com"), &b":22"[..])));
+    ///     Ok((label_buf!(b"com"), &b":22"[..])));
     /// ```
     pub fn split_str(mut s: &[u8]) -> Result<(Self, &[u8]), LabelSplitError> {
         // The buffer we'll fill into.
@@ -1449,39 +1449,25 @@ impl fmt::Debug for LabelIter<'_> {
 ///
 /// This is a convenience function for writing example-based tests; it
 /// provides a simple, convenient way to build [`Label`]s with hard-coded
-/// values.
+/// values. It takes a byte slice and returns a label with those contents.
 ///
 /// ```
 /// # use domain::new::base::name::{Label, label};
 /// #
-/// let foo: &'static Label = label!("example");
+/// let foo: &'static Label = label!(b"example");
 /// assert_eq!(foo.as_wire(), b"\x07example");
 ///
 /// // Escapes in the label are not processed.
-/// let foo: &'static Label = label!("ex\x0Amp\\e");
+/// let foo: &'static Label = label!(b"ex\x0Amp\\e");
 /// assert_eq!(foo.as_wire(), b"\x07ex\x0Amp\\e");
 ///
-/// // You can use byte strings to avoid UTF-8 validity.
-/// // Due to macro limitations, you need to disambiguate this from
-/// // a regular string literal by prepending a `b` token.
-/// let foo: &'static Label = label!(b b"ex\xFFmple");
+/// // You can pass non-UTF-8 content.
+/// let foo: &'static Label = label!(b"ex\xFFmple");
 /// assert_eq!(foo.as_wire(), b"\x07ex\xFFmple");
 /// ```
 #[doc(hidden)]
 #[macro_export]
 macro_rules! new_base_name_label {
-    // Both match arms work the same way, so we could combine them into a
-    // single thing that forwards to `label_buf!()`. But the RustDoc shows
-    // the macro's match arm rules, so it's better to keep them explicit.
-    //
-    (b $value:literal) => {
-        const {
-            const BUFFER: &$crate::new::base::name::LabelBuf =
-        &$crate::new::base::name::label_buf!(b $value);
-            BUFFER.as_label()
-        }
-    };
-
     ($value:literal) => {
         const {
             const BUFFER: &$crate::new::base::name::LabelBuf =
@@ -1496,39 +1482,29 @@ pub use crate::new_base_name_label as label;
 ///
 /// This is a convenience function for writing example-based tests; it
 /// provides a simple, convenient way to build [`LabelBuf`]s with hard-coded
-/// values.
+/// values. It takes a byte slice and returns a label with those contents.
 ///
 /// ```
 /// # use domain::new::base::name::{LabelBuf, label_buf};
 /// #
-/// let foo: LabelBuf = label_buf!("example");
+/// let foo: LabelBuf = label_buf!(b"example");
 /// assert_eq!(foo.as_wire(), b"\x07example");
 ///
 /// // Escapes in the label are not processed.
-/// let foo: LabelBuf = label_buf!("ex\x0Amp\\e");
+/// let foo: LabelBuf = label_buf!(b"ex\x0Amp\\e");
 /// assert_eq!(foo.as_wire(), b"\x07ex\x0Amp\\e");
 ///
-/// // You can use byte strings to avoid UTF-8 validity.
-/// // Due to macro limitations, you need to disambiguate this from
-/// // a regular string literal by prepending a `b` token.
-/// let foo: LabelBuf = label_buf!(b b"ex\xFFmple");
+/// // You can pass non-UTF-8 content.
+/// let foo: LabelBuf = label_buf!(b"ex\xFFmple");
 /// assert_eq!(foo.as_wire(), b"\x07ex\xFFmple");
 /// ```
 #[doc(hidden)]
 #[macro_export]
 macro_rules! new_base_name_label_buf {
-    (b $value:literal) => {
-        const {
-            let mut buffer = $crate::new::base::name::LabelBuf::new();
-            assert!(buffer.append($value).is_ok());
-            buffer
-        }
-    };
-
     ($value:literal) => {
         const {
             let mut buffer = $crate::new::base::name::LabelBuf::new();
-            assert!(buffer.append($value.as_bytes()).is_ok());
+            assert!(buffer.append($value).is_ok());
             buffer
         }
     };

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -838,7 +838,7 @@ impl LabelBuf {
     ///
     /// # Errors
     ///
-    /// Returns [`TruncationError`] if the byte does not fill in the buffer.
+    /// Returns [`TruncationError`] if the byte does not fit in the buffer.
     /// The buffer will be unmodified.
     pub const fn push(&mut self, byte: u8) -> Result<(), TruncationError> {
         let len = self.data[0] as usize;

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -394,6 +394,7 @@ impl Label {
     #[must_use]
     pub const fn contents(&self) -> &[u8] {
         // TODO: direct slicing is not possible in `const` yet.
+        //   See <https://github.com/rust-lang/rust/issues/143775>.
         // SAFETY: A `Label` always has a length octet.
         unsafe { self.0.split_at_unchecked(1).1 }
     }
@@ -793,6 +794,7 @@ impl LabelBuf {
         }
 
         // TODO: direct slicing is not possible in `const` yet.
+        //   See <https://github.com/rust-lang/rust/issues/143775>.
         // SAFETY:
         // - `1 + len <= 64 = data.len()`.
         // - `new_len = len + bytes.len() < 64`.

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -1521,7 +1521,7 @@ pub use crate::new_base_name_label as label;
 ///
 /// // Escapes in the label are not processed.
 /// let foo: LabelBuf = label_buf!("ex\x0Amp\\e");
-/// assert_eq!(foo.encoding(), b"\x07ex\x0Am\\e");
+/// assert_eq!(foo.encoding(), b"\x07ex\x0Amp\\e");
 ///
 /// // You can use byte strings to avoid UTF-8 validity.
 /// // Due to macro limitations, you need to disambiguate this from

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -215,7 +215,7 @@ impl Label {
 
     /// Copy the label into a [`Box<Label>`].
     ///
-    /// [`Box<Label>`]: https://doc.rust-lang.org/stable/std/boxed/struct.Box.html
+    /// [`Box<Label>`]: alloc::boxed::Box
     ///
     /// This is a concrete, inherent version of [`Self::unsized_copy_into()`].
     #[must_use]

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -1083,6 +1083,10 @@ impl LabelBuf {
     ///     LabelBuf::parse_str(b"example"),
     ///     Ok(label_buf!("example")));
     ///
+    /// assert_eq!(
+    ///     LabelBuf::parse_str(b"foo\\.b\\010r"),
+    ///     Ok(label_buf!("foo.b\x0Ar")));
+    ///
     /// // An empty input is parsed as the root label.
     /// assert_eq!(
     ///     LabelBuf::parse_str(b""),
@@ -1112,17 +1116,18 @@ impl LabelBuf {
                 let &[b, ref rest @ ..] = s else {
                     return Err(LabelParseError::PartialEscape);
                 };
-                s = rest;
                 let value = if b.is_ascii_digit() {
-                    let digits = rest
-                        .get(..3)
+                    let (digits, rest) = s
+                        .split_at_checked(3)
                         .ok_or(LabelParseError::PartialEscape)?;
+                    s = rest;
                     let digits = core::str::from_utf8(digits)
                         .map_err(|_| LabelParseError::InvalidEscape)?;
                     digits
                         .parse()
                         .map_err(|_| LabelParseError::InvalidEscape)?
                 } else if b.is_ascii_graphic() {
+                    s = rest;
                     b
                 } else {
                     return Err(LabelParseError::InvalidEscape);
@@ -1158,6 +1163,10 @@ impl LabelBuf {
     ///     LabelBuf::split_str(b"example.com."),
     ///     Ok((label_buf!("example"), &b".com."[..])));
     ///
+    /// assert_eq!(
+    ///     LabelBuf::split_str(b"foo\\.b\\010r.com."),
+    ///     Ok((label_buf!("foo.b\x0Ar"), &b".com."[..])));
+    ///
     /// // Even though this looks like a valid label, there is no delimiting
     /// // byte, so it cannot be parsed successfully.
     /// assert_eq!(
@@ -1189,16 +1198,18 @@ impl LabelBuf {
                 let &[b, ref rest @ ..] = s else {
                     return Err(LabelSplitError::ShortInput);
                 };
-                s = rest;
                 let value = if b.is_ascii_digit() {
-                    let digits =
-                        rest.get(..3).ok_or(LabelSplitError::ShortInput)?;
+                    let (digits, rest) = s
+                        .split_at_checked(3)
+                        .ok_or(LabelSplitError::ShortInput)?;
+                    s = rest;
                     let digits = core::str::from_utf8(digits)
                         .map_err(|_| LabelSplitError::InvalidEscape)?;
                     digits
                         .parse()
                         .map_err(|_| LabelSplitError::InvalidEscape)?
                 } else if b.is_ascii_graphic() {
+                    s = rest;
                     b
                 } else {
                     return Err(LabelSplitError::InvalidEscape);

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -178,7 +178,7 @@ impl Label {
     /// ```
     /// # use domain::new::base::name::Label;
     /// #
-    /// let mut encoded: [u8; _] = *b"\x07example";
+    /// let mut encoded: [u8; 8] = *b"\x07example";
     /// let label: &mut Label = unsafe {
     ///     Label::from_mut_bytes_unchecked(&mut encoded)
     /// };
@@ -1684,8 +1684,8 @@ mod tests {
 
     #[test]
     fn parsing() {
-        let good: [&[u8]; _] = [
-            b"\x00abc",
+        let good = [
+            b"\x00abc" as &[u8],
             b"\x07example\x03org\x00",
             b"\x07f\x00\x00&\x8Fbar-foo",
             b"\x3Fthis is a label of the longest valid length and it's surprising(ly big)",
@@ -1720,8 +1720,8 @@ mod tests {
             assert_eq!(<&Label>::parse_bytes(short_input), Err(ParseError));
         }
 
-        let bad: [&[u8]; _] = [
-            b"\x40this is not a valid label but it would be if 64 was a valid label length",
+        let bad = [
+            b"\x40this is not a valid label but it would be if 64 was a valid label length" as &[u8],
         ];
 
         for input in bad {

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -421,6 +421,11 @@ impl Label {
     /// ```
     #[must_use]
     pub const fn contents_mut(&mut self) -> &mut [u8] {
+        // NOTE: `Label`'s only safety invariant is that the length octet is
+        // well-formed (it is consistent with the slice length and is less
+        // than 64). No matter what the caller does with the returned bytes,
+        // they cannot violate that invariant.
+        //
         // TODO: slicing is not possible in `const` yet.
         // SAFETY: A `Label` always has a length octet.
         unsafe { self.0.split_at_mut_unchecked(1).1 }

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -21,8 +21,100 @@ use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 
 /// A label in a domain name.
 ///
-/// A label consists of 0 to 63 (inclusive) bytes of arbitrary data, prefixed
-/// by its own length (also between 0 and 63).
+/// A domain name like `www.example.org.` contains 4 labels: `www`, `example`,
+/// `org`, and the root label. They are encoded (in the DNS wire format) like
+/// `3 www 7 example 3 org 0`, where each number is called a _length octet_.
+/// In general, a label consists of 0 to 63 (inclusive) bytes of arbitrary
+/// data, preceded by a 1-byte length octet.
+///
+/// A `Label` is simple wrapper around `[u8]`, and must be used in similar
+/// ways (e.g. `&Label`, `Box<Label>`). It is a byte slice beginning with a
+/// length octet, followed by the specified number of bytes. A `Label` for
+/// `www` would contain the bytes `\x03www`.
+///
+/// `Label`s are rarely used directly; the vast majority of their uses occur
+/// as part of domain names like [`Name`](super::Name).
+///
+/// ## Constructing a `Label`
+///
+/// `Label` is a _dynamically sized type_ (DST), like `[u8]`, which makes it a
+/// little unwieldy. It is most easily used by reference, i.e. `&Label`.
+///
+/// You can parse a `Label` from the DNS wire format using
+/// [`<&Label>::split_bytes()`] (when the input might contain data after the
+/// label) or [`<&Label>::parse_bytes()`] (when the input ends right after
+/// the label).
+///
+/// The [`label`] macro is helpful for writing tests, and it shows up in many
+/// of the tests and examples here. It constructs a label from a hard-coded
+/// (byte) string literal.
+///
+/// ```
+/// # use domain::new::base::name::{Label, label};
+/// # use domain::new::base::wire::{ParseError, ParseBytes, SplitBytes};
+/// #
+/// let input = b"\x03www\x07example\x03org\x00";
+/// let (label, input) = <&Label>::split_bytes(input)?;
+/// assert_eq!(label.contents(), b"www");
+/// let (label, input) = <&Label>::split_bytes(input)?;
+/// assert_eq!(label.contents(), b"example");
+/// let (label, input) = <&Label>::split_bytes(input)?;
+/// assert_eq!(label.contents(), b"org");
+/// let (label, input) = <&Label>::split_bytes(input)?;
+/// assert_eq!(label.contents(), b"");
+///
+/// let input = b"\x07example";
+/// let label: &Label = <&Label>::parse_bytes(input)?;
+/// assert_eq!(label.contents(), b"example");
+/// assert_eq!(label.encoding(), b"\x07example");
+/// // `label` is not a copy of the input; it refers to the same address.
+/// assert_eq!(label.encoding().as_ptr(), input.as_ptr());
+///
+/// // You may see `label!` used in examples here.
+/// // It generates a `&'static Label` for hard-coded labels.
+/// assert_eq!(label, label!("example"));
+/// #
+/// # Ok::<(), ParseError>(())
+/// ```
+///
+/// While `&Label` is the preferred way of handling labels, you may sometimes
+/// need to store them 'on their own', without a lifetime. With a byte slice,
+/// you could achieve this using `Box<[u8]>` or `Vec<u8>`. For `Label`, you
+/// can use `Box<Label>` or [`LabelBuf`].
+///
+/// ```
+/// # #![cfg(feature = "alloc")]
+/// # use domain::new::base::name::{Label, LabelBuf, label};
+/// # use domain::new::base::wire::ParseBytes;
+/// # use domain::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
+/// #
+/// let label: &Label = label!("example");
+///
+/// // Copy into a fixed-size buffer (ideal for modification):
+/// let buffer: LabelBuf = label.to_buf();
+/// let buffer: LabelBuf = label.unsized_copy_into();
+/// let buffer: LabelBuf = LabelBuf::copy_from(label);
+/// let buffer: LabelBuf = LabelBuf::unsized_copy_from(label);
+///
+/// // Copy into a heap allocation (ideal for long-term storage):
+/// let boxed: Box<Label> = label.to_boxed();
+/// let boxed: Box<Label> = label.unsized_copy_into();
+/// let boxed: Box<Label> = Box::unsized_copy_from(label);
+/// ```
+///
+/// ## Accessing the bytes
+///
+/// `Label` does not implement [`AsRef<[u8]>`] or provide other conveniences
+/// to access the underlying bytes, because it is unclear whether the
+/// implementation should include the length octet with those bytes.
+///
+/// The preferred ways to access the bytes are [`Self::encoding()`] (which
+/// explicitly includes the length octet) and [`Self::contents()`] (which
+/// explicitly does not).
+///
+/// `Label`'s implementation of [`AsBytes`] includes the length octet, as
+/// [`AsBytes`] is primarily intended for encoding into a byte stream as in
+/// the DNS wire format.
 #[derive(AsBytes, UnsizedCopy)]
 #[repr(transparent)]
 pub struct Label([u8]);
@@ -48,11 +140,24 @@ impl Label {
 impl Label {
     /// Assume a byte slice is a valid label.
     ///
+    /// This can be used to cast a label encoded in the wire format into the
+    /// [`Label`] type without copying.
+    ///
+    /// For a checked, safe version, use [`Label::parse_bytes()`].
+    ///
+    /// ```
+    /// # use domain::new::base::name::Label;
+    /// #
+    /// let encoded: &[u8] = b"\x07example";
+    /// let label: &Label = unsafe { Label::from_bytes_unchecked(encoded) };
+    /// ```
+    ///
     /// # Safety
     ///
     /// The following conditions must hold for this call to be sound:
     /// - `bytes.len() <= 64`
     /// - `bytes[0] as usize + 1 == bytes.len()`
+    #[must_use]
     pub const unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Self {
         // SAFETY: 'Label' is 'repr(transparent)' to '[u8]'.
         unsafe { core::mem::transmute(bytes) }
@@ -60,14 +165,72 @@ impl Label {
 
     /// Assume a mutable byte slice is a valid label.
     ///
+    /// This can be used to cast a label encoded in the wire format into the
+    /// [`Label`] type without copying, while retaining mutable access.
+    ///
+    /// ```
+    /// # use domain::new::base::name::Label;
+    /// #
+    /// let mut encoded: [u8; _] = *b"\x07example";
+    /// let label: &mut Label = unsafe {
+    ///     Label::from_mut_bytes_unchecked(&mut encoded)
+    /// };
+    /// ```
+    ///
     /// # Safety
     ///
     /// The following conditions must hold for this call to be sound:
     /// - `bytes.len() <= 64`
     /// - `bytes[0] as usize + 1 == bytes.len()`
-    pub unsafe fn from_bytes_unchecked_mut(bytes: &mut [u8]) -> &mut Self {
+    #[must_use]
+    pub const unsafe fn from_mut_bytes_unchecked(
+        bytes: &mut [u8],
+    ) -> &mut Self {
         // SAFETY: 'Label' is 'repr(transparent)' to '[u8]'.
         unsafe { core::mem::transmute(bytes) }
+    }
+}
+
+//--- Manipulation
+
+impl Label {
+    /// Copy the label into a [`LabelBuf`].
+    ///
+    /// This is equivalent to [`LabelBuf::copy_from()`], but may be more
+    /// convenient to use in some cases.
+    ///
+    /// This is a concrete, inherent, and `const` version of
+    /// [`Self::unsized_copy_into()`].
+    #[must_use]
+    pub const fn to_buf(&self) -> LabelBuf {
+        LabelBuf::copy_from(self)
+    }
+
+    /// Copy the label into a [`Box<Label>`].
+    ///
+    /// This is a concrete, inherent version of [`Self::unsized_copy_into()`].
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_boxed(&self) -> alloc::boxed::Box<Label> {
+        self.unsized_copy_into()
+    }
+
+    /// Lowercase the label.
+    ///
+    /// All ASCII uppercase characters in the label will be lowercased.
+    ///
+    /// ```
+    /// # use domain::new::base::name::label_buf;
+    /// #
+    /// let mut buffer = label_buf!("eXAMpLE");
+    /// buffer.make_lowercase();
+    /// assert_eq!(buffer.contents(), b"example");
+    /// ```
+    pub const fn make_lowercase(&mut self) {
+        // We include the length octet. It is strictly less than 64, so is
+        // never a valid ASCII alphabetic character, and so it will not be
+        // affected.
+        self.0.make_ascii_lowercase()
     }
 }
 
@@ -101,7 +264,7 @@ impl BuildInMessage for Label {
         start: usize,
         _compressor: &mut NameCompressor,
     ) -> Result<usize, TruncationError> {
-        let bytes = &self.0;
+        let bytes = self.encoding();
         let end = start + bytes.len();
         contents
             .get_mut(start..end)
@@ -139,16 +302,21 @@ impl<'a> ParseBytes<'a> for &'a Label {
 
 //--- Building into byte sequences
 
+/// Serializing a [`Label`] as bytes.
+///
+/// Labels are serialized exactly as [`Label::encoding()`], their encoding in
+/// the DNS wire format: a one-byte length octet (between 0 and 63, inclusive)
+/// followed by that many bytes.
 impl BuildBytes for Label {
     fn build_bytes<'b>(
         &self,
         bytes: &'b mut [u8],
     ) -> Result<&'b mut [u8], TruncationError> {
-        self.0.build_bytes(bytes)
+        self.encoding().build_bytes(bytes)
     }
 
     fn built_bytes_size(&self) -> usize {
-        self.0.len()
+        self.encoding().len()
     }
 }
 
@@ -156,41 +324,97 @@ impl BuildBytes for Label {
 
 impl Label {
     /// Whether this is the root label.
+    ///
+    /// Equivalent to `self == Label::ROOT`.
+    #[must_use]
     pub const fn is_root(&self) -> bool {
+        // We don't need to look at the length octet directly; it is always
+        // equal to `self.0.len() - 1`.
         self.0.len() == 1
     }
 
     /// Whether this is a wildcard label.
+    ///
+    /// Equivalent to `self == Label::WILDCARD`.
+    #[must_use]
     pub const fn is_wildcard(&self) -> bool {
         matches!(self.0, [1, b'*'])
     }
 
-    /// The bytes making up this label.
+    /// Whether the label is "empty" (i.e. the root label).
     ///
-    /// This includes the leading length octet.
-    pub const fn as_bytes(&self) -> &[u8] {
+    /// This is an alias for [`Self::is_root()`], offered for uniformity with
+    /// other types that implement `len()`.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.is_root()
+    }
+
+    /// The length of the label.
+    ///
+    /// This count does not include the length octet.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.0[0] as usize
+    }
+
+    /// The encoding of the label in the DNS wire format.
+    ///
+    /// This includes the length octet. It is also accessible via
+    /// [`Self::as_bytes()`] and [`Self::build_bytes()`]. If you don't need
+    /// the length octet, use [`Self::contents()`].
+    ///
+    /// ```
+    /// # use domain::new::base::name::label;
+    /// #
+    /// let label = label!("example");
+    /// assert_eq!(label.encoding(), b"\x07example");
+    /// assert_eq!(label.contents(), b"example");
+    /// ```
+    #[must_use]
+    pub const fn encoding(&self) -> &[u8] {
         &self.0
     }
 
     /// The contents of the label.
     ///
-    /// This does not include the leading length octet.
-    pub fn contents(&self) -> &[u8] {
-        &self.0[1..]
+    /// This does not include the length octet. If you need the length octet,
+    /// use [`Self::encoding()`]. Use [`Self::contents_mut()`] for a mutable
+    /// view.
+    ///
+    /// ```
+    /// # use domain::new::base::name::label;
+    /// #
+    /// let label = label!("example");
+    /// assert_eq!(label.contents(), b"example");
+    /// assert_eq!(label.encoding(), b"\x07example");
+    /// ```
+    #[must_use]
+    pub const fn contents(&self) -> &[u8] {
+        // TODO: direct slicing is not possible in `const` yet.
+        // SAFETY: A `Label` always has a length octet.
+        unsafe { self.0.split_at_unchecked(1).1 }
     }
-}
 
-//--- Access to the underlying bytes
-
-impl AsRef<[u8]> for Label {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl<'a> From<&'a Label> for &'a [u8] {
-    fn from(value: &'a Label) -> Self {
-        &value.0
+    /// The contents of the label, mutably.
+    ///
+    /// This does not include the length octet. There is no method to get a
+    /// mutable byte slice from [`Label`] including the length octet, because
+    /// modifying it would result in an invalid label.
+    ///
+    /// ```
+    /// # use domain::new::base::name::{Label, label_buf};
+    /// # use domain::new::base::wire::ParseBytes;
+    /// #
+    /// let mut buffer = label_buf!("example");
+    /// let label: &mut Label = buffer.as_mut_label();
+    /// assert_eq!(label.contents_mut(), b"example");
+    /// ```
+    #[must_use]
+    pub const fn contents_mut(&mut self) -> &mut [u8] {
+        // TODO: slicing is not possible in `const` yet.
+        // SAFETY: A `Label` always has a length octet.
+        unsafe { self.0.split_at_mut_unchecked(1).1 }
     }
 }
 
@@ -208,11 +432,29 @@ impl Clone for alloc::boxed::Box<Label> {
 impl PartialEq for Label {
     /// Compare two labels for equality.
     ///
-    /// Labels are compared ASCII-case-insensitively.
+    /// Labels are compared ASCII-case-insensitively, as is conventional for
+    /// DNS. For a case-sensitive comparison, you can compare the byte slices
+    /// (from [`Self::contents()`], not [`Self::encoding()`]!) manually.
+    ///
+    /// ```
+    /// # use domain::new::base::name::label;
+    /// #
+    /// let a = label!("example");
+    /// let b = label!("eXAMpLE");
+    /// let c = label!("unrelated");
+    /// assert_eq!(a, b);
+    /// assert_ne!(a.contents(), b.contents());
+    /// assert_ne!(a, c);
+    /// ```
     fn eq(&self, other: &Self) -> bool {
-        let this = self.as_bytes().iter().map(u8::to_ascii_lowercase);
-        let that = other.as_bytes().iter().map(u8::to_ascii_lowercase);
-        this.eq(that)
+        // The length octet is strictly less than 64, so it cannot be an ASCII
+        // alphabetic character. This means that it is safe to include in an
+        // ASCII-case-insensitive comparison.
+        //
+        // We don't need to include it, because the lengths of the slices will
+        // be checked already. But it is probably more efficient this way.
+        // Maybe we'll benchmark it one day and find out.
+        self.encoding().eq_ignore_ascii_case(other.encoding())
     }
 }
 
@@ -221,29 +463,42 @@ impl Eq for Label {}
 //--- Ordering
 
 impl PartialOrd for Label {
-    /// Determine the order between labels.
+    /// Determine the order between two labels.
     ///
-    /// Any uppercase ASCII characters in the labels are treated as if they
-    /// were lowercase. The first unequal byte between two labels determines
-    /// its ordering: the label with the smaller byte value is the lesser. If
-    /// two labels have all the same bytes, the shorter label is lesser; if
-    /// they are the same length, they are equal.
+    /// See [`impl Ord for Label`].
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for Label {
-    /// Determine the order between labels.
+    /// Determine the order between two labels.
     ///
-    /// Any uppercase ASCII characters in the labels are treated as if they
-    /// were lowercase. The first unequal byte between two labels determines
-    /// its ordering: the label with the smaller byte value is the lesser. If
-    /// two labels have all the same bytes, the shorter label is lesser; if
-    /// they are the same length, they are equal.
+    /// Labels are compared ASCII-case-insensitively by their contents, as is
+    /// conventional for DNS. Labels are equal if their corresponding bytes
+    /// are equal (ignoring ASCII case). If their corresponding bytes are not
+    /// equal, the ordering is determined by the first mismatched byte. If one
+    /// label is a prefix of the other (i.e. all their corresponding bytes are
+    /// equal, but one has fewer bytes), it is considered less than the other.
+    ///
+    /// For a case-sensitive comparison, you can compare the byte slices
+    /// (from [`Self::contents()`], not [`Self::encoding()`]!) manually.
+    ///
+    /// ```
+    /// # use domain::new::base::name::label;
+    /// #
+    /// let a = label!("example");
+    /// let b = label!("example-");
+    /// let c = label!("org");
+    /// assert!(a < b);
+    /// assert!(a < c);
+    /// assert!(b < c);
+    /// ```
     fn cmp(&self, other: &Self) -> Ordering {
-        let this = self.as_bytes().iter().map(u8::to_ascii_lowercase);
-        let that = other.as_bytes().iter().map(u8::to_ascii_lowercase);
+        // NOTE: The standard library provides `eq_ignore_ascii_case()`, but
+        // not `cmp_ignore_ascii_case()`. So we implement it manually.
+        let this = self.contents().iter().map(u8::to_ascii_lowercase);
+        let that = other.contents().iter().map(u8::to_ascii_lowercase);
         this.cmp(that)
     }
 }
@@ -253,15 +508,26 @@ impl Ord for Label {
 impl Hash for Label {
     /// Hash this label.
     ///
-    /// All uppercase ASCII characters are lowercased beforehand. This way,
-    /// the hash of a label is case-independent, consistent with how labels
-    /// are compared and ordered.
+    /// All uppercase ASCII characters are lowercased before being hashed.
+    /// Thus, the hash is case-independent, consistent with how labels are
+    /// compared and ordered. The length octet is also hashed.
     ///
-    /// The label is hashed as if it were a name containing a single label --
-    /// the length octet is thus included. This makes the hashing consistent
-    /// between names and tuples (not slices!) of labels.
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use std::hash::BuildHasher;
+    /// # use domain::new::base::name::label;
+    /// #
+    /// # let hasher = RandomState::default();
+    /// let a = label!("example");
+    /// let b = label!("eXAMpLE");
+    /// assert_eq!(a, b);
+    /// assert_ne!(a.contents(), b.contents());
+    /// assert_eq!(hasher.hash_one(a), hasher.hash_one(b));
+    /// ```
     fn hash<H: Hasher>(&self, state: &mut H) {
-        for &byte in self.as_bytes() {
+        // NOTE: The length octet is unaffected by `to_ascii_lowercase()`
+        // because it is strictly less than 64.
+        for &byte in self.encoding() {
             state.write_u8(byte.to_ascii_lowercase())
         }
     }
@@ -272,17 +538,75 @@ impl Hash for Label {
 impl fmt::Display for Label {
     /// Print a label.
     ///
-    /// The label is printed in the conventional zone file format, with bytes
-    /// outside printable ASCII formatted as `\\DDD` (a backslash followed by
-    /// three zero-padded decimal digits), and uncommon ASCII characters just
-    /// escaped by a backslash.
+    /// There is no one convention for formatting DNS labels. Labels are
+    /// usually formatted as part of a domain name, and it is not entirely
+    /// clear how they should be formatted on their own. See the examples
+    /// here to understand how this implementation works.
+    ///
+    /// To parse a label _from_ this format, see [`impl FromStr for
+    /// LabelBuf`]. [`Label`] cannot implement [`FromStr`] itself.
+    ///
+    /// The root label is printed as an empty string. Labels are usually
+    /// delimited by `.`s when printing domain names, so this should be
+    /// consistent with formatting domain names like `example.org.`.
+    ///
+    /// Certain characters are escaped using backslashes. There are two
+    /// escape formats: `\\X`, where `X` is the character being escaped
+    /// (used when `X` is a printable ASCII character), and `\\DDD`, where
+    /// `DDD` is the byte value in decimal, zero-padded to three characters.
+    ///
+    /// The following printable ASCII characters are escaped by this version
+    /// of the implementation:
+    ///
+    /// - `"` (`0x22`), `(` (`0x28`), `)` (`0x29`), `@` (`0x40`), `\\`
+    ///   (`0x5C`): these characters are interpreted specially in zone files.
+    ///
+    /// - `/` (`0x2F`), `:` (`0x3A`), `;` (`0x3B`), `<` (`0x3C`), `=`
+    ///   (`0x3D`), `>` (`0x3E`), `?` (`0x3F`) `[` (`0x5B`), `]` (`0x5D`):
+    ///   these characters are sometimes used to delimit URLs, which may be
+    ///   nothing more than domain names.
+    ///
+    /// The following printable ASCII characters are _not_ escaped by this
+    /// version of the implementation: `!`, `#`, `$`, `%`, `&`, `'`, `*`, `+`,
+    /// `,`, `-`, `^`, `_`, `\``, `~`, `{`, `|`, `}`.
+    ///
+    /// Note that ASCII space ` ` is not considered a printable character; it
+    /// will be printed as `\\032`.
+    ///
+    /// Because the zone file format (which is the primary motivation for
+    /// this implementation) is quite under-specified, the details of this
+    /// implementation may change over time. Some printable ASCII characters
+    /// that are not escaped today may be escaped in the future. Characters
+    /// that are escaped using `\\X` syntax today could be escaped using
+    /// `\\DDD` syntax in the future.
+    ///
+    /// ```
+    /// # use domain::new::base::name::{Label, label};
+    /// #
+    /// // The simple case is pretty simple.
+    /// assert_eq!(label!("example").to_string(), "example");
+    ///
+    /// // Uppercase characters are printed as such.
+    /// assert_eq!(label!("eXAMplE").to_string(), "eXAMplE");
+    ///
+    /// // The root label is an empty string.
+    /// assert_eq!(Label::ROOT.to_string(), "");
+    ///
+    /// // Non-ASCII characters are escaped.
+    /// let label = label!(b b"helloworld\xF0\x9F\x8F\xB3\xEF\xB8\x8F\xE2\x80\x8D\xE2\x9A\xA7\xEF\xB8\x8F");
+    /// assert_eq!(label.to_string(),
+    ///     r"helloworld\240\159\143\179\239\184\143\226\128\141\226\154\167\239\184\143");
+    ///
+    /// // Uncommon and non-printable ASCII characters are escaped too.
+    /// let label = label!("\x00\x0A!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~\x7F");
+    /// assert_eq!(label.to_string(),
+    ///     r##"\000\010!\"#$%&'\(\)*+,-\.\/\:\;\<\=\>\?\@\[\\\]^_`{|}~\127"##);
+    /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_wildcard() {
-            return f.write_str("*");
-        }
-
         self.contents().iter().try_for_each(|&byte| {
-            if byte.is_ascii_alphanumeric() || b"-_".contains(&byte) {
+            if byte.is_ascii_alphanumeric()
+                || b"!#$%&'*+,-^_`{|}~".contains(&byte)
+            {
                 write!(f, "{}", byte as char)
             } else if byte.is_ascii_graphic() {
                 write!(f, "\\{}", byte as char)
@@ -295,8 +619,11 @@ impl fmt::Display for Label {
 
 impl fmt::Debug for Label {
     /// Print a label for debugging purposes.
+    ///
+    /// The format used might change in the future, and is not documented to
+    /// prevent it from being relied upon.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Label({self})")
+        write!(f, "Label(\"{self}\")")
     }
 }
 
@@ -304,16 +631,59 @@ impl fmt::Debug for Label {
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for Label {
+    /// Serialize a label.
+    ///
+    /// See [the Serde data model](https://serde.rs/data-model.html) for an
+    /// understanding of the terms here.
+    ///
+    /// Labels are serialized as `newtype_struct`s of name `Label`. For
+    /// human-readable formats (e.g. JSON and TOML), they are serialized as
+    /// per [`impl Display for Label`]. For compact formats (e.g. Postcard),
+    /// they are serialized as byte slices (specifically [`Self::contents()`],
+    /// excluding the length octet).
+    ///
+    /// To deserialize a label, see [`impl Deserialize for LabelBuf`] or
+    /// [`impl Deserialize for Box<Label>`]. They use exactly the same format.
+    /// [`Label`] cannot implement [`Deserialize`] itself.
+    ///
+    /// ```
+    /// # use serde_test::{Configure, Token, assert_ser_tokens};
+    /// # use domain::new::base::name::label;
+    /// #
+    /// assert_ser_tokens(&label!("example\x7Fabc").readable(), &[
+    ///     Token::NewtypeStruct { name: "Label" },
+    ///     Token::String("example\\127abc"),
+    /// ]);
+    /// assert_ser_tokens(&label!("example\x7Fabc").compact(), &[
+    ///     Token::NewtypeStruct { name: "Label" },
+    ///     Token::Bytes(b"example\x7Fabc"),
+    /// ]);
+    /// ```
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        use alloc::string::ToString;
-
         if serializer.is_human_readable() {
-            serializer.serialize_newtype_struct("Label", &self.to_string())
+            serializer
+                .serialize_newtype_struct("Label", &format_args!("{self}"))
         } else {
-            serializer.serialize_newtype_struct("Label", self.contents())
+            // `impl Serialize for [u8]` serializes to `Seq`, not `Bytes`.
+
+            struct NV<'a>(&'a [u8]);
+
+            impl serde::Serialize for NV<'_> {
+                fn serialize<S>(
+                    &self,
+                    serializer: S,
+                ) -> Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    serializer.serialize_bytes(self.0)
+                }
+            }
+
+            serializer.serialize_newtype_struct("Label", &NV(self.contents()))
         }
     }
 }
@@ -331,12 +701,43 @@ pub struct LabelBuf {
 //--- Construction
 
 impl LabelBuf {
+    /// Construct a new, empty [`LabelBuf`].
+    ///
+    /// The resulting buffer contains the root label. It can be appended to.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { data: [0u8; 64] }
+    }
+
     /// Copy a [`Label`] into a buffer.
-    pub fn copy_from(label: &Label) -> Self {
-        let bytes = label.as_bytes();
+    ///
+    /// This is a concrete, inherent, and `const` version of
+    /// [`Self::unsized_copy_from()`].
+    ///
+    /// ```
+    /// # use domain::new::base::name::{LabelBuf, label};
+    /// # use domain::new::base::wire::ParseBytes;
+    /// #
+    /// let buffer: LabelBuf = LabelBuf::copy_from(label!("example"));
+    /// assert_eq!(buffer.encoding(), b"\x07example");
+    /// ```
+    #[must_use]
+    pub const fn copy_from(label: &Label) -> Self {
+        let bytes = label.encoding();
         let mut data = [0u8; 64];
-        data[..bytes.len()].copy_from_slice(bytes);
+        // TODO: `for` loops and slicing aren't `const` yet.
+        let mut index = 0usize;
+        while index < bytes.len() {
+            data[index] = bytes[index];
+            index += 1;
+        }
         Self { data }
+    }
+}
+
+impl Default for LabelBuf {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -345,6 +746,163 @@ impl UnsizedCopyFrom for LabelBuf {
 
     fn unsized_copy_from(value: &Self::Source) -> Self {
         Self::copy_from(value)
+    }
+}
+
+//--- Manipulation
+
+impl LabelBuf {
+    /// Append bytes to the label.
+    ///
+    /// The length octet will be adjusted automatically.
+    ///
+    /// For more complex use cases, consider [`Self::spare_capacity_mut()`].
+    ///
+    /// ```
+    /// # use domain::new::base::name::LabelBuf;
+    /// #
+    /// let mut buffer = LabelBuf::new();
+    /// buffer.append(b"hello").unwrap();
+    /// buffer.append(b"world").unwrap();
+    /// assert_eq!(buffer.encoding(), b"\x0Ahelloworld");
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TruncationError`] if the bytes do not fit in the buffer.
+    /// The buffer will be unmodified.
+    pub const fn append(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<(), TruncationError> {
+        let len = self.data[0] as usize;
+        // PANIC: `len < 64`, and `bytes.len() <= isize::MAX` as that is the
+        // largest legal size of an allocation. So this addition will not
+        // overflow.
+        let new_len = len + bytes.len();
+        if new_len >= 64 {
+            return Err(TruncationError);
+        }
+
+        // TODO: direct slicing is not possible in `const` yet.
+        // SAFETY:
+        // - `1 + len <= 64 = data.len()`.
+        // - `new_len = len + bytes.len() < 64`.
+        // - Thus `bytes.len() < 64 - len`.
+        // - Thus `bytes.len() <= 64 - (1 + len)`.
+        let target = unsafe {
+            self.data
+                .split_at_mut_unchecked(1 + len)
+                .1
+                .split_at_mut_unchecked(bytes.len())
+                .0
+        };
+        target.copy_from_slice(bytes);
+        self.data[0] = new_len as u8;
+
+        Ok(())
+    }
+
+    /// Append a single byte to the label.
+    ///
+    /// The length octet will be adjusted automatically.
+    ///
+    /// Also see [`Self::append()`]. For more complex use cases, consider
+    /// [`Self::spare_capacity_mut()`].
+    ///
+    /// ```
+    /// # use domain::new::base::name::LabelBuf;
+    /// #
+    /// let mut buffer = LabelBuf::new();
+    /// buffer.append(b"hello").unwrap();
+    /// buffer.push(b'4').unwrap();
+    /// buffer.push(b'2').unwrap();
+    /// assert_eq!(buffer.encoding(), b"\x07hello42");
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TruncationError`] if the byte does not fill in the buffer.
+    /// The buffer will be unmodified.
+    pub const fn push(&mut self, byte: u8) -> Result<(), TruncationError> {
+        let len = self.data[0] as usize;
+        if len >= 63 {
+            return Err(TruncationError);
+        }
+
+        self.data[1 + len] = byte;
+        self.data[0] = 1 + len as u8;
+        Ok(())
+    }
+
+    /// Truncate the label to a particular length.
+    ///
+    /// The length octet will be adjusted automatically.
+    ///
+    /// ```
+    /// # use domain::new::base::name::LabelBuf;
+    /// #
+    /// let mut buffer = LabelBuf::new();
+    /// buffer.append(b"example");
+    /// assert_eq!(buffer.encoding(), b"\x07example");
+    /// buffer.truncate(4);
+    /// assert_eq!(buffer.encoding(), b"\x04exam");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the label is strictly shorter than `new_len`.
+    pub const fn truncate(&mut self, new_len: usize) {
+        // TODO: Include `len` and `new_len` in the assert message once it is
+        // `const`-safe to do so.
+        let len = self.data[0] as usize;
+        assert!(new_len <= len, "Label is shorter than desired length");
+        self.data[0] = new_len as u8;
+    }
+
+    /// Access the uninitialized portion of the buffer.
+    ///
+    /// The bytes _after_ the encoded label are returned. These can be
+    /// modified and then included in the label using [`Self::set_len()`].
+    /// This is analogous to [`Vec::spare_capacity_mut()`].
+    ///
+    /// [`Vec::spare_capacity_mut()`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.spare_capacity_mut
+    ///
+    /// ```
+    /// # use domain::new::base::name::LabelBuf;
+    /// # use domain::new::base::wire::ParseBytes;
+    /// #
+    /// let mut buffer = LabelBuf::new();
+    /// buffer.spare_capacity_mut()[..7].copy_from_slice(b"example");
+    /// buffer.set_len(7);
+    /// assert_eq!(buffer.encoding(), b"\x07example");
+    /// ```
+    #[must_use]
+    pub const fn spare_capacity_mut(&mut self) -> &mut [u8] {
+        let size = self.data[0];
+        // TODO: direct slicing is not possible in `const` yet.
+        // SAFETY: `size < 64` so `1 + size` fits within `self.data`.
+        unsafe { self.data.split_at_mut_unchecked(1 + size as usize).1 }
+    }
+
+    /// Set the length of the buffer.
+    ///
+    /// This should be used in conjunction with
+    /// [`Self::spare_capacity_mut()`]; see its documentation. This is
+    /// analogous to [`Vec::set_len()`].
+    ///
+    /// [`Vec::set_len()`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.set_len
+    ///
+    /// Prefer [`Self::truncate()`] for truncating the label.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len >= 64`.
+    pub const fn set_len(&mut self, len: usize) {
+        // TODO: Include `len` in the assert message once it is `const`-safe
+        // to do so.
+        assert!(len < 64, "Invalid length for label");
+        self.data[0] = len as u8;
     }
 }
 
@@ -414,23 +972,52 @@ impl BuildBytes for LabelBuf {
 
 //--- Access to the underlying 'Label'
 
+impl LabelBuf {
+    /// Access the underlying [`Label`].
+    ///
+    /// This is a `const` version of [`Self::deref()`].
+    #[must_use]
+    pub const fn as_label(&self) -> &Label {
+        let size = self.data[0];
+        // TODO: slicing is not possible in `const` yet.
+        // SAFETY: `size < 64`.
+        let label = unsafe {
+            core::slice::from_raw_parts(self.data.as_ptr(), 1 + size as usize)
+        };
+        // SAFETY: A `LabelBuf` always contains a valid `Label`.
+        unsafe { Label::from_bytes_unchecked(label) }
+    }
+
+    /// Access the underlying [`Label`] mutably.
+    ///
+    /// This is a `const` version of [`Self::deref_mut()`].
+    #[must_use]
+    pub const fn as_mut_label(&mut self) -> &mut Label {
+        let size = self.data[0];
+        // TODO: slicing is not possible in `const` yet.
+        // SAFETY: `size < 64`.
+        let label = unsafe {
+            core::slice::from_raw_parts_mut(
+                self.data.as_mut_ptr(),
+                1 + size as usize,
+            )
+        };
+        // SAFETY: A `LabelBuf` always contains a valid `Label`.
+        unsafe { Label::from_mut_bytes_unchecked(label) }
+    }
+}
+
 impl Deref for LabelBuf {
     type Target = Label;
 
     fn deref(&self) -> &Self::Target {
-        let size = self.data[0] as usize;
-        let label = &self.data[..1 + size];
-        // SAFETY: A 'LabelBuf' always contains a valid 'Label'.
-        unsafe { Label::from_bytes_unchecked(label) }
+        self.as_label()
     }
 }
 
 impl DerefMut for LabelBuf {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        let size = self.data[0] as usize;
-        let label = &mut self.data[..1 + size];
-        // SAFETY: A 'LabelBuf' always contains a valid 'Label'.
-        unsafe { Label::from_bytes_unchecked_mut(label) }
+        self.as_mut_label()
     }
 }
 
@@ -486,31 +1073,78 @@ impl Hash for LabelBuf {
     }
 }
 
+//--- Forwarding formatting
+
+impl fmt::Display for LabelBuf {
+    /// See [`impl Display for Label`].
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl fmt::Debug for LabelBuf {
+    /// Print a label for debugging purposes.
+    ///
+    /// The format used might change in the future, and is not documented to
+    /// prevent it from being relied upon.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LabelBuf(\"{self}\")")
+    }
+}
+
 //--- Parsing from strings
 
 impl LabelBuf {
-    /// Parse a label from the zonefile format.
-    pub fn parse_str(mut s: &[u8]) -> Result<(Self, &[u8]), LabelParseError> {
-        if let &[b'*', ref rest @ ..] = s {
-            return Ok((Self::copy_from(Label::WILDCARD), rest));
-        }
-
+    /// Parse a printed label.
+    ///
+    /// This will parse a label from the format used by [`impl Display for
+    /// Label`]. Labels are usually parsed as part of a domain name, and it
+    /// is not entirely clear how they should be parsed on their own. See the
+    /// examples here to understand how this implementation works.
+    ///
+    /// This function is a direct inverse of [`impl Display for LabelBuf`],
+    /// but it cannot be used to parse a label embedded within a larger
+    /// string. For that, see [`LabelBuf::split_str()`].
+    ///
+    /// ```
+    /// # use domain::new::base::name::{LabelBuf, LabelParseError, label_buf};
+    /// #
+    /// assert_eq!(
+    ///     LabelBuf::parse_str(b"example"),
+    ///     Ok(label_buf!("example")));
+    ///
+    /// // An empty input is parsed as the root label.
+    /// assert_eq!(
+    ///     LabelBuf::parse_str(b""),
+    ///     Ok(LabelBuf::new()));
+    ///
+    /// // Irregular characters cause failure.
+    /// assert_eq!(
+    ///     LabelBuf::parse_str(b"example.com."),
+    ///     Err(LabelParseError::InvalidChar));
+    /// ```
+    pub fn parse_str(mut s: &[u8]) -> Result<Self, LabelParseError> {
         // The buffer we'll fill into.
-        let mut this = Self { data: [0u8; 64] };
+        let mut this = Self::new();
 
         // Parse character by character.
         loop {
-            let full = s;
-            let &[b, ref rest @ ..] = s else { break };
+            let &[b, ref rest @ ..] = s else {
+                // The entire input has been consumed.
+                return Ok(this);
+            };
             s = rest;
-            let value = if b.is_ascii_alphanumeric() || b"-_".contains(&b) {
+            if b.is_ascii_alphanumeric() || b"!#$%&'*+,-^_`{|}~".contains(&b)
+            {
                 // A regular label character.
-                b
+                this.push(b).map_err(|_| LabelParseError::Overlong)?;
             } else if b == b'\\' {
                 // An escape character.
-                let &[b, ref rest @ ..] = s else { break };
+                let &[b, ref rest @ ..] = s else {
+                    return Err(LabelParseError::PartialEscape);
+                };
                 s = rest;
-                if b.is_ascii_digit() {
+                let value = if b.is_ascii_digit() {
                     let digits = rest
                         .get(..3)
                         .ok_or(LabelParseError::PartialEscape)?;
@@ -523,40 +1157,99 @@ impl LabelBuf {
                     b
                 } else {
                     return Err(LabelParseError::InvalidEscape);
-                }
-            } else if b". \n\r\t".contains(&b) {
-                // The label has ended.
-                s = full;
-                break;
+                };
+                this.push(value).map_err(|_| LabelParseError::Overlong)?;
             } else {
                 return Err(LabelParseError::InvalidChar);
             };
-
-            let off = this.data[0] as usize + 1;
-            this.data[0] += 1;
-            let ptr =
-                this.data.get_mut(off).ok_or(LabelParseError::Overlong)?;
-            *ptr = value;
         }
+    }
 
-        if this.data[0] == 0 {
-            return Err(LabelParseError::Empty);
+    /// Parse a printed label from a larger string.
+    ///
+    /// This will parse a label from the format used by [`impl Display for
+    /// Label`]. Labels are usually parsed as part of a domain name, and it
+    /// is not entirely clear how they should be parsed on their own. See the
+    /// examples here to understand how this implementation works.
+    ///
+    /// This function is designed for use when parsing labels embedded within
+    /// some larger string (e.g. a zone file). The string may be buffered,
+    /// so only a part of it is provided; the string is considered to be
+    /// infinitely long. A label is only parsed successfully once a delimiting
+    /// byte (one that lies _after_ it) is found. As such, this function is
+    /// **not** a perfect inverse of [`impl Display for Label`]. For such an
+    /// inverse, see [`LabelBuf::parse_str()`].
+    ///
+    /// ```
+    /// # use domain::new::base::name::{LabelBuf, LabelSplitError, label_buf};
+    /// #
+    /// assert_eq!(
+    ///     LabelBuf::split_str(b"example.com."),
+    ///     Ok((label_buf!("example"), &b".com."[..])));
+    ///
+    /// // Even though this looks like a valid label, there is no delimiting
+    /// // byte, so it cannot be parsed successfully.
+    /// assert_eq!(
+    ///     LabelBuf::split_str(b"example"),
+    ///     Err(LabelSplitError::ShortInput));
+    ///
+    /// // Any "uncommon" ASCII character, non-printable ASCII character, or
+    /// // non-ASCII character can serve as the delimiting byte.
+    /// assert_eq!(
+    ///     LabelBuf::split_str(b"com:22"),
+    ///     Ok((label_buf!("com"), &b":22"[..])));
+    /// ```
+    pub fn split_str(mut s: &[u8]) -> Result<(Self, &[u8]), LabelSplitError> {
+        // The buffer we'll fill into.
+        let mut this = Self::new();
+
+        // Parse character by character.
+        loop {
+            let full = s;
+            let &[b, ref rest @ ..] = s else {
+                return Err(LabelSplitError::ShortInput);
+            };
+            s = rest;
+            if b.is_ascii_alphanumeric() || b"!#$%&'*+,-^_`{|}~".contains(&b)
+            {
+                // A regular label character.
+                this.push(b).map_err(|_| LabelSplitError::Overlong)?;
+            } else if b == b'\\' {
+                // An escape character.
+                let &[b, ref rest @ ..] = s else {
+                    return Err(LabelSplitError::ShortInput);
+                };
+                s = rest;
+                let value = if b.is_ascii_digit() {
+                    let digits =
+                        rest.get(..3).ok_or(LabelSplitError::ShortInput)?;
+                    let digits = core::str::from_utf8(digits)
+                        .map_err(|_| LabelSplitError::InvalidEscape)?;
+                    digits
+                        .parse()
+                        .map_err(|_| LabelSplitError::InvalidEscape)?
+                } else if b.is_ascii_graphic() {
+                    b
+                } else {
+                    return Err(LabelSplitError::InvalidEscape);
+                };
+                this.push(value).map_err(|_| LabelSplitError::Overlong)?;
+            } else {
+                // An invalid character has been reached; the label has ended.
+                break Ok((this, full));
+            };
         }
-
-        Ok((this, s))
     }
 }
 
 impl FromStr for LabelBuf {
     type Err = LabelParseError;
 
-    /// Parse a label from a string.
+    /// Parse a printed label.
+    ///
+    /// See [`LabelBuf::parse_str()`].
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match Self::parse_str(s.as_bytes()) {
-            Ok((this, &[])) => Ok(this),
-            Ok(_) => Err(LabelParseError::InvalidChar),
-            Err(err) => Err(err),
-        }
+        Self::parse_str(s.as_bytes())
     }
 }
 
@@ -564,6 +1257,7 @@ impl FromStr for LabelBuf {
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for LabelBuf {
+    /// See [`impl Serialize for Label`].
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -676,8 +1370,11 @@ impl<'a> serde::Deserialize<'a> for LabelBuf {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "alloc"))]
 impl<'a> serde::Deserialize<'a> for alloc::boxed::Box<Label> {
+    /// Deserialize a label and allocate it on the heap.
+    ///
+    /// See [`impl Deserialize for LabelBuf`].
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'a>,
@@ -761,6 +1458,100 @@ impl fmt::Debug for LabelIter<'_> {
     }
 }
 
+//============ Macros ========================================================
+
+/// Construct a hard-coded [`Label`] at compile time.
+///
+/// This is a convenience function for writing example-based tests; it
+/// provides a simple, convenient way to build [`Label`]s with hard-coded
+/// values.
+///
+/// ```
+/// # use domain::new::base::name::{Label, label};
+/// #
+/// let foo: &'static Label = label!("example");
+/// assert_eq!(foo.encoding(), b"\x07example");
+///
+/// // Escapes in the label are not processed.
+/// let foo: &'static Label = label!("ex\x0Amp\\e");
+/// assert_eq!(foo.encoding(), b"\x07ex\x0Amp\\e");
+///
+/// // You can use byte strings to avoid UTF-8 validity.
+/// // Due to macro limitations, you need to disambiguate this from
+/// // a regular string literal by prepending a `b` token.
+/// let foo: &'static Label = label!(b b"ex\xFFmple");
+/// assert_eq!(foo.encoding(), b"\x07ex\xFFmple");
+/// ```
+#[doc(hidden)]
+#[macro_export]
+macro_rules! new_base_name_label {
+    // Both match arms work the same way, so we could combine them into a
+    // single thing that forwards to `label_buf!()`. But the RustDoc shows
+    // the macro's match arm rules, so it's better to keep them explicit.
+    //
+    (b $value:literal) => {
+        const {
+            const BUFFER: &$crate::new::base::name::LabelBuf =
+        &$crate::new::base::name::label_buf!(b $value);
+            BUFFER.as_label()
+        }
+    };
+
+    ($value:literal) => {
+        const {
+            const BUFFER: &$crate::new::base::name::LabelBuf =
+                &$crate::new::base::name::label_buf!($value);
+            BUFFER.as_label()
+        }
+    };
+}
+pub use crate::new_base_name_label as label;
+
+/// Construct a hard-coded [`LabelBuf`] at compile time.
+///
+/// This is a convenience function for writing example-based tests; it
+/// provides a simple, convenient way to build [`LabelBuf`]s with hard-coded
+/// values.
+///
+/// ```
+/// # use domain::new::base::name::{LabelBuf, label_buf};
+/// #
+/// let foo: LabelBuf = label_buf!("example");
+/// assert_eq!(foo.encoding(), b"\x07example");
+///
+/// // Escapes in the label are not processed.
+/// let foo: LabelBuf = label_buf!("ex\x0Amp\\e");
+/// assert_eq!(foo.encoding(), b"\x07ex\x0Am\\e");
+///
+/// // You can use byte strings to avoid UTF-8 validity.
+/// // Due to macro limitations, you need to disambiguate this from
+/// // a regular string literal by prepending a `b` token.
+/// let foo: LabelBuf = label_buf!(b b"ex\xFFmple");
+/// assert_eq!(foo.encoding(), b"\x07ex\xFFmple");
+/// ```
+#[doc(hidden)]
+#[macro_export]
+macro_rules! new_base_name_label_buf {
+    (b $value:literal) => {
+        const {
+            let mut buffer = $crate::new::base::name::LabelBuf::new();
+            assert!(buffer.append($value).is_ok());
+            buffer
+        }
+    };
+
+    ($value:literal) => {
+        const {
+            let mut buffer = $crate::new::base::name::LabelBuf::new();
+            assert!(buffer.append($value.as_bytes()).is_ok());
+            buffer
+        }
+    };
+}
+pub use crate::new_base_name_label_buf as label_buf;
+
+//============ Errors ========================================================
+
 //------------ LabelParseError -----------------------------------------------
 
 /// An error in parsing a [`Label`] from a string.
@@ -773,12 +1564,6 @@ pub enum LabelParseError {
     ///
     /// Valid labels are between 1 and 63 bytes, inclusive.
     Overlong,
-
-    /// The label was empty.
-    ///
-    /// While root labels do exist, they can only be found at the end of a
-    /// domain name, and cannot be parsed using [`LabelBuf::from_str()`].
-    Empty,
 
     /// An invalid character was used.
     ///
@@ -808,10 +1593,112 @@ impl fmt::Display for LabelParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Self::Overlong => "the label was too large",
-            Self::Empty => "the label was empty",
             Self::InvalidChar => "the label contained an invalid character",
             Self::PartialEscape => "the label contained an incomplete escape",
             Self::InvalidEscape => "the label contained an invalid escape",
         })
+    }
+}
+
+//------------ LabelSplitError -----------------------------------------------
+
+/// An error in parsing a [`Label`] from a larger string.
+///
+/// This can be returned by [`LabelBuf::split_str()`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LabelSplitError {
+    /// The label was too large.
+    ///
+    /// Valid labels are between 1 and 63 bytes, inclusive.
+    Overlong,
+
+    /// An invalid character was used.
+    ///
+    /// Only alphanumeric characters and hyphens are allowed in labels. This
+    /// prevents the encoding of perfectly valid labels containing non-ASCII
+    /// bytes, but they're fairly rare anyway.
+    InvalidChar,
+
+    /// An invalid escape was used.
+    ///
+    /// An escape must be `\\DDD`, where `DDD` are 3 ASCII decimal digits
+    /// representing an unsigned 8-bit integer; or `\\X`, where `X` is a
+    /// graphical, non-digit ASCII character.
+    InvalidEscape,
+
+    /// The input was too short to parse the label.
+    ///
+    /// The input did not sufficiently delimit the label. More input (if any)
+    /// needs to be collected to correctly parse the entire label.
+    ShortInput,
+}
+
+impl core::error::Error for LabelSplitError {}
+
+impl fmt::Display for LabelSplitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Overlong => "the label was too large",
+            Self::InvalidChar => "the label contained an invalid character",
+            Self::InvalidEscape => "the label contained an invalid escape",
+            Self::ShortInput => "the input was too short to parse the label",
+        })
+    }
+}
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use super::Label;
+
+    use crate::new::base::wire::{ParseBytes, ParseError, SplitBytes};
+
+    #[test]
+    fn parsing() {
+        let good: [&[u8]; _] = [
+            b"\x00abc",
+            b"\x07example\x03org\x00",
+            b"\x07f\x00\x00&\x8Fbar-foo",
+            b"\x3Fthis is a label of the longest valid length and it's surprising(ly big)",
+        ];
+
+        for input in good {
+            // Try parsing input with some bytes following it.
+            let expected_len = input[0] as usize + 1;
+            assert_eq!(<&Label>::parse_bytes(input), Err(ParseError));
+            let (actual, rest) = <&Label>::split_bytes(input).unwrap();
+            assert_eq!(actual.encoding().len(), expected_len);
+            assert_eq!(actual.encoding().as_ptr(), input.as_ptr());
+            assert_eq!(actual.encoding().len() + rest.len(), input.len());
+            assert_eq!(
+                rest.as_ptr(),
+                input.as_ptr().wrapping_add(expected_len)
+            );
+
+            // Try parsing input that _only_ contains a label.
+            let min_input = &input[..expected_len];
+            let (actual, rest) = <&Label>::split_bytes(min_input).unwrap();
+            assert_eq!(actual.encoding().as_ptr(), min_input.as_ptr());
+            assert_eq!(actual.encoding().len(), min_input.len());
+            assert_eq!(rest, &[] as &[u8]);
+            let actual = <&Label>::parse_bytes(min_input).unwrap();
+            assert_eq!(actual.encoding().as_ptr(), min_input.as_ptr());
+            assert_eq!(actual.encoding().len(), min_input.len());
+
+            // Try parsing input that's a byte too short.
+            let short_input = &input[..expected_len - 1];
+            assert_eq!(<&Label>::split_bytes(short_input), Err(ParseError));
+            assert_eq!(<&Label>::parse_bytes(short_input), Err(ParseError));
+        }
+
+        let bad: [&[u8]; _] = [
+            b"\x40this is not a valid label but it would be if 64 was a valid label length",
+        ];
+
+        for input in bad {
+            assert_eq!(<&Label>::split_bytes(input), Err(ParseError));
+            assert_eq!(<&Label>::parse_bytes(input), Err(ParseError));
+        }
     }
 }

--- a/src/new/base/name/mod.rs
+++ b/src/new/base/name/mod.rs
@@ -83,10 +83,13 @@ use super::wire::{BuildBytes, TruncationError};
 //--- Submodules
 
 mod label;
-pub use label::{Label, LabelBuf, LabelIter, LabelParseError};
+pub use label::{
+    Label, LabelBuf, LabelIter, LabelParseError, LabelSplitError, label,
+    label_buf,
+};
 
 mod absolute;
-pub use absolute::{Name, NameBuf, NameParseError};
+pub use absolute::{Name, NameBuf, NameParseError, NameSplitError};
 
 mod reversed;
 pub use reversed::{RevName, RevNameBuf};

--- a/src/new/base/name/mod.rs
+++ b/src/new/base/name/mod.rs
@@ -62,7 +62,7 @@
 //! use domain::new::base::name;
 //!
 //! let name_buf: name::NameBuf =
-//!     "www.nlnetlabs.nl".parse().unwrap();
+//!     "www.nlnetlabs.nl.".parse().unwrap();
 //! let name_ref: &name::Name = &name_buf;
 //!
 //! println!("NameBuf {}, &Name {}", name_buf, name_ref);
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_build_lowercased_bytes_simple() {
-        let name: NameBuf = "E.com".parse().unwrap();
+        let name: NameBuf = "E.com.".parse().unwrap();
         let mut buf = vec![0u8; name.built_bytes_size()];
         assert!(name.build_lowercased_bytes(&mut buf).unwrap().is_empty());
         assert_eq!(buf, buf.to_ascii_lowercase());
@@ -259,7 +259,7 @@ mod tests {
 
     #[test]
     fn test_build_lowercased_bytes_too_long_buffer() {
-        let name: NameBuf = "E.com".parse().unwrap();
+        let name: NameBuf = "E.com.".parse().unwrap();
         let mut buf = vec![0u8; 100];
         let rest = name.build_lowercased_bytes(&mut buf).unwrap();
 

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -140,9 +140,9 @@ impl BuildInMessage for RevName {
             let labels = unsafe { LabelIter::new_unchecked(rest) };
             for label in labels {
                 let label_buffer;
-                let offset = buffer.len() - label.encoding().len();
+                let offset = buffer.len() - label.as_wire().len();
                 (buffer, label_buffer) = buffer.split_at_mut(offset);
-                label_buffer.copy_from_slice(label.encoding());
+                label_buffer.copy_from_slice(label.as_wire());
             }
 
             // Add the top bits and the 12-byte offset for the message header.
@@ -174,9 +174,9 @@ impl BuildBytes for RevName {
         // Write out the labels in the name in reverse.
         for label in self.labels() {
             let label_buffer;
-            let offset = buffer.len() - label.encoding().len();
+            let offset = buffer.len() - label.as_wire().len();
             (buffer, label_buffer) = buffer.split_at_mut(offset);
-            label_buffer.copy_from_slice(label.encoding());
+            label_buffer.copy_from_slice(label.as_wire());
         }
 
         Ok(rest)

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -12,6 +12,7 @@ use core::{
 use crate::{
     new::base::{
         build::{BuildInMessage, NameCompressor},
+        name::NameSplitError,
         parse::{ParseMessageBytes, SplitMessageBytes},
         wire::{
             BuildBytes, ParseBytes, ParseError, SplitBytes, TruncationError,
@@ -139,9 +140,9 @@ impl BuildInMessage for RevName {
             let labels = unsafe { LabelIter::new_unchecked(rest) };
             for label in labels {
                 let label_buffer;
-                let offset = buffer.len() - label.as_bytes().len();
+                let offset = buffer.len() - label.encoding().len();
                 (buffer, label_buffer) = buffer.split_at_mut(offset);
-                label_buffer.copy_from_slice(label.as_bytes());
+                label_buffer.copy_from_slice(label.encoding());
             }
 
             // Add the top bits and the 12-byte offset for the message header.
@@ -173,9 +174,9 @@ impl BuildBytes for RevName {
         // Write out the labels in the name in reverse.
         for label in self.labels() {
             let label_buffer;
-            let offset = buffer.len() - label.as_bytes().len();
+            let offset = buffer.len() - label.encoding().len();
             (buffer, label_buffer) = buffer.split_at_mut(offset);
-            label_buffer.copy_from_slice(label.as_bytes());
+            label_buffer.copy_from_slice(label.encoding());
         }
 
         Ok(rest)
@@ -620,9 +621,38 @@ impl fmt::Debug for RevNameBuf {
 //--- Parsing from strings
 
 impl RevNameBuf {
-    /// Parse a domain name from the zonefile format.
-    pub fn parse_str(s: &[u8]) -> Result<(Self, &[u8]), NameParseError> {
-        NameBuf::parse_str(s).map(|(this, rest)| (this.into(), rest))
+    /// Parse a printed domain name.
+    ///
+    /// This will parse a domain name from the format used by [`impl Display
+    /// for RevName`]. This is a subset of the syntax of the zone file format.
+    /// See the examples here to understand how this implementation works.
+    ///
+    /// This function is a direct inverse of [`impl Display for RevNameBuf`],
+    /// but it cannot be used to parse a domain name embedded within a larger
+    /// string. For that, see [`RevNameBuf::split_str()`].
+    //
+    // TODO: Doc tests
+    pub fn parse_str(s: &[u8]) -> Result<Self, NameParseError> {
+        NameBuf::parse_str(s).map(Self::from)
+    }
+
+    /// Parse a printed domain name from a larger string.
+    ///
+    /// This will parse a domain name from the format used by [`impl Display
+    /// for RevName`]. This is a subset of the syntax of the zone file format.
+    /// See the examples here to understand how this implementation works.
+    ///
+    /// This function is designed for use when parsing domain names embedded
+    /// within some larger string (e.g. a zone file). The string may be
+    /// buffered, so only a part of it is provided; the string is considered
+    /// to be infinitely long. A domain name is only parsed successfully
+    /// once a delimiting byte (one that lies _after_ it) is found. As such,
+    /// this function is **not** a perfect inverse of [`impl Display for
+    /// RevNameBuf`]. For such an inverse, see [`RevNameBuf::parse_str()`].
+    //
+    // TODO: Doc tests
+    pub fn split_str(s: &[u8]) -> Result<(Self, &[u8]), NameSplitError> {
+        NameBuf::split_str(s).map(|(this, rest)| (this.into(), rest))
     }
 }
 
@@ -631,11 +661,7 @@ impl FromStr for RevNameBuf {
 
     /// Parse a name from a string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match Self::parse_str(s.as_bytes()) {
-            Ok((this, &[])) => Ok(this),
-            Ok(_) => Err(NameParseError::InvalidChar),
-            Err(err) => Err(err),
-        }
+        Self::parse_str(s.as_bytes())
     }
 }
 

--- a/src/new/base/name/reversed.rs
+++ b/src/new/base/name/reversed.rs
@@ -735,7 +735,7 @@ mod tests {
 
     #[test]
     fn test_to_name() {
-        let revnamebuf: RevNameBuf = "example.com".parse().unwrap();
+        let revnamebuf: RevNameBuf = "example.com.".parse().unwrap();
         assert_eq!(
             revnamebuf.to_name().as_bytes(),
             b"\x07example\x03com\x00",

--- a/src/new/base/parse/mod.rs
+++ b/src/new/base/parse/mod.rs
@@ -42,12 +42,12 @@
 //! // A parsed version of the same message.
 //! let items = [
 //!     MessageItem::Question(Question {
-//!         qname: "www.example.org".parse::<RevNameBuf>().unwrap(),
+//!         qname: "www.example.org.".parse::<RevNameBuf>().unwrap(),
 //!         qtype: QType::A,
 //!         qclass: QClass::IN,
 //!     }),
 //!     MessageItem::Answer(Record {
-//!         rname: "www.example.org".parse::<RevNameBuf>().unwrap(),
+//!         rname: "www.example.org.".parse::<RevNameBuf>().unwrap(),
 //!         rtype: RType::A,
 //!         rclass: RClass::IN,
 //!         ttl: 3600.into(),
@@ -119,7 +119,7 @@
 //! (question, offset) = <Question<RevNameBuf>>
 //!     ::split_message_bytes(&message.contents, offset).unwrap();
 //!
-//! assert_eq!(question.qname, "www.example.org".parse().unwrap());
+//! assert_eq!(question.qname, "www.example.org.".parse().unwrap());
 //! assert_eq!(question.qtype, QType::A);
 //! assert_eq!(question.qclass, QClass::IN);
 //!
@@ -128,7 +128,7 @@
 //! (answer, offset) = <Record<RevNameBuf, RecordData<'_, NameBuf>>>
 //!     ::split_message_bytes(&message.contents, offset).unwrap();
 //!
-//! assert_eq!(answer.rname, "www.example.org".parse().unwrap());
+//! assert_eq!(answer.rname, "www.example.org.".parse().unwrap());
 //! assert_eq!(answer.rtype, RType::A);
 //! assert_eq!(answer.rclass, RClass::IN);
 //! assert_eq!(answer.ttl.value.get(), 3600);

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -25,12 +25,12 @@ use super::wire::{
 ///     base::name::RevNameBuf,
 ///     rdata::CName<base::name::NameBuf>,
 /// > = base::Record {
-///     rname: "www.nlnetlabs.nl".parse().unwrap(),
+///     rname: "www.nlnetlabs.nl.".parse().unwrap(),
 ///     rtype: base::RType::CNAME,
 ///     rclass: base::RClass::IN,
 ///     ttl: base::TTL::from(3600),
 ///     rdata: rdata::CName {
-///         name: "nlnetlabs.nl".parse().unwrap(),
+///         name: "nlnetlabs.nl.".parse().unwrap(),
 ///     },
 /// };
 ///

--- a/src/new/base/wire/build.rs
+++ b/src/new/base/wire/build.rs
@@ -24,6 +24,7 @@ pub trait BuildBytes {
     /// This reports the exact number of bytes that will be written to the
     /// buffer passed to [`Self::build_bytes()`]. Note that this is not the
     /// cheapest operation; it may have to traverse all the fields in `self`.
+    #[must_use]
     fn built_bytes_size(&self) -> usize;
 }
 

--- a/src/new/base/wire/mod.rs
+++ b/src/new/base/wire/mod.rs
@@ -42,7 +42,7 @@
 //!
 //! // Parse into a new 'Question'.
 //! let question = Question::<RevNameBuf>::parse_bytes(&bytes).unwrap();
-//! assert_eq!(question.qname, "org".parse::<RevNameBuf>().unwrap());
+//! assert_eq!(question.qname, "org.".parse::<RevNameBuf>().unwrap());
 //! assert_eq!(question.qtype, QType::A);
 //! assert_eq!(question.qclass, QClass::IN);
 //!

--- a/src/new/rdata/basic/cname.rs
+++ b/src/new/rdata/basic/cname.rs
@@ -64,7 +64,7 @@ use crate::new::base::{
 /// #
 /// // Build a 'CName' manually:
 /// let manual: CName<RevNameBuf> = CName {
-///     name: "example.org".parse().unwrap(),
+///     name: "example.org.".parse().unwrap(),
 /// };
 ///
 /// // Its wire format serialization looks like:

--- a/src/new/rdata/basic/mx.rs
+++ b/src/new/rdata/basic/mx.rs
@@ -61,7 +61,7 @@ use crate::new::base::{
 /// // Build an 'Mx' manually:
 /// let manual: Mx<RevNameBuf> = Mx {
 ///     preference: 10.into(),
-///     exchange: "example.org".parse().unwrap(),
+///     exchange: "example.org.".parse().unwrap(),
 /// };
 ///
 /// let bytes = b"\x00\x0A\x07example\x03org\x00";

--- a/src/new/rdata/basic/ns.rs
+++ b/src/new/rdata/basic/ns.rs
@@ -69,7 +69,7 @@ use crate::new::base::{
 /// #
 /// // Build an 'Ns' manually:
 /// let manual: Ns<RevNameBuf> = Ns {
-///     server: "example.org".parse().unwrap(),
+///     server: "example.org.".parse().unwrap(),
 /// };
 ///
 /// // Its wire format serialization looks like:

--- a/src/new/rdata/basic/ptr.rs
+++ b/src/new/rdata/basic/ptr.rs
@@ -58,7 +58,7 @@ use crate::new::base::{
 /// #
 /// // Build a 'Ptr' manually:
 /// let manual: Ptr<RevNameBuf> = Ptr {
-///     name: "example.org".parse().unwrap(),
+///     name: "example.org.".parse().unwrap(),
 /// };
 ///
 /// // Its wire format serialization looks like:

--- a/src/new/rdata/basic/soa.rs
+++ b/src/new/rdata/basic/soa.rs
@@ -71,8 +71,8 @@ use crate::new::base::{
 /// #
 /// // Build a 'Soa' manually:
 /// let manual: Soa<RevNameBuf> = Soa {
-///     mname: "ns.example.org".parse().unwrap(),
-///     rname: "admin.example.org".parse().unwrap(),
+///     mname: "ns.example.org.".parse().unwrap(),
+///     rname: "admin.example.org.".parse().unwrap(),
 ///     serial: 42.into(),
 ///     refresh: 3600.into(),
 ///     retry: 600.into(),

--- a/src/new/rdata/dname.rs
+++ b/src/new/rdata/dname.rs
@@ -69,7 +69,7 @@ use crate::utils::dst::UnsizedCopy;
 /// # use domain::utils::dst::UnsizedCopy;
 /// #
 /// // Parse a 'Name' and build a 'DName' from there:
-/// let name = "example.org".parse::<NameBuf>().unwrap();
+/// let name = "example.org.".parse::<NameBuf>().unwrap();
 /// let dname = DName::new(&name);
 ///
 /// // Parse a 'DName' from the DNS wire format:

--- a/src/new/rdata/rp.rs
+++ b/src/new/rdata/rp.rs
@@ -57,8 +57,8 @@ use crate::new::base::{
 /// #
 /// // Build an 'Rp' manually:
 /// let manual: Rp<RevNameBuf> = Rp {
-///     mailbox: "postmaster.example.org".parse().unwrap(),
-///     texts: "findme.example.org".parse().unwrap(),
+///     mailbox: "postmaster.example.org.".parse().unwrap(),
+///     texts: "findme.example.org.".parse().unwrap(),
 /// };
 ///
 /// // Its wire format serialization looks like:


### PR DESCRIPTION
@Philip-NLnetLabs discovered a bug in the `RevName` comparison which was rooted in a change to `Label`. While fixing this, I decided to clean up some API surface and add documentation and examples (which also serve as doc tests!). This eventually led to a complete overhaul of the module. I think it's in a much better shape now, and I hope to extend this effort to `absolute.rs` and `reversed.rs` later.