### PR TITLE
Implement the SRV record type in `new::*` + bugfixes

### DIFF
--- a/src/new/base/charstr.rs
+++ b/src/new/base/charstr.rs
@@ -6,6 +6,9 @@ use core::hash::{Hash, Hasher};
 use core::ops::{Deref, DerefMut};
 use core::str::FromStr;
 
+use crate::new::base::parse::{
+    parse_without_compression, split_without_compression,
+};
 use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 
 use super::{
@@ -78,8 +81,7 @@ impl<'a> SplitMessageBytes<'a> for &'a CharStr {
         contents: &'a [u8],
         start: usize,
     ) -> Result<(Self, usize), ParseError> {
-        Self::split_bytes(&contents[start..])
-            .map(|(this, rest)| (this, contents.len() - start - rest.len()))
+        split_without_compression(contents, start)
     }
 }
 
@@ -88,7 +90,7 @@ impl<'a> ParseMessageBytes<'a> for &'a CharStr {
         contents: &'a [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        Self::parse_bytes(&contents[start..])
+        parse_without_compression(contents, start)
     }
 }
 
@@ -286,8 +288,7 @@ impl SplitMessageBytes<'_> for CharStrBuf {
         contents: &'_ [u8],
         start: usize,
     ) -> Result<(Self, usize), ParseError> {
-        <&CharStr>::split_message_bytes(contents, start)
-            .map(|(this, rest)| (Self::copy_from(this), rest))
+        split_without_compression(contents, start)
     }
 }
 
@@ -296,7 +297,7 @@ impl ParseMessageBytes<'_> for CharStrBuf {
         contents: &'_ [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        <&CharStr>::parse_message_bytes(contents, start).map(Self::copy_from)
+        parse_without_compression(contents, start)
     }
 }
 

--- a/src/new/base/name/absolute.rs
+++ b/src/new/base/name/absolute.rs
@@ -14,8 +14,8 @@ use crate::{
         build::BuildInMessage,
         parse::{ParseMessageBytes, SplitMessageBytes},
         wire::{
-            AsBytes, BuildBytes, ParseBytes, ParseError, SplitBytes,
-            TruncationError,
+            AsBytes, BuildBytes, ParseBytes, ParseBytesZC, ParseError,
+            SplitBytes, SplitBytesZC, TruncationError,
         },
     },
     utils::dst::{UnsizedCopy, UnsizedCopyFrom},
