### PR TITLE
Add EDE 33 (Negative Trust Anchor)

### DIFF
--- a/src/base/iana/exterr.rs
+++ b/src/base/iana/exterr.rs
@@ -152,6 +152,10 @@ int_enum! {
 
     /// The requested resource record type should not appear in a query.
     (INVALID_QUERY_TYPE => 30, "Invalid Query Type")
+
+    /// The resolver is configured with a Negative Trust Anchor for the
+    /// queried name, disabling DNSSEC validation.
+    (NEGATIVE_TRUST_ANCHOR => 33, "Negative Trust Anchor")
 }
 
 /// Start of the private range for EDE codes.


### PR DESCRIPTION
Newly assigned in the [IANA registry](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#extended-dns-error-codes) via [draft-farrokhi-dnsop-ede-nta-00](https://datatracker.ietf.org/doc/draft-farrokhi-dnsop-ede-nta/).