### PR TITLE
added feature flag to CI check and fixed failing cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     # check --all-features --all-targets' execution.  Due to the minimal
     # dependency set, it still runs fairly quickly.
     - name: Check empty feature set
-      run: cargo check --all-targets --no-default-features
+      run: cargo check --all-targets --no-default-features --features unstable-new
 
     - name: Check `alloc` without `std`
       run: cargo check --all-targets --no-default-features --features alloc,unstable-new

--- a/src/new/base/record.rs
+++ b/src/new/base/record.rs
@@ -4,7 +4,10 @@ use core::{borrow::Borrow, cmp::Ordering, fmt, ops::Deref};
 
 use crate::utils::dst::UnsizedCopy;
 
-use super::super::rdata::{BoxedRecordData, RecordData};
+#[cfg(feature = "alloc")]
+use super::super::rdata::BoxedRecordData;
+use super::super::rdata::RecordData;
+
 use super::build::{BuildInMessage, NameCompressor};
 use super::parse::{ParseMessageBytes, SplitMessageBytes};
 use super::wire::{
@@ -844,6 +847,7 @@ impl<'a, N> Record<N, RecordData<'a, N>> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<N> Record<N, BoxedRecordData> {
     /// Constructor that is more compatible with old base that takes
     /// BoxedRecordData.

--- a/src/new/rdata/dnssec/rrsig.rs
+++ b/src/new/rdata/dnssec/rrsig.rs
@@ -1,9 +1,9 @@
 //! The RRSIG record data type.
 
-use alloc::fmt;
 #[cfg(feature = "std")]
 use core::cmp;
 use core::cmp::Ordering;
+use core::fmt;
 #[cfg(feature = "std")]
 use core::time::Duration;
 #[cfg(feature = "std")]


### PR DESCRIPTION
This PR enables the `new-unstable` feature in the CI checks for `cargo check`. And resolves failing cases.