@@ -124,17 +124,19 @@ impl CanonicalName for Name {
 
 //--- Parsing from bytes
 
-impl<'a> ParseBytes<'a> for &'a Name {
-    fn parse_bytes(bytes: &'a [u8]) -> Result<Self, ParseError> {
-        match Self::split_bytes(bytes) {
+unsafe impl ParseBytesZC for Name {
+    fn parse_bytes_by_ref(bytes: &[u8]) -> Result<&Self, ParseError> {
+        match Self::split_bytes_by_ref(bytes) {
             Ok((this, &[])) => Ok(this),
             _ => Err(ParseError),
         }
     }
 }
 
-impl<'a> SplitBytes<'a> for &'a Name {
-    fn split_bytes(bytes: &'a [u8]) -> Result<(Self, &'a [u8]), ParseError> {
+unsafe impl SplitBytesZC for Name {
+    fn split_bytes_by_ref(
+        bytes: &[u8],
+    ) -> Result<(&Self, &[u8]), ParseError> {
         let mut offset = 0usize;
         while offset < 255 {
             match *bytes.get(offset..).ok_or(ParseError)? {

--- a/src/new/base/name/label.rs
+++ b/src/new/base/name/label.rs
@@ -10,10 +10,15 @@ use core::{
     str::FromStr,
 };
 
-use crate::new::base::build::{BuildInMessage, NameCompressor};
-use crate::new::base::parse::{ParseMessageBytes, SplitMessageBytes};
+use crate::new::base::parse::{
+    ParseMessageBytes, SplitMessageBytes, split_without_compression,
+};
 use crate::new::base::wire::{
     AsBytes, BuildBytes, ParseBytes, ParseError, SplitBytes, TruncationError,
+};
+use crate::new::base::{
+    build::{BuildInMessage, NameCompressor},
+    parse::parse_without_compression,
 };
 use crate::utils::dst::{UnsizedCopy, UnsizedCopyFrom};
 
@@ -78,7 +83,7 @@ impl<'a> ParseMessageBytes<'a> for &'a Label {
         contents: &'a [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        Self::parse_bytes(&contents[start..])
+        parse_without_compression(contents, start)
     }
 }
 
@@ -87,8 +92,7 @@ impl<'a> SplitMessageBytes<'a> for &'a Label {
         contents: &'a [u8],
         start: usize,
     ) -> Result<(Self, usize), ParseError> {
-        Self::split_bytes(&contents[start..])
-            .map(|(this, rest)| (this, contents.len() - start - rest.len()))
+        split_without_compression(contents, start)
     }
 }
 
@@ -355,7 +359,7 @@ impl ParseMessageBytes<'_> for LabelBuf {
         contents: &'_ [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        Self::parse_bytes(&contents[start..])
+        parse_without_compression(contents, start)
     }
 }
 
@@ -364,8 +368,7 @@ impl SplitMessageBytes<'_> for LabelBuf {
         contents: &'_ [u8],
         start: usize,
     ) -> Result<(Self, usize), ParseError> {
-        Self::split_bytes(&contents[start..])
-            .map(|(this, rest)| (this, contents.len() - start - rest.len()))
+        split_without_compression(contents, start)
     }
 }
 

--- a/src/new/base/parse/mod.rs
+++ b/src/new/base/parse/mod.rs
@@ -259,13 +259,17 @@ impl<'a> ParseMessageBytes<'a> for u8 {
     }
 }
 
-impl<'a, T: ?Sized + ParseBytesZC> ParseMessageBytes<'a> for &'a T {
-    fn parse_message_bytes(
-        contents: &'a [u8],
-        start: usize,
-    ) -> Result<Self, ParseError> {
-        T::parse_bytes_by_ref(&contents[start..])
-    }
+/// Parse bytes from a DNS message, without name compression.
+///
+/// This can be used to parse types that do not contain compressed names
+/// and do not implement [`ParseMessageBytes`]. An explicit conversion
+/// step is needed because some types implement both [`ParseBytes`] and
+/// [`ParseMessageBytes`], but with differing semantics.
+pub fn parse_without_compression<'a, T: ParseBytes<'a>>(
+    contents: &'a [u8],
+    start: usize,
+) -> Result<T, ParseError> {
+    T::parse_bytes(&contents[start..])
 }
 
 impl<'a, T: SplitMessageBytes<'a>, const N: usize> ParseMessageBytes<'a>
@@ -310,7 +314,7 @@ impl<'a> ParseMessageBytes<'a> for alloc::string::String {
         contents: &'a [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        <&str>::parse_message_bytes(contents, start).map(|s| s.into())
+        parse_without_compression::<&str>(contents, start).map(|s| s.into())
     }
 }
 
@@ -348,14 +352,20 @@ impl<'a> SplitMessageBytes<'a> for u8 {
     }
 }
 
-impl<'a, T: ?Sized + SplitBytesZC> SplitMessageBytes<'a> for &'a T {
-    fn split_message_bytes(
-        contents: &'a [u8],
-        start: usize,
-    ) -> Result<(Self, usize), ParseError> {
-        T::split_bytes_by_ref(&contents[start..])
-            .map(|(this, rest)| (this, contents.len() - rest.len()))
-    }
+/// Parse a value from the start of a byte sequence within a DNS message,
+/// without name compression.
+///
+/// This can be used to parse types that do not contain compressed names
+/// and do not implement [`SplitMessageBytes`]. An explicit conversion
+/// step is needed because some types implement both [`SplitBytes`] and
+/// [`SplitMessageBytes`], but with differing semantics.
+pub fn split_without_compression<'a, T: SplitBytes<'a>>(
+    contents: &'a [u8],
+    start: usize,
+) -> Result<(T, usize), ParseError> {
+    let (result, rest) = T::split_bytes(&contents[start..])?;
+    let end = contents.len() - rest.len();
+    Ok((result, end))
 }
 
 impl<'a, T: SplitMessageBytes<'a>, const N: usize> SplitMessageBytes<'a>

