### PR TITLE
[CI] Fix CI `rust-version` value stored in cache.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
     - name: Note Rust version for the cache
       if: github.event_name == 'schedule'
       run: |
-        rustup toolchain list | grep nightly- | tee target/rust-version
+        rustup toolchain list --quiet | grep nightly- | tee target/rust-version
 
     # Save to the cache every week.
     - name: Save to the cache


### PR DESCRIPTION
The new CI workflow has a slight bug when processing the rust version which is stored in `target/rust-version`. 

Failing CI looks like this:

```
Run actions/cache/restore@v6
  with:
    path: ~/.cargo
  target/
  
    key: Linux-X64-nightly-clippy-
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
  env:
    RUSTFLAGS: -D warnings
Cache hit for restore-key: Linux-X64-nightly-clippy-29573720245
Received 29360128 of 100838384 (29.1%), 28.0 MBs/sec
Received 100838384 of 100838384 (100.0%), 63.1 MBs/sec
Cache Size: ~96 MB (100838384 B)
/usr/bin/tar -xf /home/runner/work/_temp/9cd02a15-74cf-41aa-bb27-1cf0b1cf2bde/cache.tzst -P -C /home/runner/work/domain/domain --use-compress-program unzstd
Cache restored successfully
Cache restored from key: Linux-X64-nightly-clippy-29573720245
0s
Run if [[ -f target/rust-version ]]; then
  if [[ -f target/rust-version ]]; then
    echo "rust-version=$(cat target/rust-version)" >> "$GITHUB_OUTPUT"
  else
    echo "rust-version=nightly" >> "$GITHUB_OUTPUT"
  fi
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    RUSTFLAGS: -D warnings
0s
Run actions-rust-lang/setup-rust-toolchain@v1
Run : construct rustup command line
Run if [[ ! -v CARGO_INCREMENTAL ]]; then
Run if ! command -v rustup &> /dev/null ; then
Run # Check if value is set
error: invalid value '(active)' for '[TOOLCHAIN]...': invalid toolchain name: '(active)'

For more information, try '--help'.
Error: Process completed with exit code 1.
```
Original here: https://github.com/NLnetLabs/domain/actions/runs/29577670110/job/87875766358


`--quiet` is the fix.

```
$ rustup toolchain list --help
List installed toolchains

Usage: rustup[EXE] toolchain list [OPTIONS]

Options:
  -v, --verbose  Enable verbose output with toolchain information
  -q, --quiet    Force the output to be a single column
  -h, --help     Print help
```