--- a/src/new/base/question.rs
+++ b/src/new/base/question.rs
@@ -190,6 +190,9 @@ impl QType {
     /// The type of queries for [`Aaaa`](crate::new::rdata::Aaaa) records.
     pub const AAAA: Self = Self::new(28);
 
+    /// The type of queries for [`Srv`](crate::new::rdata::Srv) records.
+    pub const SRV: Self = Self::new(33);
+
     /// The type of queries for [`DName`](crate::new::rdata::DName) records.
     pub const DNAME: Self = Self::new(39);
 
@@ -267,6 +270,7 @@ impl fmt::Debug for QType {
             Self::TXT => "QType::TXT",
             Self::RP => "QType::RP",
             Self::AAAA => "QType::AAAA",
+            Self::SRV => "QType::SRV",
             Self::DNAME => "QType::DNAME",
             Self::OPT => "QType::OPT",
             Self::DS => "QType::DS",

--- a/src/new/base/question.rs
+++ b/src/new/base/question.rs
@@ -4,6 +4,8 @@ use core::fmt;
 
 use domain_macros::*;
 
+use crate::new::base::parse::split_without_compression;
+
 use super::{
     build::{BuildInMessage, NameCompressor, TruncationError},
     parse::{ParseMessageBytes, SplitMessageBytes},
@@ -79,8 +81,8 @@ where
         start: usize,
     ) -> Result<(Self, usize), ParseError> {
         let (qname, rest) = N::split_message_bytes(contents, start)?;
-        let (&qtype, rest) = <&QType>::split_message_bytes(contents, rest)?;
-        let (&qclass, rest) = <&QClass>::split_message_bytes(contents, rest)?;
+        let (&qtype, rest) = split_without_compression(contents, rest)?;
+        let (&qclass, rest) = split_without_compression(contents, rest)?;
         Ok((Self::new(qname, qtype, qclass), rest))
     }
 }

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -2,6 +2,7 @@
 
 use core::{borrow::Borrow, cmp::Ordering, fmt, ops::Deref};
 
+use crate::new::base::parse::split_without_compression;
 use crate::utils::dst::UnsizedCopy;
 
 use super::build::{BuildInMessage, NameCompressor};
@@ -131,12 +132,12 @@ where
         start: usize,
     ) -> Result<(Self, usize), ParseError> {
         let (rname, rest) = N::split_message_bytes(contents, start)?;
-        let (&rtype, rest) = <&RType>::split_message_bytes(contents, rest)?;
-        let (&rclass, rest) = <&RClass>::split_message_bytes(contents, rest)?;
-        let (&ttl, rest) = <&TTL>::split_message_bytes(contents, rest)?;
+        let (&rtype, rest) = split_without_compression(contents, rest)?;
+        let (&rclass, rest) = split_without_compression(contents, rest)?;
+        let (&ttl, rest) = split_without_compression(contents, rest)?;
         let rdata_start = rest;
-        let (_, rest) =
-            <&SizePrefixed<U16, [u8]>>::split_message_bytes(contents, rest)?;
+        let (_, rest): (&SizePrefixed<U16, [u8]>, _) =
+            split_without_compression(contents, rest)?;
         let rdata =
             D::parse_record_data(&contents[..rest], rdata_start + 2, rtype)?;
 

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -313,6 +313,9 @@ impl RType {
     /// The type of an [`Aaaa`](crate::new::rdata::Aaaa) record.
     pub const AAAA: Self = Self::new(28);
 
+    /// The type of an [`Srv`](crate::new::rdata::Srv) record.
+    pub const SRV: Self = Self::new(33);
+
     /// The type of a [`DName`](crate::new::rdata::DName) record.
     pub const DNAME: Self = Self::new(39);
 
@@ -378,7 +381,7 @@ impl RType {
     /// - `NXT` (obsolete)
     /// - `NAPTR`
     /// - `KX`
-    /// - `SRV`
+    /// - [`SRV`](RType::SRV)
     /// - [`DNAME`](RType::DNAME)
     /// - `A6` (obsolete)
     /// - [`RRSIG`](RType::RRSIG)
@@ -395,6 +398,7 @@ impl RType {
                 | Self::PTR
                 | Self::MX
                 | Self::RP
+                | Self::SRV
                 | Self::DNAME
                 | Self::RRSIG
         )
@@ -432,6 +436,7 @@ impl fmt::Debug for RType {
             Self::TXT => "RType::TXT",
             Self::RP => "RType::RP",
             Self::AAAA => "RType::AAAA",
+            Self::SRV => "RType::SRV",
             Self::DNAME => "RType::DNAME",
             Self::OPT => "RType::OPT",
             Self::DS => "RType::DS",
@@ -480,6 +485,7 @@ impl fmt::Display for RType {
             Self::TXT => "TXT",
             Self::RP => "RP",
             Self::AAAA => "AAAA",
+            Self::SRV => "SRV",
             Self::DNAME => "DNAME",
             Self::OPT => "OPT",
             Self::DS => "DS",

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -135,11 +135,12 @@ where
         let (&rtype, rest) = split_without_compression(contents, rest)?;
         let (&rclass, rest) = split_without_compression(contents, rest)?;
         let (&ttl, rest) = split_without_compression(contents, rest)?;
-        let rdata_start = rest;
-        let (_, rest): (&SizePrefixed<U16, [u8]>, _) =
-            split_without_compression(contents, rest)?;
-        let rdata =
-            D::parse_record_data(&contents[..rest], rdata_start + 2, rtype)?;
+
+        // Parse the rdata length and split the input accordingly.
+        let (size, rest) = split_without_compression::<&U16>(contents, rest)?;
+        let (rdata_start, rest) = (rest, rest + size.get() as usize);
+        let contents = contents.get(..rest).ok_or(ParseError)?;
+        let rdata = D::parse_record_data(contents, rdata_start, rtype)?;
 
         Ok((Self::new(rname, rtype, rclass, ttl, rdata), rest))
     }

--- a/src/new/edns/mod.rs
+++ b/src/new/edns/mod.rs
@@ -9,7 +9,10 @@ use core::fmt;
 use core::hash::{Hash, Hasher};
 
 use crate::new::base::build::{BuildInMessage, NameCompressor};
-use crate::new::base::parse::{ParseMessageBytes, SplitMessageBytes};
+use crate::new::base::parse::{
+    ParseMessageBytes, SplitMessageBytes, parse_without_compression,
+    split_without_compression,
+};
 use crate::new::base::wire::{
     AsBytes, BuildBytes, ParseBytes, ParseBytesZC, ParseError, SizePrefixed,
     SplitBytes, SplitBytesZC, TruncationError, U16,
@@ -96,8 +99,7 @@ impl<'a, D: ParseBytes<'a>> SplitMessageBytes<'a> for EdnsRecord<D> {
         contents: &'a [u8],
         start: usize,
     ) -> Result<(Self, usize), ParseError> {
-        Self::split_bytes(contents.get(start..).ok_or(ParseError)?)
-            .map(|(this, rest)| (this, contents.len() - start - rest.len()))
+        split_without_compression(contents, start)
     }
 }
 
@@ -106,7 +108,7 @@ impl<'a, D: ParseBytes<'a>> ParseMessageBytes<'a> for EdnsRecord<D> {
         contents: &'a [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        Self::parse_bytes(contents.get(start..).ok_or(ParseError)?)
+        parse_without_compression(contents, start)
     }
 }
 

--- a/src/new/rdata/basic/a.rs
+++ b/src/new/rdata/basic/a.rs
@@ -6,7 +6,7 @@ use core::net::Ipv4Addr;
 use core::str::FromStr;
 
 use crate::new::base::build::{BuildInMessage, NameCompressor};
-use crate::new::base::parse::ParseMessageBytes;
+use crate::new::base::parse::{ParseMessageBytes, parse_without_compression};
 use crate::new::base::wire::*;
 use crate::new::base::{
     CanonicalRecordData, ParseRecordData, ParseRecordDataBytes, RType,
@@ -159,10 +159,7 @@ impl ParseMessageBytes<'_> for A {
         contents: &'_ [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        contents
-            .get(start..)
-            .ok_or(ParseError)
-            .and_then(Self::parse_bytes)
+        parse_without_compression(contents, start)
     }
 }
 

--- a/src/new/rdata/basic/hinfo.rs
+++ b/src/new/rdata/basic/hinfo.rs
@@ -5,7 +5,7 @@ use core::cmp::Ordering;
 use crate::new::base::build::{
     BuildInMessage, NameCompressor, TruncationError,
 };
-use crate::new::base::parse::ParseMessageBytes;
+use crate::new::base::parse::{ParseMessageBytes, parse_without_compression};
 use crate::new::base::wire::{
     BuildBytes, ParseBytes, ParseError, SplitBytes,
 };
@@ -198,10 +198,7 @@ impl<'a> ParseMessageBytes<'a> for HInfo<'a> {
         contents: &'a [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        contents
-            .get(start..)
-            .ok_or(ParseError)
-            .and_then(Self::parse_bytes)
+        parse_without_compression(contents, start)
     }
 }
 

--- a/src/new/rdata/basic/mx.rs
+++ b/src/new/rdata/basic/mx.rs
@@ -4,7 +4,7 @@ use core::cmp::Ordering;
 
 use crate::new::base::build::{BuildInMessage, NameCompressor};
 use crate::new::base::name::CanonicalName;
-use crate::new::base::parse::{ParseMessageBytes, SplitMessageBytes};
+use crate::new::base::parse::{ParseMessageBytes, split_without_compression};
 use crate::new::base::wire::*;
 use crate::new::base::{
     CanonicalRecordData, ParseRecordData, ParseRecordDataBytes, RType,
@@ -160,8 +160,7 @@ impl<'a, N: ParseMessageBytes<'a>> ParseMessageBytes<'a> for Mx<N> {
         contents: &'a [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        let (&preference, rest) =
-            <&U16>::split_message_bytes(contents, start)?;
+        let (&preference, rest) = split_without_compression(contents, start)?;
         let exchange = N::parse_message_bytes(contents, rest)?;
         Ok(Self {
             preference,

--- a/src/new/rdata/basic/soa.rs
+++ b/src/new/rdata/basic/soa.rs
@@ -4,7 +4,10 @@ use core::cmp::Ordering;
 
 use crate::new::base::build::{BuildInMessage, NameCompressor};
 use crate::new::base::name::CanonicalName;
-use crate::new::base::parse::{ParseMessageBytes, SplitMessageBytes};
+use crate::new::base::parse::{
+    ParseMessageBytes, SplitMessageBytes, parse_without_compression,
+    split_without_compression,
+};
 use crate::new::base::{
     CanonicalRecordData, ParseRecordData, ParseRecordDataBytes, RType,
     Serial, wire::*,
@@ -290,11 +293,11 @@ impl<'a, N: SplitMessageBytes<'a>> ParseMessageBytes<'a> for Soa<N> {
     ) -> Result<Self, ParseError> {
         let (mname, rest) = N::split_message_bytes(contents, start)?;
         let (rname, rest) = N::split_message_bytes(contents, rest)?;
-        let (&serial, rest) = <&Serial>::split_message_bytes(contents, rest)?;
-        let (&refresh, rest) = <&U32>::split_message_bytes(contents, rest)?;
-        let (&retry, rest) = <&U32>::split_message_bytes(contents, rest)?;
-        let (&expire, rest) = <&U32>::split_message_bytes(contents, rest)?;
-        let &minimum = <&U32>::parse_message_bytes(contents, rest)?;
+        let (&serial, rest) = split_without_compression(contents, rest)?;
+        let (&refresh, rest) = split_without_compression(contents, rest)?;
+        let (&retry, rest) = split_without_compression(contents, rest)?;
+        let (&expire, rest) = split_without_compression(contents, rest)?;
+        let &minimum = parse_without_compression(contents, rest)?;
 
         Ok(Self {
             mname,

--- a/src/new/rdata/dname.rs
+++ b/src/new/rdata/dname.rs
@@ -8,9 +8,8 @@ use crate::new::base::build::{
     AsBytes, BuildBytes, BuildInMessage, NameCompressor,
 };
 use crate::new::base::name::{CanonicalName, Name};
-use crate::new::base::wire::{
-    ParseBytes, ParseError, SplitBytes, TruncationError,
-};
+use crate::new::base::parse::{ParseMessageBytes, parse_without_compression};
+use crate::new::base::wire::*;
 use crate::new::base::{
     CanonicalRecordData, ParseRecordData, ParseRecordDataBytes, RType,
 };
@@ -104,6 +103,8 @@ use crate::utils::dst::UnsizedCopy;
     Hash,
     AsBytes,
     BuildBytes,
+    ParseBytesZC,
+    SplitBytesZC,
     UnsizedCopy,
 )]
 #[repr(transparent)]
@@ -150,18 +151,14 @@ impl BuildInMessage for DName {
     }
 }
 
-//--- Parsing from bytes
+//--- Parsing from DNS messages
 
-impl<'a> ParseBytes<'a> for &'a DName {
-    fn parse_bytes(bytes: &'a [u8]) -> Result<Self, ParseError> {
-        <&Name>::parse_bytes(bytes).map(DName::new)
-    }
-}
-
-impl<'a> SplitBytes<'a> for &'a DName {
-    fn split_bytes(bytes: &'a [u8]) -> Result<(Self, &'a [u8]), ParseError> {
-        <&Name>::split_bytes(bytes)
-            .map(|(name, rest)| (DName::new(name), rest))
+impl<'a> ParseMessageBytes<'a> for &'a DName {
+    fn parse_message_bytes(
+        contents: &'a [u8],
+        start: usize,
+    ) -> Result<Self, ParseError> {
+        parse_without_compression(contents, start)
     }
 }
 

--- a/src/new/rdata/dnssec/dnskey.rs
+++ b/src/new/rdata/dnssec/dnskey.rs
@@ -8,12 +8,12 @@ use core::{
 
 use crate::{
     new::base::{
-        CanonicalRecordData,
+        CanonicalRecordData, ParseRecordData, ParseRecordDataBytes, RType,
         build::BuildInMessage,
         name::NameCompressor,
         wire::{
-            AsBytes, BuildBytes, ParseBytes, ParseBytesZC, SplitBytes,
-            SplitBytesZC, TruncationError, U16,
+            AsBytes, BuildBytes, ParseBytes, ParseBytesZC, ParseError,
+            SplitBytes, SplitBytesZC, TruncationError, U16,
         },
     },
     utils::dst::UnsizedCopy,
@@ -92,6 +92,22 @@ impl Eq for DNSKey {}
 impl Hash for DNSKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(self.as_bytes())
+    }
+}
+
+//--- Parsing record data
+
+impl<'a> ParseRecordData<'a> for &'a DNSKey {}
+
+impl<'a> ParseRecordDataBytes<'a> for &'a DNSKey {
+    fn parse_record_data_bytes(
+        bytes: &'a [u8],
+        rtype: RType,
+    ) -> Result<Self, ParseError> {
+        match rtype {
+            RType::DNSKEY => Self::parse_bytes(bytes),
+            _ => Err(ParseError),
+        }
     }
 }
 

--- a/src/new/rdata/ipv6.rs
+++ b/src/new/rdata/ipv6.rs
@@ -10,7 +10,7 @@ use core::str::FromStr;
 use crate::new::base::build::{
     BuildInMessage, NameCompressor, TruncationError,
 };
-use crate::new::base::parse::ParseMessageBytes;
+use crate::new::base::parse::{ParseMessageBytes, parse_without_compression};
 use crate::new::base::wire::{
     AsBytes, BuildBytes, ParseBytes, ParseBytesZC, ParseError, SplitBytes,
     SplitBytesZC,
@@ -173,10 +173,7 @@ impl ParseMessageBytes<'_> for Aaaa {
         contents: &'_ [u8],
         start: usize,
     ) -> Result<Self, ParseError> {
-        contents
-            .get(start..)
-            .ok_or(ParseError)
-            .and_then(Self::parse_bytes)
+        parse_without_compression(contents, start)
     }
 }
 

--- a/src/new/rdata/mod.rs
+++ b/src/new/rdata/mod.rs
@@ -43,6 +43,7 @@
 //! - [`Mx`]
 //! - [`Txt`]
 //! - [`Rp`]
+//! - [`Srv`]
 //!
 //! Indirection types:
 //! - [`CName`]
@@ -114,6 +115,9 @@ pub use edns::{EdnsOptionsIter, Opt};
 
 mod rp;
 pub use rp::Rp;
+
+mod srv;
+pub use srv::Srv;
 
 mod dnssec;
 pub use dnssec::{
@@ -280,6 +284,9 @@ define_record_data! {
         /// Identification of the person/party responsible for this domain.
         Rp(Rp<N>) = RP,
 
+        /// The locations of services associated with this domain.
+        Srv(&'a Srv) = SRV,
+
         /// The IPv6 address of a host responsible for this domain.
         Aaaa(Aaaa) = AAAA,
 
@@ -331,6 +338,7 @@ impl<'a, N> RecordData<'a, N> {
             Self::Txt(r) => RecordData::Txt(r),
             Self::Rp(r) => RecordData::Rp(r.map_names(f)),
             Self::Aaaa(r) => RecordData::Aaaa(r),
+            Self::Srv(r) => RecordData::Srv(r),
             Self::DName(r) => RecordData::DName(r),
             Self::Opt(r) => RecordData::Opt(r),
             Self::Ds(r) => RecordData::Ds(r),
@@ -360,6 +368,7 @@ impl<'a, N> RecordData<'a, N> {
             Self::Txt(r) => RecordData::Txt(r),
             Self::Rp(r) => RecordData::Rp(r.map_names_by_ref(f)),
             Self::Aaaa(r) => RecordData::Aaaa(*r),
+            Self::Srv(r) => RecordData::Srv(r),
             Self::DName(r) => RecordData::DName(r),
             Self::Opt(r) => RecordData::Opt(r),
             Self::Ds(r) => RecordData::Ds(r),
@@ -395,6 +404,7 @@ impl<'a, N> RecordData<'a, N> {
             Self::Txt(r) => RecordData::Txt(copy_to_bump(*r, bump)),
             Self::Rp(r) => RecordData::Rp(r.clone()),
             Self::Aaaa(r) => RecordData::Aaaa(*r),
+            Self::Srv(r) => RecordData::Srv(copy_to_bump(*r, bump)),
             Self::DName(r) => RecordData::DName(copy_to_bump(*r, bump)),
             Self::Opt(r) => RecordData::Opt(copy_to_bump(*r, bump)),
             Self::Ds(r) => RecordData::Ds(copy_to_bump(*r, bump)),
@@ -449,6 +459,9 @@ impl<'a, N: SplitMessageBytes<'a>> ParseRecordData<'a> for RecordData<'a, N> {
             }
             RType::AAAA => {
                 Aaaa::parse_bytes(&contents[start..]).map(Self::Aaaa)
+            }
+            RType::SRV => {
+                <&Srv>::parse_bytes(&contents[start..]).map(Self::Srv)
             }
             RType::DNAME => {
                 <&DName>::parse_bytes(&contents[start..]).map(Self::DName)

--- a/src/new/rdata/srv.rs
+++ b/src/new/rdata/srv.rs
@@ -1,0 +1,112 @@
+//! The SRV record data type.
+//!
+//! See [RFC 2782](https://datatracker.ietf.org/doc/html/rfc2782).
+
+use core::cmp::Ordering;
+
+use crate::new::base::build::{
+    AsBytes, BuildBytes, BuildInMessage, NameCompressor,
+};
+use crate::new::base::name::{CanonicalName, Name};
+use crate::new::base::wire::*;
+use crate::new::base::{
+    CanonicalRecordData, ParseRecordData, ParseRecordDataBytes, RType,
+};
+use crate::utils::dst::UnsizedCopy;
+
+//----------- Srv ------------------------------------------------------------
+
+/// The locations of services associated with this domain.
+//
+// TODO: Documentation.
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    AsBytes,
+    BuildBytes,
+    ParseBytesZC,
+    SplitBytesZC,
+    UnsizedCopy,
+)]
+#[repr(C)]
+pub struct Srv {
+    /// The priority of this host.
+    pub priority: U16,
+
+    /// The relative weight for selection of this host.
+    pub weight: U16,
+
+    /// The port number on which the service is provided.
+    pub port: U16,
+
+    /// The domain name of the target host.
+    pub name: Name,
+}
+
+//--- Canonical operations
+
+impl CanonicalRecordData for Srv {
+    fn build_canonical_bytes<'b>(
+        &self,
+        bytes: &'b mut [u8],
+    ) -> Result<&'b mut [u8], TruncationError> {
+        let bytes = self.priority.build_bytes(bytes)?;
+        let bytes = self.weight.build_bytes(bytes)?;
+        let bytes = self.port.build_bytes(bytes)?;
+        let bytes = self.name.build_lowercased_bytes(bytes)?;
+        Ok(bytes)
+    }
+
+    fn cmp_canonical(&self, other: &Self) -> Ordering {
+        // `Srv` uses canonical comparisons by default.
+        self.cmp(other)
+    }
+}
+
+//--- Building into DNS messages
+
+impl BuildInMessage for Srv {
+    fn build_in_message(
+        &self,
+        contents: &mut [u8],
+        start: usize,
+        _compressor: &mut NameCompressor,
+    ) -> Result<usize, TruncationError> {
+        let bytes = self.as_bytes();
+        let end = start + bytes.len();
+        contents
+            .get_mut(start..end)
+            .ok_or(TruncationError)?
+            .copy_from_slice(bytes);
+        Ok(end)
+    }
+}
+
+//--- Cloning
+
+#[cfg(feature = "alloc")]
+impl Clone for alloc::boxed::Box<Srv> {
+    fn clone(&self) -> Self {
+        (*self).unsized_copy_into()
+    }
+}
+
+//--- Parsing record data
+
+impl<'a> ParseRecordData<'a> for &'a Srv {}
+
+impl<'a> ParseRecordDataBytes<'a> for &'a Srv {
+    fn parse_record_data_bytes(
+        bytes: &'a [u8],
+        rtype: RType,
+    ) -> Result<Self, ParseError> {
+        match rtype {
+            RType::SRV => Self::parse_bytes(bytes),
+            _ => Err(ParseError),
+        }
+    }
+}


### PR DESCRIPTION
SRV does not allow name compression, so I sought to define it with `Name` in-place and derive `{Parse,Split}BytesZC` for it. It turned out `Name` did not implement these due to small points of friction in the design; I decided to make the change anyways. I think I ended up fixing a number of silent bugs in `SplitMessageBytes` impls along the way. The SRV definition is pretty basic, and is inspired by the needs of #649.